### PR TITLE
ZCS-3219: Fixed NPE due to config properties duplication in if condition

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -437,14 +437,14 @@ public class ExecuteHarnessMain {
 
 			SleepMetrics.report();
 
-			if (!ConfigProperties.getStringProperty(ConfigProperties.getStringProperty("emailTo")).contains("pnq-automation@synacor.com")) {
+			if (!ConfigProperties.getStringProperty("emailTo").contains("pnq-automation@synacor.com")) {
 
 				String project = classfilter.toString().replace("com.zimbra.qa.selenium.", "").replace("projects.", "");
 				project = project.substring(0, 1).toUpperCase() + project.substring(1);
 				String[] projectSplit = project.split(".tests.");
 
-				String suite = groups.toString().replace("always, ", "").replace("[", "").replace("]", "").trim();
-				if (suite.equals("sanity,smoke,functional") || suite.equals("sanity, smoke, functional")) {
+				String suite = groups.toString().replace("always, ", "").replace("[", "").replace("]", "").replace(" ", "").trim();
+				if (suite.equals("sanity,smoke,functional") || suite.equals("L0,L1,L2,L3")) {
 					suite = "Full";
 				}
 				suite = suite.substring(0, 1).toUpperCase() + suite.substring(1).replace(".tests", "");


### PR DESCRIPTION
Fixed NPE due to config properties duplication in if condition:

java.lang.NullPointerException
	at com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain.executeTests(ExecuteHarnessMain.java:440)
	at com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain.executeSelenium(ExecuteHarnessMain.java:359)
	at com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain.execute(ExecuteHarnessMain.java:324)
	at com.zimbra.qa.selenium.staf.StafIntegration.handleExecute(StafIntegration.java:312)
	at com.zimbra.qa.selenium.staf.StafIntegration.acceptRequest(StafIntegration.java:99)
	at com.ibm.staf.service.STAFServiceHelper.callService(STAFServiceHelper.java:349)