### PR TITLE
ZCS-1799: Fixed L0 failed testcases of Ajax client.

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeparateWindow.java
+++ b/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeparateWindow.java
@@ -115,16 +115,11 @@ public abstract class AbsSeparateWindow extends AbsPage {
 
 	public void sTypeNewWindow(String locator, String value) throws HarnessException {
 		logger.info(myPageName() + " sType(" + locator + ", " + value + ")");
-
-		try {
+			
 			super.sSelectWindow(this.DialogWindowID);
 			super.sType(locator, value);
-
-		} finally {
-
-		}
-
-	}
+			SleepUtil.sleepSmall();
+		} 
 
 	public String sGetText(String locator) throws HarnessException {
 		logger.info(myPageName() + " sGetText(" + locator + ")");

--- a/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeparateWindow.java
+++ b/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeparateWindow.java
@@ -120,6 +120,14 @@ public abstract class AbsSeparateWindow extends AbsPage {
 			super.sType(locator, value);
 			SleepUtil.sleepSmall();
 		} 
+	
+	public void sClickNewWindow(String locator) throws HarnessException {
+		logger.info(myPageName() + " sClickInNewWindow(" + locator + ")");
+			
+			super.sSelectWindow(this.DialogWindowID);
+			super.sClick(locator);
+			SleepUtil.sleepSmall();
+		} 
 
 	public String sGetText(String locator) throws HarnessException {
 		logger.info(myPageName() + " sGetText(" + locator + ")");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/GetAppointment.java
@@ -59,7 +59,7 @@ public class GetAppointment extends AjaxCommonTest {
 		ZDate endUTC  = null;
 		
 		// if current day of the week is Sunday, create an appointment on Monday so that it remains in the current week view even after time zone adjustment.
-		if(now.get(Calendar.DAY_OF_WEEK) == 1) {
+		if ( now.get(Calendar.DAY_OF_WEEK) == 1 ) {
 			
 			startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH) + 1, 12, 0, 0);
 			endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH) + 1, 14, 0, 0);
@@ -109,7 +109,7 @@ public class GetAppointment extends AjaxCommonTest {
 		// Enable trash
 		app.zPageCalendar.zCheckboxSet(Checkbox.C_TRASH, true);
 		
-		//Verify the presence of appointment in Trash
+		// Verify the presence of appointment in Trash
 		ZAssert.assertTrue(app.zPageCalendar.zIsAppointmentPresentInTrash(apptSubject), "Verify appointment is present in Trash!");
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/GetAppointment.java
@@ -40,6 +40,7 @@ public class GetAppointment extends AjaxCommonTest {
 
 		// All tests start at the Calendar page
 		super.startingPage = app.zPageCalendar;
+		super.startingAccountPreferences.put("zimbraPrefCalendarInitialView", "week");
 	}
 
 	@Test( description = "Verify the presence of appointment in Trash after deletion.",
@@ -47,7 +48,6 @@ public class GetAppointment extends AjaxCommonTest {
 	
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
 		// Create the message data to be sent
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
@@ -55,9 +55,20 @@ public class GetAppointment extends AjaxCommonTest {
 
 		// Absolute dates in UTC zone
 		Calendar now = Calendar.getInstance();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
-
+		ZDate startUTC = null;
+		ZDate endUTC  = null;
+		
+		// if current day of the week is Sunday, create an appointment on Monday so that it remains in the current week view even after time zone adjustment.
+		if(now.get(Calendar.DAY_OF_WEEK) == 1) {
+			
+			startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH) + 1, 12, 0, 0);
+			endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH) + 1, 14, 0, 0);
+			
+		} else {
+			
+			startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
+			endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
+		}
 		// EST timezone string
 		String tz = ZTimeZone.TimeZoneEST.getID();
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/GetAppointment.java
@@ -55,20 +55,15 @@ public class GetAppointment extends AjaxCommonTest {
 
 		// Absolute dates in UTC zone
 		Calendar now = Calendar.getInstance();
-		ZDate startUTC = null;
-		ZDate endUTC  = null;
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
+		ZDate endUTC  = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		
-		// if current day of the week is Sunday, create an appointment on Monday so that it remains in the current week view even after time zone adjustment.
+		// Considering the EST time zone, if current day of the week is Sunday, create an appointment on Monday so that it remains in the current week view even after time zone adjustment.
 		if ( now.get(Calendar.DAY_OF_WEEK) == 1 ) {
-			
-			startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH) + 1, 12, 0, 0);
-			endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH) + 1, 14, 0, 0);
-			
-		} else {
-			
-			startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
-			endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
-		}
+			startUTC.addDays(1);
+			endUTC.addDays(1);
+		}	
+		
 		// EST timezone string
 		String tz = ZTimeZone.TimeZoneEST.getID();
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/SeparateWindowFormMailNew.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/SeparateWindowFormMailNew.java
@@ -193,7 +193,7 @@ public class SeparateWindowFormMailNew extends AbsSeparateWindow {
 			throw new HarnessException("not implemented for field " + field);
 		}
 
-		sType(locator, value);
+		sTypeNewWindow(locator, value);
 		
 		if (field == Field.To || field == Field.Cc || field == Field.Bcc) {
 			SleepUtil.sleepMedium();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/SeparateWindowFormMailNew.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/SeparateWindowFormMailNew.java
@@ -193,14 +193,10 @@ public class SeparateWindowFormMailNew extends AbsSeparateWindow {
 			throw new HarnessException("not implemented for field " + field);
 		}
 
-		this.sFocus(locator);
-		this.sClick(locator);
-		this.zWaitForBusyOverlay();
-
-		sTypeNewWindow(locator, value);
+		sType(locator, value);
 		
 		if (field == Field.To || field == Field.Cc || field == Field.Bcc) {
-			SleepUtil.sleepSmall();
+			SleepUtil.sleepMedium();
 			this.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ENTER);
 			SleepUtil.sleepSmall();
 		}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/SeparateWindowFormMailNew.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/SeparateWindowFormMailNew.java
@@ -320,7 +320,7 @@ public class SeparateWindowFormMailNew extends AbsSeparateWindow {
 			throw new HarnessException("no logic defined for button " + button);
 		}
 
-		this.sClick(locator);
+		this.sClickNewWindow(locator);
 		SleepUtil.sleepSmall();
 
 		return (page);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/zimlet/DialogViewCertificate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/zimlet/DialogViewCertificate.java
@@ -90,8 +90,7 @@ public class DialogViewCertificate extends AbsDialog {
 	public String zGetDisplayedText(String issuedToEmail) throws HarnessException {
 		logger.info(myPageName() + " Issued to email");
 
-		String locator = "css=div[class='CertificateDetailsWrapper'] table[class='CertificateDetails'] tbody tr[data-name='Email'] td[class='Value']" ;
-		
+		String locator = "//table[@class='CertificateDetails']/tbody/tr[@data-name='Email'][1]/td[@class='Value']";
 		// Make sure the locator exists
 		if ( !this.sIsElementPresent(locator) ) {
 			throw new HarnessException("Issued to email "+ locator +" is not present");
@@ -103,11 +102,11 @@ public class DialogViewCertificate extends AbsDialog {
 	public String zGetDisplayedTextIssuedToOrganization() throws HarnessException {
 		logger.info(myPageName() + " Issued to Organisation");
 
-		String locator = "css=div[class='CertificateDetailsWrapper'] table[class='CertificateDetails'] tbody tr[data-name='Organization(O)'] td[class='Value']" ;
+		String locator = "//table[@class='CertificateDetails']/tbody/tr[@data-name='Organization (O)'][1]/td[@class='Value']" ;
 		
 		// Make sure the locator exists
 		if ( !this.sIsElementPresent(locator) ) {
-			throw new HarnessException("Issued to email "+ locator +" is not present");
+			throw new HarnessException("Issued to organization "+ locator +" is not present");
 		}
 		
 		return(this.sGetText(locator));
@@ -115,11 +114,11 @@ public class DialogViewCertificate extends AbsDialog {
 	public String zGetDisplayedTextIssuedByOrganization() throws HarnessException {
 		logger.info(myPageName() + " Issued by Organisation");
 
-		String locator = "//table[@class='CertificateDetails']/tbody/tr[@data-name='Organization(O)'][2]/td[@class='Value']" ;
+		String locator = "//table[@class='CertificateDetails']/tbody/tr[@data-name='Organization (O)'][2]/td[@class='Value']" ;
 		
 		// Make sure the locator exists
 		if ( !this.sIsElementPresent(locator) ) {
-			throw new HarnessException("Issued to email "+ locator +" is not present");
+			throw new HarnessException("Issued by organization "+ locator +" is not present");
 		}
 		
 		return(this.sGetText(locator));
@@ -131,7 +130,7 @@ public class DialogViewCertificate extends AbsDialog {
 		
 		// Make sure the locator exists
 		if ( !this.sIsElementPresent(locator) ) {
-			throw new HarnessException("Issued to email "+ locator +" is not present");
+			throw new HarnessException("Issued by email "+ locator +" is not present");
 		}
 		
 		return(this.sGetText(locator));
@@ -143,7 +142,7 @@ public class DialogViewCertificate extends AbsDialog {
 		
 		// Make sure the locator exists
 		if ( !this.sIsElementPresent(locator) ) {
-			throw new HarnessException("Issued to email "+ locator +" is not present");
+			throw new HarnessException("Algorithm used "+ locator +" is not present");
 		}
 		
 		return(this.sGetText(locator));


### PR DESCRIPTION
Following Ajax client L0 test cases are fixed:

- com.zimbra.qa.selenium.projects.ajax.tests.calendar.trash.GetAppointment.GetAppointment_01

 --> Changed the view to week view and made sure that appointment is created on the date which is in the view in any timezone.

- com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment.CreateMailWithAttachment.CreateMailWithAttachment_01

 --> 'To' field was getting cleared, added some delay to let the auto-complete get completed. While working on it, realized that new-window test cases need a lot of refactoring. Also, zUpload() method sometimes does not work.

I have started working on it https://jira.corp.synacor.com/browse/ZCS-1801

- com.zimbra.qa.selenium.projects.ajax.tests.network.zimlets.smime.ContactCertificate.ContactUploadCertificate_01

 --> Corrected the locators

- com.zimbra.qa.selenium.projects.ajax.tests.network.zimlets.smime.mail.SendEncryptedMail.SendEncryptedMail_01

 --> Corrected the locators

- com.zimbra.qa.selenium.projects.ajax.tests.network.zimlets.smime.mail.SendSignedMail.SendSignedMail_01

 --> Corrected the locators

The following tests didn't fail while debugging, no fix required
com.zimbra.qa.selenium.projects.ajax.tests.mail.folders.CreateFolder.CreateFolder_01
com.zimbra.qa.selenium.projects.ajax.tests.network.preferences.accounts.twofactorauth.DisableZimbraTwoFactorAuth.DisableZimbraTwoFactorAuth_01