### PR TITLE
ZCS-3087: Fixing NPE and replicating same working code for Admin console to unblock the selenium run

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/util/staf/StafAbstract.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/staf/StafAbstract.java
@@ -116,15 +116,7 @@ public class StafAbstract {
 	    			}
 	    			return runSTAFCommand(StafServer,handle);
 
-	        	} else if (StafParms.indexOf("zmmemcachedctl") >=0 ) {
-	    			if (StafServer.indexOf(".lab.zimbra.com") >=0 ) {
-	    				StafServer = StafServer.replace(StafServer.substring(StafServer.indexOf(".")-10, StafServer.indexOf(".com")+4), ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".server.host", ConfigProperties.getStringProperty("server.host")));
-	    			} else if (StafServer.indexOf(".eng.zimbra.com") >=0 ) {
-	    				StafServer = StafServer.replace(StafServer.substring(StafServer.indexOf(".")-7, StafServer.indexOf(".com")+4), ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".server.host", ConfigProperties.getStringProperty("server.host")));
-	    			}
-	    			return runSTAFCommand(StafServer,handle);
-
-	    		} else if (StafParms.indexOf("zmmailbox") >=0 || StafParms.indexOf("zmtlsctl") >=0 || StafParms.indexOf("zm") >=0 || StafParms.indexOf("zmprov") >=0 || StafParms.indexOf("SYSTEM") >=0) {
+	    		} else if (StafParms.indexOf("zmmailbox") >=0 || StafParms.indexOf("zmtlsctl") >=0 || StafParms.indexOf("zmprov") >=0) {
 
 	    			Boolean storeCommandResponse = true;
 	    			String StoreServer = null;
@@ -143,9 +135,16 @@ public class StafAbstract {
 	    				}
 	    			}
 	    			return storeCommandResponse;
+	    			
+	    		} else {
+	    			if (StafServer.indexOf(".lab.zimbra.com") >=0 ) {
+	    				StafServer = StafServer.replace(StafServer.substring(StafServer.indexOf(".")-10, StafServer.indexOf(".com")+4), ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".server.host", ConfigProperties.getStringProperty("server.host")));
+	    			} else if (StafServer.indexOf(".eng.zimbra.com") >=0 ) {
+	    				StafServer = StafServer.replace(StafServer.substring(StafServer.indexOf(".")-7, StafServer.indexOf(".com")+4), ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".server.host", ConfigProperties.getStringProperty("server.host")));
+	    			}
+	    			return runSTAFCommand(StafServer,handle);
+	    			
 	    		}
-
-	        	return false;
 
 			} finally {
 

--- a/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCommonTest.java
@@ -34,10 +34,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-
 import org.apache.commons.lang.WordUtils;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -63,6 +63,7 @@ import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.core.ClientSessionFactory;
 import com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain;
 import com.zimbra.qa.selenium.framework.ui.AbsTab;
+import com.zimbra.qa.selenium.framework.util.CommandLine;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
 import com.zimbra.qa.selenium.framework.util.SleepUtil;
@@ -72,16 +73,17 @@ import com.zimbra.qa.selenium.projects.admin.ui.AppAdminConsole;
 
 public class AdminCommonTest {
 
-	protected static Logger logger = LogManager.getLogger(AdminCommonTest.class);
-	protected final ZimbraAdminAccount gAdmin = ZimbraAdminAccount.AdminConsoleAdmin();
 	protected AppAdminConsole app = null;
-
 	protected AbsTab startingPage = null;
+	public static ArrayList<String> mailboxStores=null;
+	
+	protected final ZimbraAdminAccount gAdmin = ZimbraAdminAccount.AdminConsoleAdmin();
 	protected ZimbraAdminAccount startingAccount = null;
 
-	private WebDriver webDriver = ClientSessionFactory.session().webDriver();
 	WebElement we = null;
-
+	private WebDriver webDriver = ClientSessionFactory.session().webDriver();
+	protected static Logger logger = LogManager.getLogger(AdminCommonTest.class);
+	
 	protected StafServicePROCESS staf = new StafServicePROCESS();
 	String sJavaScriptErrorsHtmlFileName = "Javascript-errors-report.html";
 
@@ -92,6 +94,23 @@ public class AdminCommonTest {
 
 		startingPage = app.zPageMain;
 		startingAccount = gAdmin;
+	}
+	
+	public void commonTestZimbraConfiguration() throws HarnessException {
+		
+		logger.info("-------------- Pre-configuration and required setup --------------");
+
+		if (ConfigProperties.getStringProperty("staf").equals("true")) {
+			
+			try {
+				// Get all mailbox stores
+				mailboxStores = CommandLine.getAllMailboxStoreServers();
+				logger.info("Mailbox stores (especially for multi-node setup): " + mailboxStores);
+								
+			} catch(Exception e) {
+				logger.error("Unable to get mailbox stores", e);
+			}
+		}
 	}
 
 	@BeforeSuite(groups = { "always" })
@@ -135,6 +154,8 @@ public class AdminCommonTest {
 					}
 				}
 			}
+			logger.info("App is ready!");
+			commonTestZimbraConfiguration();
 
 		} catch (WebDriverException e) {
 			logger.error("Unable to open admin app. Is a valid certificate installed?", e);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCommonTest.java
@@ -97,18 +97,19 @@ public class AjaxCommonTest {
 			try {
 				// Get all mailbox stores
 				mailboxStores = CommandLine.getAllMailboxStoreServers();
+				logger.info("Mailbox stores (especially for multi-node setup): " + mailboxStores);
 				
 				// Grant createDistList right to domain
-				logger.info("Grant createDistList right to domain");
+				logger.info("Grant createDistList right to domain using STAF");
 				staf.execute("zmprov grr domain " + ConfigProperties.getStringProperty("testdomain") + " dom "
 						+ ConfigProperties.getStringProperty("testdomain") + " createDistList");
 				
 				// Disable zimbraSmimeOCSPEnabled attribute for S/MIME
-				logger.info("Disable zimbraSmimeOCSPEnabled attribute for S/MIME");
+				logger.info("Disable zimbraSmimeOCSPEnabled attribute for S/MIME using STAF");
 				staf.execute("zmprov mcf zimbraSmimeOCSPEnabled FALSE");
 				
 			} catch(Exception e) {
-				logger.error("Unable to get mailbox stores, grant createDistList right or can't disable zimbraSmimeOCSPEnabled for S/MIME", e);
+				logger.error("Unable to get mailbox stores, grant createDistList right or can't disable zimbraSmimeOCSPEnabled for S/MIME using STAF", e);
 			}
 		}
 	}


### PR DESCRIPTION
ZCS-3087: Fixing NPE and replicating same working code for Admin console to unblock the selenium run for 8.8 release. Selenium tests are completed failed due to our recent work for multi-server support, going ahead to unblock now to continue execution of selenium tests.

Error submitting request, RC: 38
Additional info
---------------
java.lang.NullPointerException
	at com.zimbra.qa.selenium.framework.util.staf.StafAbstract.execute(StafAbstract.java:132)
	at com.zimbra.qa.selenium.staf.StafDevProperties.getLocalMachineName(StafDevProperties.java:92)
	at com.zimbra.qa.selenium.staf.StafDevProperties.getRemoteFile(StafDevProperties.java:78)
	at com.zimbra.qa.selenium.staf.StafDevProperties.load(StafDevProperties.java:47)
	at com.zimbra.qa.selenium.staf.StafIntegration.parseExecute(StafIntegration.java:165)
	at com.zimbra.qa.selenium.staf.StafIntegration.handleExecute(StafIntegration.java:292)
	at com.zimbra.qa.selenium.staf.StafIntegration.acceptRequest(StafIntegration.java:99)
	at com.ibm.staf.service.STAFServiceHelper.callService(STAFServiceHelper.java:349)

This is extension to fix provided couple of hours ago by to run tests on multi-node setup.