### PR TITLE
ZCS-1553: Updated build script to copy AjxMsg properties files from zm-ajax repo.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,6 +19,7 @@
 	<property name="network-admin-tests.dir" location="../zm-selenium/src/java/com/zimbra/qa/selenium/projects/admin/tests/network"/>
 	<property name="store-conf.dir" location="../zm-mailbox/store-conf"/>
 	<property name="web-client.dir" location="../zm-web-client"/>
+	<property name="ajax.dir" location="../zm-ajax"/>
 	<property name="zimlets.dir" location="../zm-zimlets"/>
 
 	<path id="all.java.path">
@@ -64,6 +65,7 @@
 	<target name="bundles-classes" description="Copies the I18N properties files to build">
 		<copy todir="${build.resources.dir}">
 			<fileset dir="${web-client.dir}/WebRoot/messages/"/>
+			<fileset dir="${ajax.dir}/WebRoot/messages/"/>
 		</copy>
 		<copy todir="${build.resources.dir}">
 			<fileset dir="${store-conf.dir}/conf/msgs/"/>


### PR DESCRIPTION
As a part of ZCS-1510, AjxMsg.properties and I18nMsg.properties files have been moved to zm-ajax repo. 
These files are required for creating Selenium build and executing the automation take suite. Earlier these files used to be copied from zm-web-client repo.
We need to update zm-selenium build script so that these files are taken from zm-ajax repo.