### PR TITLE
Added 2 tests to verify the display of 'Add external account' and 'Add Persona' buttons based on the access provided to the user.

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisableExternalAccountCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisableExternalAccountCreation.java
@@ -77,10 +77,36 @@ public class DisableExternalAccountCreation extends AjaxCommonTest {
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
+		
+		// Verify the display of Add External Account button when External IMAP/POP3 access is allowed.
+		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zAddExternalAccountButton), "Add External Account button is not present!");
+		
+		// Enable External IMAP access and disable External POP3 access
+		ZimbraAdminAccount.GlobalAdmin().soapSend(
+				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
+						+		"<id>"+ app.zGetActiveAccount().ZimbraId +"</id>"
+						+		"<a n='zimbraFeatureImapDataSourceEnabled'>TRUE</a>"
+						+		"<a n='zimbraFeaturePop3DataSourceEnabled'>FALSE</a>"
+						+	"</ModifyAccountRequest>");
 
+		// Refresh Web-client
+		app.zPageMail.sRefresh();
+
+		// Navigate to Preferences-->Accounts
+		startingPage.zNavigateTo();
+		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
+		
+		// Verify the display of Add External Account button when one of External IMAP and POP3 accesses is allowed.
+		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zAddExternalAccountButton), 
+				"Add External Account button is not present when External IMAP is allowed and External POP3 accesses is disabled!");
+		
 		// Add an external account
 		app.zPagePreferences.sClick(Locators.zAddExternalAccountButton);
-
+		
+		// Verify that only IMAP radio button is present
+		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zImapRadioButton), "IMAP option is not enabled!");
+		ZAssert.assertFalse(app.zPagePreferences.sIsElementPresent(Locators.zPop3RadioButton), "POP3 option is not disabled!");
+		
 		// Verify that a new External account row has been added
 		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zExternalAccountRow1), "External account is not getting created!");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisableExternalAccountCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisableExternalAccountCreation.java
@@ -26,16 +26,16 @@ import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
 import com.zimbra.qa.selenium.projects.ajax.ui.preferences.PagePreferences.Locators;
 import com.zimbra.qa.selenium.projects.ajax.ui.preferences.TreePreferences.TreeItem;
 
-public class DisableExternalAcountCreation extends AjaxCommonTest {
+public class DisableExternalAccountCreation extends AjaxCommonTest {
 
-	public DisableExternalAcountCreation() {
+	public DisableExternalAccountCreation() {
 		super.startingPage = app.zPagePreferences;
 	}
 
 	@Test(description = "Verify the display of 'Add External Account' button when External IMAP and POP3 is disabled", 
 			groups = { "functional", "L3" })
 
-	public void DisableExternalAcountCreation_01() throws HarnessException {
+	public void DisableExternalAccountCreation_01() throws HarnessException {
 
 		// Navigate to preferences -> Accounts
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
@@ -44,18 +44,18 @@ public class DisableExternalAcountCreation extends AjaxCommonTest {
 		// Verify the display of Add External Account button when External IMAP/POP3 access is allowed.
 		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zAddExternalAccountButton), "Add External Account button is not present!");
 
-		//Disable the External IMAP and POP3 access for the user
+		// Disable the External IMAP and POP3 access for the user
 		ZimbraAdminAccount.GlobalAdmin().soapSend(
 				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
-						+		"<id>"+app.zGetActiveAccount().ZimbraId +"</id>"
+						+		"<id>"+ app.zGetActiveAccount().ZimbraId +"</id>"
 						+		"<a n='zimbraFeatureImapDataSourceEnabled'>FALSE</a>"
 						+		"<a n='zimbraFeaturePop3DataSourceEnabled'>FALSE</a>"
 						+	"</ModifyAccountRequest>");
 
-		//Refresh Web-client
+		// Refresh Web-client
 		app.zPageMail.sRefresh();
 
-		//Navigate to Preferences-->Accounts
+		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
 
@@ -63,25 +63,25 @@ public class DisableExternalAcountCreation extends AjaxCommonTest {
 		ZAssert.assertFalse(app.zPagePreferences.sIsElementPresent(Locators.zAddExternalAccountButton), 
 				"Add External Account button is displayed even if the external IMAP and POP3 accesses are disabled!");
 
-		//Enable External IMAP and POP3 access for the user
+		// Enable External IMAP and POP3 access for the user
 		ZimbraAdminAccount.GlobalAdmin().soapSend(
 				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
-						+		"<id>"+app.zGetActiveAccount().ZimbraId +"</id>"
+						+		"<id>"+ app.zGetActiveAccount().ZimbraId +"</id>"
 						+		"<a n='zimbraFeatureImapDataSourceEnabled'>TRUE</a>"
 						+		"<a n='zimbraFeaturePop3DataSourceEnabled'>TRUE</a>"
 						+	"</ModifyAccountRequest>");
 
-		//Refresh Web-client
+		// Refresh Web-client
 		app.zPageMail.sRefresh();
 
-		//Navigate to Preferences-->Accounts
+		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
 
-		//Add an external account
+		// Add an external account
 		app.zPagePreferences.sClick(Locators.zAddExternalAccountButton);
 
-		//Verify that a new External account row has been added
+		// Verify that a new External account row has been added
 		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zExternalAccountRow1), "External account is not getting created!");
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisableExternalAcountCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisableExternalAcountCreation.java
@@ -1,0 +1,88 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2015, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.qa.selenium.projects.ajax.tests.preferences.accounts;
+
+import org.testng.annotations.Test;
+
+import com.zimbra.qa.selenium.framework.ui.Action;
+import com.zimbra.qa.selenium.framework.util.HarnessException;
+import com.zimbra.qa.selenium.framework.util.ZAssert;
+import com.zimbra.qa.selenium.framework.util.ZimbraAdminAccount;
+import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.preferences.PagePreferences.Locators;
+import com.zimbra.qa.selenium.projects.ajax.ui.preferences.TreePreferences.TreeItem;
+
+public class DisableExternalAcountCreation extends AjaxCommonTest {
+
+	public DisableExternalAcountCreation() {
+		super.startingPage = app.zPagePreferences;
+	}
+
+	@Test(description = "Verify the display of 'Add External Account' button when External IMAP and POP3 is disabled", 
+			groups = { "functional", "L3" })
+
+	public void DisableExternalAcountCreation_01() throws HarnessException {
+
+		// Navigate to preferences -> Accounts
+		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
+
+		// See https://bugzilla.zimbra.com/show_bug.cgi?id=106132
+		// Verify the display of Add External Account button when External IMAP/POP3 access is allowed.
+		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zAddExternalAccountButton), "Add External Account button is not present!");
+
+		//Disable the External IMAP and POP3 access for the user
+		ZimbraAdminAccount.GlobalAdmin().soapSend(
+				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
+						+		"<id>"+app.zGetActiveAccount().ZimbraId +"</id>"
+						+		"<a n='zimbraFeatureImapDataSourceEnabled'>FALSE</a>"
+						+		"<a n='zimbraFeaturePop3DataSourceEnabled'>FALSE</a>"
+						+	"</ModifyAccountRequest>");
+
+		//Refresh Web-client
+		app.zPageMail.sRefresh();
+
+		//Navigate to Preferences-->Accounts
+		startingPage.zNavigateTo();
+		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
+
+		// Verify the display of Add External Account button when External IMAP/POP3 accesses are not allowed.
+		ZAssert.assertFalse(app.zPagePreferences.sIsElementPresent(Locators.zAddExternalAccountButton), 
+				"Add External Account button is displayed even if the external IMAP and POP3 accesses are disabled!");
+
+		//Enable External IMAP and POP3 access for the user
+		ZimbraAdminAccount.GlobalAdmin().soapSend(
+				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
+						+		"<id>"+app.zGetActiveAccount().ZimbraId +"</id>"
+						+		"<a n='zimbraFeatureImapDataSourceEnabled'>TRUE</a>"
+						+		"<a n='zimbraFeaturePop3DataSourceEnabled'>TRUE</a>"
+						+	"</ModifyAccountRequest>");
+
+		//Refresh Web-client
+		app.zPageMail.sRefresh();
+
+		//Navigate to Preferences-->Accounts
+		startingPage.zNavigateTo();
+		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
+
+		//Add an external account
+		app.zPagePreferences.sClick(Locators.zAddExternalAccountButton);
+
+		//Verify that a new External account row has been added
+		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zExternalAccountRow1), "External account is not getting created!");
+	}
+
+}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisablePersonaCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisablePersonaCreation.java
@@ -50,10 +50,10 @@ public class DisablePersonaCreation extends AjaxCommonTest {
 						+		"<a n='zimbraFeatureIdentitiesEnabled'>FALSE</a>"
 						+	"</ModifyAccountRequest>");
 
-		//Refresh Web-client
+		// Refresh Web-client
 		app.zPageMail.sRefresh();
 
-		//Navigate to Preferences-->Accounts
+		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
 
@@ -61,24 +61,24 @@ public class DisablePersonaCreation extends AjaxCommonTest {
 		ZAssert.assertFalse(app.zPagePreferences.sIsElementPresent(Locators.zAddPersonaButton), 
 				"Add persona button is displayed even if the Persona access is disabled!");
 
-		//Enable Persona for the user
+		// Enable Persona for the user
 		ZimbraAdminAccount.GlobalAdmin().soapSend(
 				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
 						+		"<id>"+app.zGetActiveAccount().ZimbraId +"</id>"
 						+		"<a n='zimbraFeatureIdentitiesEnabled'>TRUE</a>"
 						+	"</ModifyAccountRequest>");
 
-		//Refresh Web-client
+		// Refresh Web-client
 		app.zPageMail.sRefresh();
 
-		//Navigate to Preferences-->Accounts
+		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
 
-		//Add a Persona
+		// Add a Persona
 		app.zPagePreferences.sClick(Locators.zAddPersonaButton);
 
-		//Verify that a Persona row has been added
+		// Verify that a Persona row has been added
 		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zPersonaRow1), "Persona is not getting created!");
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisablePersonaCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisablePersonaCreation.java
@@ -46,7 +46,7 @@ public class DisablePersonaCreation extends AjaxCommonTest {
 		//Disable the External IMAP and POP3 access for the user
 		ZimbraAdminAccount.GlobalAdmin().soapSend(
 				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
-						+		"<id>"+app.zGetActiveAccount().ZimbraId +"</id>"
+						+		"<id>"+ app.zGetActiveAccount().ZimbraId +"</id>"
 						+		"<a n='zimbraFeatureIdentitiesEnabled'>FALSE</a>"
 						+	"</ModifyAccountRequest>");
 
@@ -64,7 +64,7 @@ public class DisablePersonaCreation extends AjaxCommonTest {
 		// Enable Persona for the user
 		ZimbraAdminAccount.GlobalAdmin().soapSend(
 				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
-						+		"<id>"+app.zGetActiveAccount().ZimbraId +"</id>"
+						+		"<id>"+ app.zGetActiveAccount().ZimbraId +"</id>"
 						+		"<a n='zimbraFeatureIdentitiesEnabled'>TRUE</a>"
 						+	"</ModifyAccountRequest>");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisablePersonaCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisablePersonaCreation.java
@@ -1,0 +1,85 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2015, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.qa.selenium.projects.ajax.tests.preferences.accounts;
+
+import org.testng.annotations.Test;
+
+import com.zimbra.qa.selenium.framework.ui.Action;
+import com.zimbra.qa.selenium.framework.util.HarnessException;
+import com.zimbra.qa.selenium.framework.util.ZAssert;
+import com.zimbra.qa.selenium.framework.util.ZimbraAdminAccount;
+import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.preferences.PagePreferences.Locators;
+import com.zimbra.qa.selenium.projects.ajax.ui.preferences.TreePreferences.TreeItem;
+
+public class DisablePersonaCreation extends AjaxCommonTest {
+
+	public DisablePersonaCreation() {
+		super.startingPage = app.zPagePreferences;
+	}
+
+	@Test(description = "Verify the display of 'Add Persona' button when Persona creation is disabled", 
+			groups = { "functional", "L3" })
+
+	public void DisablePersonaCreation_01() throws HarnessException {
+
+		// Navigate to preferences -> Accounts
+		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
+		
+		// Verify the display of Add Persona button when Persona creation is allowed.
+		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zAddPersonaButton), "Add persona button is not present!");
+
+		//Disable the External IMAP and POP3 access for the user
+		ZimbraAdminAccount.GlobalAdmin().soapSend(
+				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
+						+		"<id>"+app.zGetActiveAccount().ZimbraId +"</id>"
+						+		"<a n='zimbraFeatureIdentitiesEnabled'>FALSE</a>"
+						+	"</ModifyAccountRequest>");
+
+		//Refresh Web-client
+		app.zPageMail.sRefresh();
+
+		//Navigate to Preferences-->Accounts
+		startingPage.zNavigateTo();
+		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
+
+		// Verify the display of Add Persona button when Persona access is disabled.
+		ZAssert.assertFalse(app.zPagePreferences.sIsElementPresent(Locators.zAddPersonaButton), 
+				"Add persona button is displayed even if the Persona access is disabled!");
+
+		//Enable Persona for the user
+		ZimbraAdminAccount.GlobalAdmin().soapSend(
+				"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
+						+		"<id>"+app.zGetActiveAccount().ZimbraId +"</id>"
+						+		"<a n='zimbraFeatureIdentitiesEnabled'>TRUE</a>"
+						+	"</ModifyAccountRequest>");
+
+		//Refresh Web-client
+		app.zPageMail.sRefresh();
+
+		//Navigate to Preferences-->Accounts
+		startingPage.zNavigateTo();
+		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.MailAccounts);
+
+		//Add a Persona
+		app.zPagePreferences.sClick(Locators.zAddPersonaButton);
+
+		//Verify that a Persona row has been added
+		ZAssert.assertTrue(app.zPagePreferences.sIsElementPresent(Locators.zPersonaRow1), "Persona is not getting created!");
+	}
+
+}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/preferences/PagePreferences.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/preferences/PagePreferences.java
@@ -225,6 +225,8 @@ public class PagePreferences extends AbsTab {
 		public static final String zExternalAccountRow1 = "css=div[id^='zlic__ACCT__new-dsrc'][id$='__na_name']:contains('New External Account')";
 		public static final String zAddPersonaButton = "css=td[id$='_title']:contains('Add Persona')";
 		public static final String zPersonaRow1 = "css=div[id^='zlic__ACCT__new-persona'][id$='__na_name']:contains('New Persona')";
+		public static final String zPop3RadioButton = "css=input[id$='_input'][value='Pop']";
+		public static final String zImapRadioButton = "css=input[id$='_input'][value='Imap']";
 		
 		// Import/Export
 		public static final String zBrowseFileButton = "css=input#ZmImportView_FILE";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/preferences/PagePreferences.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/preferences/PagePreferences.java
@@ -221,7 +221,11 @@ public class PagePreferences extends AbsTab {
 		public static final String zRevokeThisDeviceLink = "css=td[class='ZOptionsField'] a[id='Prefs_Pages_ACCOUNTS_TRUSTED_DEVICE_REVOKE_LINK']:contains('revoke this device')";
 		public static final String zChangePwdButton = "css=td[id='CHANGE_PASSWORD_title']";
 		public static final String zAddApplicationCodeButton = "css=td[id='addApplicationCodeBtn_title']";
-
+		public static final String zAddExternalAccountButton = "css=td[id$='_title']:contains('Add External Account')";
+		public static final String zExternalAccountRow1 = "css=div[id^='zlic__ACCT__new-dsrc'][id$='__na_name']:contains('New External Account')";
+		public static final String zAddPersonaButton = "css=td[id$='_title']:contains('Add Persona')";
+		public static final String zPersonaRow1 = "css=div[id^='zlic__ACCT__new-persona'][id$='__na_name']:contains('New Persona')";
+		
 		// Import/Export
 		public static final String zBrowseFileButton = "css=input#ZmImportView_FILE";
 		public static final String zImportButton = "css=div[id='IMPORT_BUTTON'] td[id$='_title']";


### PR DESCRIPTION
* Added test DisableExternalAcountCreation_01 to verify the display and working of 'Add External Account' button in WebClient - Preferences based the access provided to the user.

* Added test DisablePersonaCreation_01 to verify the display and working of 'Add Persona' button in WebClient - Preferences based the access provided to the user.