### PR TITLE
ZCS-3219: Add Clarity theme support in selenium for Universal UI via zimbra pre-configuration

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -1402,7 +1402,7 @@ public class ExecuteHarnessMain {
 			String universalUITheme = "clarity";
 
 			Boolean themeFound = false;
-			for (String serverUniversalUITheme : CommandLineUtility.runCommandOnZimbraServer("ls /opt/zimbra/jetty/webapps/zimbra/skins")) {
+			for (String serverUniversalUITheme : CommandLineUtility.runCommandOnZimbraServer("ls /opt/zimbra/jetty/webapps/zimbra/skins | grep -i " + universalUITheme)) {
 				if (serverUniversalUITheme.contains(universalUITheme)) {
 					themeFound = true;
 					break ;

--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -901,7 +901,7 @@ public class ExecuteHarnessMain {
 
 			String machineName, resultDirectory = null, seleniumProject = null, resultRootDirectory = null,
 					labScriptFile, labResultURL;
-			String bugReports = "c:/opt/qa/BugReports/bugReports.jar";
+			String bugReportsJar = "c:/opt/qa/BugReports/BugReports.jar";
 
 			machineName = getLocalMachineName().replace(".corp.telligent.com", "").replace(".lab.zimbra.com", "").replace(".eng.zimbra.com", "");
 			emailBody.append("Selenium Automation Report: ")
@@ -1002,7 +1002,7 @@ public class ExecuteHarnessMain {
 			}
 
 			StafExecute staf = new StafExecute("SERVICE",
-					"ADD SERVICE BUGZILLA LIBRARY JSTAF EXECUTE " + bugReports);
+					"ADD SERVICE BUGZILLA LIBRARY JSTAF EXECUTE " + bugReportsJar);
 			staf.execute();
 
 			staf = new StafExecute("BUGZILLA",

--- a/src/java/com/zimbra/qa/selenium/framework/core/SeleniumService.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/SeleniumService.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Date;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import com.zimbra.qa.selenium.framework.util.CommandLine;
+import com.zimbra.qa.selenium.framework.util.CommandLineUtility;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
 import com.zimbra.qa.selenium.framework.util.OperatingSystem;
 import com.zimbra.qa.selenium.framework.util.SleepMetrics;
@@ -123,15 +123,15 @@ public class SeleniumService {
 
 		try {
 			if (SeleniumBrowser.contains("iexplore")) {
-			    CommandLine.CmdExec("taskkill /f /t /im iexplore.exe");
+			    CommandLineUtility.CmdExec("taskkill /f /t /im iexplore.exe");
 			} else if (SeleniumBrowser.contains("firefox")) {
-				CommandLine.CmdExec("taskkill /f /t /im firefox.exe");
-				CommandLine.CmdExec("taskkill /f /t /im geckodriver.exe");
+				CommandLineUtility.CmdExec("taskkill /f /t /im firefox.exe");
+				CommandLineUtility.CmdExec("taskkill /f /t /im geckodriver.exe");
 			} else if (SeleniumBrowser.contains("safari")) {
-			    CommandLine.CmdExec("taskkill /f /t /im safari.exe");
+			    CommandLineUtility.CmdExec("taskkill /f /t /im safari.exe");
 			} else if (SeleniumBrowser.contains("chrome")) {
-				CommandLine.CmdExec("taskkill /f /t /im chrome.exe");
-				CommandLine.CmdExec("taskkill /f /t /im chromedriver.exe");
+				CommandLineUtility.CmdExec("taskkill /f /t /im chrome.exe");
+				CommandLineUtility.CmdExec("taskkill /f /t /im chromedriver.exe");
 			}
 
 		} catch (IOException e) {
@@ -151,11 +151,11 @@ public class SeleniumService {
 
 		try {
 			if (SeleniumBrowser.contains("firefox")) {
-				CommandLine.CmdExec("killall firefox");
-				CommandLine.CmdExec("killall geckodriver");
+				CommandLineUtility.CmdExec("killall firefox");
+				CommandLineUtility.CmdExec("killall geckodriver");
 			} else if (SeleniumBrowser.contains("chrome")) {
-				CommandLine.CmdExec("killall googlechrome");
-				CommandLine.CmdExec("killall chromedriver");
+				CommandLineUtility.CmdExec("killall googlechrome");
+				CommandLineUtility.CmdExec("killall chromedriver");
 			}
 
 		} catch (IOException e) {
@@ -174,13 +174,13 @@ public class SeleniumService {
 
 		try {
 			if (SeleniumBrowser.contains("firefox")) {
-				CommandLine.CmdExec("pkill -f firefox");
-				CommandLine.CmdExec("pkill -f geckodriver");
+				CommandLineUtility.CmdExec("pkill -f firefox");
+				CommandLineUtility.CmdExec("pkill -f geckodriver");
 			} else if (SeleniumBrowser.contains("chrome")) {
-				CommandLine.CmdExec("pkill -f googlechrome");
-				CommandLine.CmdExec("pkill -f chromedriver");
+				CommandLineUtility.CmdExec("pkill -f googlechrome");
+				CommandLineUtility.CmdExec("pkill -f chromedriver");
 			} else if (SeleniumBrowser.contains("safari")) {
-				CommandLine.CmdExec("pkill -f safari");
+				CommandLineUtility.CmdExec("pkill -f safari");
 			}
 
 		} catch (IOException e) {
@@ -210,7 +210,7 @@ public class SeleniumService {
 
 	private volatile static SeleniumService Instance;
 
-	private SeleniumService() {
+	public SeleniumService() {
 		logger.info("New SeleniumService object");
 
 		String modeProp = ConfigProperties.getStringProperty("seleniumMode", "local").toLowerCase();

--- a/src/java/com/zimbra/qa/selenium/framework/util/CommandLineUtility.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/CommandLineUtility.java
@@ -63,8 +63,8 @@ class StreamGobbler extends Thread
     }
 }
 
-public class CommandLine {
-	private static Logger logger = LogManager.getLogger(CommandLine.class);
+public class CommandLineUtility {
+	private static Logger logger = LogManager.getLogger(CommandLineUtility.class);
 
 	/**
 	 * Execute Command line with no STDIN parameter and return the execution status

--- a/src/java/com/zimbra/qa/selenium/framework/util/GeneralUtility.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/GeneralUtility.java
@@ -232,7 +232,7 @@ public class GeneralUtility {
     * @throws HarnessException 
     */
    public static boolean findWindowsRunningTask(String taskName) throws IOException, InterruptedException, HarnessException {
-      String output = CommandLine.cmdExecWithOutput("TASKLIST /FI \"IMAGENAME EQ " + taskName + "\"");
+      String output = CommandLineUtility.cmdExecWithOutput("TASKLIST /FI \"IMAGENAME EQ " + taskName + "\"");
       logger.debug("output: " + output);
       if (output.contains(taskName)) {
          return true;

--- a/src/java/com/zimbra/qa/selenium/framework/util/staf/StafAbstract.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/staf/StafAbstract.java
@@ -26,15 +26,14 @@ import java.nio.file.StandardOpenOption;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import com.ibm.staf.STAFException;
 import com.ibm.staf.STAFHandle;
 import com.ibm.staf.STAFMarshallingContext;
 import com.ibm.staf.STAFResult;
+import com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
 
 /**
  * A wrapper class to create STAF classes from
@@ -124,7 +123,6 @@ public class StafAbstract {
 			String sStafLogFilePath = sStafLogFileFolderPath + "\\" + sStafLogFileName;
 			Path pStafLogFilePath = Paths.get(sStafLogFileFolderPath, sStafLogFileName);
 			File fStafLogFile = new File(sStafLogFilePath);
-			List<String> lines = null;
 
 			// Create STAF log folder and file
 			File fStafLogFileFolder = new File(sStafLogFileFolderPath);
@@ -142,7 +140,7 @@ public class StafAbstract {
 
 	        try {
 
-	        	if (AjaxCommonTest.totalZimbraServers < 1) {
+	        	if (ExecuteHarnessMain.totalZimbraServers < 1) {
 
 	        		// Single Node Server
 
@@ -150,9 +148,9 @@ public class StafAbstract {
 
 						StafServer = ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".server.host", ConfigProperties.getStringProperty("server.host"));
 
-						lines = Arrays.asList("Executing STAF Command: " + StafParms + " on Single Node server (" + StafServer + ")\n");
 						try {
-							Files.write(pStafLogFilePath, lines, Charset.forName("UTF-8"), StandardOpenOption.APPEND);
+							Files.write(pStafLogFilePath, Arrays.asList("Executing STAF Command: " + StafParms + " on Single Node server (" + StafServer + ")\n"), 
+									Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 						} catch (IOException e) {
 							e.printStackTrace();
 						}
@@ -163,9 +161,9 @@ public class StafAbstract {
 
 						// Localhost
 
-						lines = Arrays.asList("Executing STAF Command: " + StafParms + " on localhost (" + StafServer + ")\n");
 						try {
-							Files.write(pStafLogFilePath, lines, Charset.forName("UTF-8"), StandardOpenOption.APPEND);
+							Files.write(pStafLogFilePath, Arrays.asList("Executing STAF Command: " + StafParms + " on localhost (" + StafServer + ")\n"), 
+									Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 						} catch (IOException e) {
 							e.printStackTrace();
 						}
@@ -182,9 +180,9 @@ public class StafAbstract {
 	        			
 						StafServer = ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".mta.host", ConfigProperties.getStringProperty("mta.host"));
 
-						lines = Arrays.asList("Executing STAF Command: " + StafParms + " on MTA Host (" + StafServer + ")\n");
 						try {
-							Files.write(pStafLogFilePath, lines, Charset.forName("UTF-8"), StandardOpenOption.APPEND);
+							Files.write(pStafLogFilePath, Arrays.asList("Executing STAF Command: " + StafParms + " on MTA Host (" + StafServer + ")\n"), 
+									Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 						} catch (IOException e) {
 							e.printStackTrace();
 						}
@@ -197,13 +195,13 @@ public class StafAbstract {
 						Boolean storeCommandResponse = true;
 						String storeServer = null;
 
-						for (int i=0; i<AjaxCommonTest.storeServers.size(); i++) {
+						for (int i=0; i<ExecuteHarnessMain.storeServers.size(); i++) {
 
-							storeServer = AjaxCommonTest.storeServers.get(i);
+							storeServer = ExecuteHarnessMain.storeServers.get(i);
 
-							lines = Arrays.asList("Executing STAF Command: " + StafParms + " on Store Host (" + storeServer + ")\n");
 							try {
-								Files.write(pStafLogFilePath, lines, Charset.forName("UTF-8"), StandardOpenOption.APPEND);
+								Files.write(pStafLogFilePath, Arrays.asList("Executing STAF Command: " + StafParms + " on Store Host (" + storeServer + ")\n"), 
+										Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
@@ -220,9 +218,9 @@ public class StafAbstract {
 
 						// Localhost
 
-						lines = Arrays.asList("Executing STAF Command: " + StafParms + " on localhost (" + StafServer + ")\n");
 						try {
-							Files.write(pStafLogFilePath, lines, Charset.forName("UTF-8"), StandardOpenOption.APPEND);
+							Files.write(pStafLogFilePath, Arrays.asList("Executing STAF Command: " + StafParms + " on localhost (" + StafServer + ")\n"), 
+									Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 						} catch (IOException e) {
 							e.printStackTrace();
 						}
@@ -234,9 +232,9 @@ public class StafAbstract {
 
 				logger.info("STAF Response: " + StafResponse);
 
-				lines = Arrays.asList("STAT Command: " +  StafParms + " Response: " + StafResponse + "\n\n");
 				try {
-					Files.write(pStafLogFilePath, lines, Charset.forName("UTF-8"), StandardOpenOption.APPEND);
+					Files.write(pStafLogFilePath, Arrays.asList("STAT Command: " +  StafParms + " Response: " + StafResponse + "\n\n"), 
+							Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 				} catch (IOException e) {
 					e.printStackTrace();
 				}

--- a/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCommonTest.java
@@ -34,7 +34,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -62,7 +61,6 @@ import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.core.ClientSessionFactory;
 import com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain;
 import com.zimbra.qa.selenium.framework.ui.AbsTab;
-import com.zimbra.qa.selenium.framework.util.CommandLine;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
 import com.zimbra.qa.selenium.framework.util.SleepUtil;
@@ -74,9 +72,6 @@ public class AdminCommonTest {
 
 	protected AppAdminConsole app = null;
 	protected AbsTab startingPage = null;
-	public static ArrayList<String> storeServers = null;
-	public static ArrayList<String> zimbraServers = null;
-	public static int totalZimbraServers;
 	
 	protected final ZimbraAdminAccount gAdmin = ZimbraAdminAccount.AdminConsoleAdmin();
 	protected ZimbraAdminAccount startingAccount = null;
@@ -97,29 +92,6 @@ public class AdminCommonTest {
 		startingAccount = gAdmin;
 	}
 	
-	public void commonTestZimbraConfiguration() throws HarnessException {
-		
-		logger.info("-------------- Pre-configuration and required setup --------------");
-
-		if (ConfigProperties.getStringProperty("staf").equals("true")) {
-			
-			try {
-				// Get all store servers
-				storeServers = CommandLine.runCommandOnZimbraServer("zmprov -l gas mailbox");
-				logger.info("Store servers (especially for multi-node environment): " + storeServers);
-				
-				// Get total zimbra servers
-				for (String noOfZimbraServers : CommandLine.runCommandOnZimbraServer("zmprov -l gas | wc -l")) {
-					totalZimbraServers = Integer.parseInt(noOfZimbraServers);
-				}
-				logger.info("No. of zimbra servers (especially for multi-node environment): " + totalZimbraServers);
-												
-			} catch(Exception e) {
-				logger.error("Unable to get mailbox stores using CLI utility", e);
-			}
-		}
-	}
-
 	@BeforeSuite(groups = { "always" })
 	public void commonTestBeforeSuite() throws HarnessException {
 
@@ -162,7 +134,6 @@ public class AdminCommonTest {
 				}
 			}
 			logger.info("App is ready!");
-			commonTestZimbraConfiguration();
 
 		} catch (WebDriverException e) {
 			logger.error("Unable to open admin app. Is a valid certificate installed?", e);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCommonTest.java
@@ -65,9 +65,6 @@ public class AjaxCommonTest {
 	
 	protected AppAjaxClient app = null;
 	protected AbsTab startingPage = null;
-	public static ArrayList<String> storeServers = null;
-	public static ArrayList<String> zimbraServers = null;
-	public static int totalZimbraServers;
 
 	protected Map<String, String> startingAccountPreferences = null;
 	protected Map<String, String> startingUserPreferences = null;
@@ -88,38 +85,6 @@ public class AjaxCommonTest {
 		startingPage = app.zPageMain;
 		startingAccountPreferences = new HashMap<String, String>();
 		startingUserZimletPreferences = new HashMap<String, String>();
-	}
-
-	public void commonTestZimbraConfiguration() throws HarnessException {
-		
-		logger.info("-------------- Pre-configuration and required setup --------------");
-
-		if (ConfigProperties.getStringProperty("staf").equals("true")) {
-			
-			try {
-				// Get all store servers
-				storeServers = CommandLine.runCommandOnZimbraServer("zmprov -l gas mailbox");
-				logger.info("Store servers (especially for multi-node environment): " + storeServers);
-				
-				// Get total zimbra servers
-				for (String noOfZimbraServers : CommandLine.runCommandOnZimbraServer("zmprov -l gas | wc -l")) {
-					totalZimbraServers = Integer.parseInt(noOfZimbraServers);
-				}
-				logger.info("No. of zimbra servers (especially for multi-node environment): " + totalZimbraServers);
-				
-				// Grant createDistList right to domain
-				logger.info("Grant createDistList right to domain using STAF");
-				staf.execute("zmprov grr domain " + ConfigProperties.getStringProperty("testdomain") + " dom "
-						+ ConfigProperties.getStringProperty("testdomain") + " createDistList");
-				
-				// Disable zimbraSmimeOCSPEnabled attribute for S/MIME
-				logger.info("Disable zimbraSmimeOCSPEnabled attribute for S/MIME using STAF");
-				staf.execute("zmprov mcf zimbraSmimeOCSPEnabled FALSE");
-				
-			} catch(Exception e) {
-				logger.error("Unable to get mailbox stores, grant createDistList right or disable zimbraSmimeOCSPEnabled using STAF/CLI utility", e);
-			}
-		}
 	}
 
 	@BeforeSuite(groups = { "always" })
@@ -155,7 +120,6 @@ public class AjaxCommonTest {
 				}
 			}
 			logger.info("App is ready!");
-			commonTestZimbraConfiguration();
 
 		} catch (WebDriverException e) {
 			logger.error("Unable to open ajax app. Is a valid certificate installed?", e);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/ui/PageLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/ui/PageLogin.java
@@ -113,13 +113,13 @@ public class PageLogin extends AbsTab {
 				SeleniumBrowser = ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".browser",	ConfigProperties.getStringProperty("browser"));
 
 				if (SeleniumBrowser.contains("iexplore")) {
-				    CommandLine.CmdExec("taskkill /f /t /im iexplore.exe");
+				    CommandLineUtility.CmdExec("taskkill /f /t /im iexplore.exe");
 				} else if (SeleniumBrowser.contains("firefox")) {
-					CommandLine.CmdExec("taskkill /f /t /im firefox.exe");
+					CommandLineUtility.CmdExec("taskkill /f /t /im firefox.exe");
 				} else if (SeleniumBrowser.contains("safariproxy")) {
-				    CommandLine.CmdExec("taskkill /f /t /im safari.exe");
+				    CommandLineUtility.CmdExec("taskkill /f /t /im safari.exe");
 				} else if (SeleniumBrowser.contains("chrome")) {
-					CommandLine.CmdExec("taskkill /f /t /im chrome.exe");
+					CommandLineUtility.CmdExec("taskkill /f /t /im chrome.exe");
 				}
 
 			} catch (IOException e) {

--- a/src/java/com/zimbra/qa/selenium/projects/touch/ui/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/ui/PageMain.java
@@ -124,13 +124,13 @@ public class PageMain extends AbsTab {
 				SeleniumBrowser = ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".browser",	ConfigProperties.getStringProperty("browser"));
 
 				if (SeleniumBrowser.contains("iexplore")) {
-				    CommandLine.CmdExec("taskkill /f /t /im iexplore.exe");
+				    CommandLineUtility.CmdExec("taskkill /f /t /im iexplore.exe");
 				} else if (SeleniumBrowser.contains("firefox")) {
-					CommandLine.CmdExec("taskkill /f /t /im firefox.exe");
+					CommandLineUtility.CmdExec("taskkill /f /t /im firefox.exe");
 				} else if (SeleniumBrowser.contains("safariproxy")) {
-				    CommandLine.CmdExec("taskkill /f /t /im safari.exe");
+				    CommandLineUtility.CmdExec("taskkill /f /t /im safari.exe");
 				} else if (SeleniumBrowser.contains("chrome")) {
-					CommandLine.CmdExec("taskkill /f /t /im chrome.exe");
+					CommandLineUtility.CmdExec("taskkill /f /t /im chrome.exe");
 				}
 
 			} catch (IOException e) {

--- a/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalCommonTest.java
@@ -63,16 +63,16 @@ import com.zimbra.qa.selenium.projects.universal.ui.contacts.FormContactGroupNew
 
 public class UniversalCommonTest {
 
-	protected static Logger logger = LogManager.getLogger(UniversalCommonTest.class);
 	protected AppUniversalClient app = null;
-
-	protected AbsTab startingPage = null;
+	protected AbsTab startingPage = null;	
+	
 	protected Map<String, String> startingAccountPreferences = null;
 	protected Map<String, String> startingUserPreferences = null;
 	protected Map<String, String> startingUserZimletPreferences = null;
 
-	private WebDriver webDriver = ClientSessionFactory.session().webDriver();
 	WebElement we = null;
+	private WebDriver webDriver = ClientSessionFactory.session().webDriver();
+	protected static Logger logger = LogManager.getLogger(UniversalCommonTest.class);
 	
 	protected StafServicePROCESS staf = new StafServicePROCESS();
 	String sJavaScriptErrorsHtmlFileName = "Javascript-errors-report.html";
@@ -85,28 +85,6 @@ public class UniversalCommonTest {
 		startingPage = app.zPageMain;
 		startingAccountPreferences = new HashMap<String, String>();
 		startingUserZimletPreferences = new HashMap<String, String>();
-	}
-
-	public void commonTestZimbraConfiguration() throws HarnessException {
-		
-		logger.info("-------------- Pre-configuration and required setup --------------");
-
-		if (ConfigProperties.getStringProperty("staf").equals("true")) {
-			
-			try {
-				// Grant createDistList right to domain
-				logger.info("Grant createDistList right to domain");
-				staf.execute("zmprov grr domain " + ConfigProperties.getStringProperty("testdomain") + " dom "
-						+ ConfigProperties.getStringProperty("testdomain") + " createDistList");
-				
-				// Disable zimbraSmimeOCSPEnabled attribute for S/MIME
-				logger.info("Disable zimbraSmimeOCSPEnabled attribute for S/MIME");
-				staf.execute("zmprov mcf zimbraSmimeOCSPEnabled FALSE");
-				
-			} catch(Exception e) {
-				logger.error("Unable to grant createDistList right and can't disable zimbraSmimeOCSPEnabled for S/MIME", e);
-			}
-		}
 	}
 
 	@BeforeSuite(groups = { "always" })
@@ -142,7 +120,6 @@ public class UniversalCommonTest {
 				}
 			}
 			logger.info("App is ready!");
-			commonTestZimbraConfiguration();
 
 		} catch (WebDriverException e) {
 			logger.error("Unable to open ajax app. Is a valid certificate installed?", e);


### PR DESCRIPTION
ZCS-3219: Add Clarity theme support in selenium for Universal UI via zimbra pre-configuration

1. Using clarity theme when project is universal.

2. Renamed custom CommandLine.java to CommandLineUtility.java because it conflicts with apache's - org.apache.commons.cli.CommandLine.

3. Removed duplicate code of zimbra pre-configuration from AjaxCommonTest, AdminCommonTest, UniversalCommonTest to common place ExecuteHarnessMain. 