### PR TITLE
ZCS-3290: Skip all attachment adding testcases for MS Edge till IE driver fixes this issue or to have better solution

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UploadFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UploadFile.java
@@ -80,7 +80,7 @@ public class UploadFile extends FeatureBriefcaseTest {
 	
 	public void UploadFile_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -121,7 +121,7 @@ public class UploadFile extends FeatureBriefcaseTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/attachments/CreateMeetingWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/attachments/CreateMeetingWithAttachment.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.organizer.singleday.create;
+package com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.organizer.singleday.create.attachments;
 
 import java.awt.event.KeyEvent;
 import java.util.Calendar;
@@ -27,8 +27,8 @@ import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.universal.core.CalendarWorkWeekTest;
-import com.zimbra.qa.selenium.projects.universal.ui.calendar.FormApptNew;
+import com.zimbra.qa.selenium.projects.ajax.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.calendar.FormApptNew;
 
 public class CreateMeetingWithAttachment extends CalendarWorkWeekTest {
 
@@ -43,7 +43,7 @@ public class CreateMeetingWithAttachment extends CalendarWorkWeekTest {
 			
 	public void CreateMeetingWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 	
 			try {
 			
@@ -124,7 +124,7 @@ public class CreateMeetingWithAttachment extends CalendarWorkWeekTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/modify/ModifyByAddingAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/modify/ModifyByAddingAttachment.java
@@ -42,7 +42,7 @@ public class ModifyByAddingAttachment extends CalendarWorkWeekTest {
 
 	public void ModifyByAddingAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 				// Create a meeting
@@ -102,7 +102,7 @@ public class ModifyByAddingAttachment extends CalendarWorkWeekTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ComposeForwardMailWithAttachmentAndVariousOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ComposeForwardMailWithAttachmentAndVariousOptions.java
@@ -48,7 +48,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -126,7 +126,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -137,7 +137,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -205,7 +205,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -215,7 +215,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_03() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -288,7 +288,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ComposeReplyMailWithAttachmentAndVariousOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ComposeReplyMailWithAttachmentAndVariousOptions.java
@@ -34,10 +34,10 @@ import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
 import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
 import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew.Locators;
 
-public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
+public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
 
-	public ComposeReplyWithAttachmentAndVariousOptions() {
-		logger.info("New "+ ComposeReplyWithAttachmentAndVariousOptions.class.getCanonicalName());
+	public ComposeReplyMailWithAttachmentAndVariousOptions() {
+		logger.info("New "+ ComposeReplyMailWithAttachmentAndVariousOptions.class.getCanonicalName());
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
 	}
 
@@ -47,7 +47,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -126,7 +126,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -137,7 +137,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -203,7 +203,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -213,7 +213,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_03() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -286,7 +286,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/CreateMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/CreateMailWithAttachment.java
@@ -39,7 +39,7 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void CreateMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -105,7 +105,7 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ForwardMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ForwardMailWithAttachment.java
@@ -41,7 +41,7 @@ public class ForwardMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void ForwardMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -105,7 +105,7 @@ public class ForwardMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyAllMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyAllMailWithAttachment.java
@@ -41,7 +41,7 @@ public class ReplyAllMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void ReplyAllMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -139,7 +139,7 @@ public class ReplyAllMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyMailWithAttachment.java
@@ -41,7 +41,7 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void ReplyMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -115,7 +115,7 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/attachments/SaveDraftMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/attachments/SaveDraftMailWithAttachment.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.drafts;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.drafts.attachments;
 
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -41,7 +41,7 @@ public class SaveDraftMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void SaveDraftMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -108,7 +108,7 @@ public class SaveDraftMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -118,7 +118,7 @@ public class SaveDraftMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void OpenExistingSavedDraftMailWithAttachment_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -208,7 +208,7 @@ public class SaveDraftMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/attachments/SaveDraftMailWithIncludeOriginalAsAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/attachments/SaveDraftMailWithIncludeOriginalAsAttachment.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.universal.tests.mail.compose.drafts;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.drafts.attachments;
 
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
@@ -26,10 +26,10 @@ import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.universal.ui.DialogWarning;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew.Field;
+import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.DialogWarning;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew.Field;
 
 public class SaveDraftMailWithIncludeOriginalAsAttachment extends PrefGroupMailByMessageTest {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/CreateMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/CreateMailWithInlineImageAttachment.java
@@ -40,7 +40,7 @@ public class CreateMailWithInlineImageAttachment extends PrefGroupMailByMessageT
 
 	public void CreateMailWithInlineImageAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -115,7 +115,7 @@ public class CreateMailWithInlineImageAttachment extends PrefGroupMailByMessageT
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ForwardMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ForwardMailWithInlineImageAttachment.java
@@ -42,7 +42,7 @@ public class ForwardMailWithInlineImageAttachment extends PrefGroupMailByMessage
 
 	public void ForwardMailWithInlineImageAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -115,7 +115,7 @@ public class ForwardMailWithInlineImageAttachment extends PrefGroupMailByMessage
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ReplyMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ReplyMailWithInlineImageAttachment.java
@@ -42,7 +42,7 @@ public class ReplyMailWithInlineImageAttachment extends PrefGroupMailByMessageTe
 
 	public void ReplyMailWithInlineImageAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -111,7 +111,7 @@ public class ReplyMailWithInlineImageAttachment extends PrefGroupMailByMessageTe
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ReplyMailWithInlineImageBodyHtmlToText.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ReplyMailWithInlineImageBodyHtmlToText.java
@@ -49,7 +49,7 @@ public class ReplyMailWithInlineImageBodyHtmlToText extends PrefGroupMailByMessa
 
 	public void ReplyMailWithInlineImageBodyHtmlToText_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -114,7 +114,7 @@ public class ReplyMailWithInlineImageBodyHtmlToText extends PrefGroupMailByMessa
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/group/messages/SortByDateGroupByDateAscending.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/group/messages/SortByDateGroupByDateAscending.java
@@ -55,7 +55,7 @@ public class SortByDateGroupByDateAscending extends PrefGroupMailByMessageTest {
 	
 	public void SortByDateGroupByDateAscending_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			// File (export of an Inbox which contained mail of different past dates) to import. 
 			// The is required so that mails can be grouped by date and issue can be reproduced.

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/ComposeForwardMailWithAttachmentAndVariousOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/ComposeForwardMailWithAttachmentAndVariousOptions.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachments;
 
 import java.awt.event.KeyEvent;
 import org.testng.SkipException;
@@ -29,10 +29,10 @@ import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowFormMailNew;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew.Locators;
+import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowFormMailNew;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew.Locators;
 
 public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
 
@@ -46,7 +46,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -98,17 +98,13 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					window.zWaitForWindow(windowTitle);
-					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
-
-					// Select the window
-					window.sSelectWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
 
 					// Verify that the message is included as attachment in new window
 					ZAssert.assertTrue(mailform.zHasAttachment(subject),"Original message is not present as attachment");
 
-					app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
-					app.zPageMail.zPressButton(Button.B_MY_COMPUTER);
+					window.zPressButton(Button.O_ATTACH_DROPDOWN);
+					window.zPressButton(Button.B_MY_COMPUTER);
 					zUploadFile(filePath);
 
 					SleepUtil.sleepSmall();
@@ -122,13 +118,6 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 				} finally {
 					app.zPageMain.zCloseWindow(window, windowTitle, app);
-					
-					// This is just for bug 106583
-					if (window != null) {
-						window.zCloseWindow(fileName);
-						window = null;
-					}
-					app.zPageMail.zSelectWindow(null);
 				}
 
 			} finally {
@@ -138,7 +127,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -149,7 +138,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -206,11 +195,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					window.zWaitForWindow(windowTitle);
-					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
-
-					// Select the window
-					window.sSelectWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
 
 					// Verify that the attachment is present in new window as well.
 					ZAssert.assertTrue(mailform.zHasAttachment(fileName),"Attachment is not present in new window!");
@@ -226,7 +211,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -236,7 +221,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_03() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -301,11 +286,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					window.zWaitForWindow(windowTitle);
-					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
-
-					// Select the window
-					window.sSelectWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
 
 					// Verify that the attachment is present in new window as well.
 					ZAssert.assertTrue(mailform.zHasAttachment(fileName),"Attachment is not present in new window!");
@@ -321,7 +302,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 	

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/ComposeReplyMailWithAttachmentAndVariousOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/ComposeReplyMailWithAttachmentAndVariousOptions.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachments;
 
 import java.awt.event.KeyEvent;
 import org.testng.SkipException;
@@ -29,15 +29,15 @@ import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowFormMailNew;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew.Locators;
+import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowFormMailNew;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew.Locators;
 
-public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
+public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
 
-	public ComposeReplyWithAttachmentAndVariousOptions() {
-		logger.info("New "+ ComposeReplyWithAttachmentAndVariousOptions.class.getCanonicalName());
+	public ComposeReplyMailWithAttachmentAndVariousOptions() {
+		logger.info("New "+ ComposeReplyMailWithAttachmentAndVariousOptions.class.getCanonicalName());
 	}
 
 	@Bugs(ids = "103903, 106583")
@@ -46,7 +46,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -98,17 +98,13 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					window.zWaitForWindow(windowTitle);
-					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
-
-					// Select the window
-					window.sSelectWindow(windowTitle);
-
+					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
+					
 					// Verify that the message is included as attachment in new window
 					ZAssert.assertTrue(mailform.zHasAttachment(subject),"Original message is not present as attachment");
 
-					app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
-					app.zPageMail.zPressButton(Button.B_MY_COMPUTER);
+					window.zPressButton(Button.O_ATTACH_DROPDOWN);
+					window.zPressButton(Button.B_MY_COMPUTER);
 					zUploadFile(filePath);
 					
 					SleepUtil.sleepSmall();
@@ -122,13 +118,6 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 				} finally {
 					app.zPageMain.zCloseWindow(window, windowTitle, app);
-					
-					// This is just for bug 106583
-					if (window != null) {
-						window.zCloseWindow(fileName);
-						window = null;
-					}
-					app.zPageMail.zSelectWindow(null);
 				}
 
 			} finally {
@@ -138,7 +127,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -149,7 +138,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -206,11 +195,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					window.zWaitForWindow(windowTitle);
-					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
-
-					// Select the window
-					window.sSelectWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
 
 					// Verify that the attachment is present in new window as well.
 					ZAssert.assertTrue(mailform.zHasAttachment(fileName),"Attachment is not present in new window!");
@@ -226,7 +211,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -236,7 +221,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_03() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -301,11 +286,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					window.zWaitForWindow(windowTitle);
-					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
-
-					// Select the window
-					window.sSelectWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
 
 					// Verify that the attachment is present in new window as well.
 					ZAssert.assertTrue(mailform.zHasAttachment(fileName),"Attachment is not present in new window!");
@@ -321,7 +302,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 	

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/ComposeReplyWithAttachmentAndVariousOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/ComposeReplyWithAttachmentAndVariousOptions.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachments;
 
 import java.awt.event.KeyEvent;
 import org.testng.SkipException;
@@ -34,10 +34,10 @@ import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
 import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowFormMailNew;
 import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew.Locators;
 
-public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
+public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
 
-	public ComposeReplyMailWithAttachmentAndVariousOptions() {
-		logger.info("New "+ ComposeReplyMailWithAttachmentAndVariousOptions.class.getCanonicalName());
+	public ComposeReplyWithAttachmentAndVariousOptions() {
+		logger.info("New "+ ComposeReplyWithAttachmentAndVariousOptions.class.getCanonicalName());
 	}
 
 	@Bugs(ids = "103903, 106583")
@@ -46,7 +46,7 @@ public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMa
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -103,8 +103,8 @@ public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMa
 					// Verify that the message is included as attachment in new window
 					ZAssert.assertTrue(mailform.zHasAttachment(subject),"Original message is not present as attachment");
 
-					window.zPressButton(Button.O_ATTACH_DROPDOWN);
-					window.zPressButton(Button.B_MY_COMPUTER);
+					app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
+					app.zPageMail.zPressButton(Button.B_MY_COMPUTER);
 					zUploadFile(filePath);
 					
 					SleepUtil.sleepSmall();
@@ -118,6 +118,13 @@ public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMa
 
 				} finally {
 					app.zPageMain.zCloseWindow(window, windowTitle, app);
+					
+					// This is just for bug 106583
+					if (window != null) {
+						window.zCloseWindow(fileName);
+						window = null;
+					}
+					app.zPageMail.zSelectWindow(null);
 				}
 
 			} finally {
@@ -127,7 +134,7 @@ public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMa
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -138,7 +145,7 @@ public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMa
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -211,7 +218,7 @@ public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMa
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -221,7 +228,7 @@ public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMa
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_03() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -302,7 +309,7 @@ public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMa
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 	

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/CreateMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/CreateMailWithAttachment.java
@@ -15,7 +15,7 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachments;
 
 import java.awt.event.KeyEvent;
 import org.testng.SkipException;
@@ -25,8 +25,8 @@ import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowFormMailNew;
+import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowFormMailNew;
 
 public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 
@@ -40,7 +40,7 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 	
 	public void CreateMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -63,11 +63,7 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW_IN_NEW_WINDOW);
 
 					window.zSetWindowTitle(windowTitle);
-					window.zWaitForActive();
-
-					window.waitForComposeWindow();
-
-					ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
+					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
 
 					// Fill out the form with the data
 					window.zFill(mail);
@@ -129,7 +125,7 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/EditAsNewWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/EditAsNewWithAttachment.java
@@ -15,7 +15,7 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachments;
 
 import org.testng.SkipException;
 import org.testng.annotations.Test;
@@ -38,7 +38,7 @@ public class EditAsNewWithAttachment extends PrefGroupMailByMessageTest {
 	
 	public void EditAsNewWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
@@ -115,7 +115,7 @@ public class EditAsNewWithAttachment extends PrefGroupMailByMessageTest {
 			ZAssert.assertTrue(app.zPageMail.zVerifyAttachmentExistsInMail(fileName),"Verify attachment exists in the email");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/FwdMailWithAnAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/FwdMailWithAnAttachment.java
@@ -15,30 +15,39 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachments;
 
 import org.testng.SkipException;
 import org.testng.annotations.Test;
-import com.zimbra.qa.selenium.framework.items.*;
-import com.zimbra.qa.selenium.framework.ui.*;
-import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowDisplayMail;
+import com.zimbra.qa.selenium.framework.items.FolderItem;
+import com.zimbra.qa.selenium.framework.items.MailItem;
+import com.zimbra.qa.selenium.framework.ui.Action;
+import com.zimbra.qa.selenium.framework.ui.Button;
+import com.zimbra.qa.selenium.framework.util.ConfigProperties;
+import com.zimbra.qa.selenium.framework.util.HarnessException;
+import com.zimbra.qa.selenium.framework.util.OperatingSystem;
+import com.zimbra.qa.selenium.framework.util.SleepUtil;
+import com.zimbra.qa.selenium.framework.util.ZAssert;
+import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
+import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowDisplayMail;
 
-public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
+public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
 
-	public ReplyMailWithAttachment() {
-		logger.info("New "+ ReplyMailWithAttachment.class.getCanonicalName());
+	public FwdMailWithAnAttachment() {
+		logger.info("New "+ FwdMailWithAnAttachment.class.getCanonicalName());
 	}
 
-	@Test( description = "Reply to a mail  with an attachment by pressing Reply button>>attach - in separate window",
+	@Test( description = "Forward a mail  with an attachment by pressing Forward button>>attach - in separate window",
 			groups = { "smoke", "L1" })
-	
-	public void ReplyMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+	public void FwdMailWithAnAttachment_01() throws HarnessException {
+
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
+
 
 			// Send a message to the account
 			ZimbraAccount.AccountA().soapSend(
@@ -52,7 +61,6 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 							"</m>" +
 					"</SendMsgRequest>");
 
-
 			// Refresh current view
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 
@@ -63,7 +71,7 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 
 			// Create file item
 			final String fileName = "testtextfile.txt";
-			final String filePath = ConfigProperties.getBaseDirectory()	+ "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
 
 			SeparateWindowDisplayMail window = null;
 			String windowTitle = "Zimbra: " + subject;
@@ -74,25 +82,20 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 				window = (SeparateWindowDisplayMail)app.zPageMail.zToolbarPressPulldown(Button.B_ACTIONS, Button.B_LAUNCH_IN_SEPARATE_WINDOW);
 
 				window.zSetWindowTitle(windowTitle);
-				window.zWaitForActive();
-
-				ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
-
-				window.zToolbarPressButton(Button.B_REPLY);
-				SleepUtil.sleepMedium();
-				windowTitle = "Zimbra: Reply";
-
-				window.zSetWindowTitle(windowTitle);
-				SleepUtil.sleepMedium();
-				ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
-
+				ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
+				
+				window.zToolbarPressButton(Button.B_FORWARD);
+				String locator = FormMailNew.Locators.zToField;
+				window.sType(locator, ZimbraAccount.AccountB().EmailAddress+",");
+				SleepUtil.sleepSmall();
+				
 				// Add an attachment
 				window.zPressButton(Button.B_ATTACH);
 				zUpload(filePath, window);
 
 				// Click Send
 				window.zToolbarPressButton(Button.B_SEND);
-				
+
 			} finally {
 				app.zPageMain.zCloseWindow(window, windowTitle, app);
 			}
@@ -102,13 +105,14 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 			app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
 			ZAssert.assertTrue(app.zPageMail.zVerifyAttachmentExistsInMail(fileName),"Verify attachment exists in the email");
 
-			MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountA(), "in:inbox subject:("+subject +")");
+			MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountB(), "in:inbox subject:("+subject +")");
+
 			ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress, "Verify the from field is correct");
-			ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountA().EmailAddress, "Verify the to field is correct");
-			ZAssert.assertStringContains(received.dSubject, "Re: " + subject, "Verify Reply subject field is correct");
+			ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountB().EmailAddress, "Verify the to field is correct");
+			ZAssert.assertStringContains(received.dSubject, "Fwd: " + subject, "Verify forward subject field is correct");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/OpenComposedMsgWithAnAttachmentInNewWindow.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/OpenComposedMsgWithAnAttachmentInNewWindow.java
@@ -1,4 +1,4 @@
-package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachments;
 
 /*
  * ***** BEGIN LICENSE BLOCK *****
@@ -20,12 +20,14 @@ package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachmen
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.ui.Button;
-import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowFormMailNew;
+import com.zimbra.qa.selenium.framework.util.ConfigProperties;
+import com.zimbra.qa.selenium.framework.util.HarnessException;
+import com.zimbra.qa.selenium.framework.util.OperatingSystem;
+import com.zimbra.qa.selenium.framework.util.ZAssert;
+import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowFormMailNew;
 
 public class OpenComposedMsgWithAnAttachmentInNewWindow extends PrefGroupMailByMessageTest {
 
@@ -38,7 +40,7 @@ public class OpenComposedMsgWithAnAttachmentInNewWindow extends PrefGroupMailByM
 	
 	public void OpenComposedMsgWithAnAttachmentInNewWindow_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			// Create file item
 			final String fileName = "testtextfile.txt";
@@ -60,11 +62,7 @@ public class OpenComposedMsgWithAnAttachmentInNewWindow extends PrefGroupMailByM
 				window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 				window.zSetWindowTitle(windowTitle);
-				window.waitForComposeWindow();
-				ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
-
-				// Select the window
-				window.sSelectWindow(windowTitle);
+				ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
 				
 				// Verify Attachment should not disappeared  New compose window
 				Assert.assertTrue(window.zIsVisiblePerPosition("css=a[id^='COMPOSE']:contains(" + fileName + ")", 0, 0),"vcf attachment link present");
@@ -74,7 +72,7 @@ public class OpenComposedMsgWithAnAttachmentInNewWindow extends PrefGroupMailByM
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/ReplyMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/attachments/ReplyMailWithAttachment.java
@@ -15,33 +15,30 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachments;
 
-import java.awt.event.KeyEvent;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowDisplayMail;
+import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowDisplayMail;
 
-public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
+public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 
-	public FwdMailWithAnAttachment() {
-		logger.info("New "+ FwdMailWithAnAttachment.class.getCanonicalName());
+	public ReplyMailWithAttachment() {
+		logger.info("New "+ ReplyMailWithAttachment.class.getCanonicalName());
 	}
 
-	@Test( description = "Forward a mail  with an attachment by pressing Forward button>>attach - in separate window",
+	@Test( description = "Reply to a mail  with an attachment by pressing Reply button>>attach - in separate window",
 			groups = { "smoke", "L1" })
 	
-	public void FwdMailWithAnAttachment_01() throws HarnessException {
+	public void ReplyMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
-
 
 			// Send a message to the account
 			ZimbraAccount.AccountA().soapSend(
@@ -55,6 +52,7 @@ public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
 							"</m>" +
 					"</SendMsgRequest>");
 
+
 			// Refresh current view
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 
@@ -65,7 +63,7 @@ public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
 
 			// Create file item
 			final String fileName = "testtextfile.txt";
-			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory()	+ "\\data\\public\\other\\" + fileName;
 
 			SeparateWindowDisplayMail window = null;
 			String windowTitle = "Zimbra: " + subject;
@@ -76,53 +74,33 @@ public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
 				window = (SeparateWindowDisplayMail)app.zPageMail.zToolbarPressPulldown(Button.B_ACTIONS, Button.B_LAUNCH_IN_SEPARATE_WINDOW);
 
 				window.zSetWindowTitle(windowTitle);
-				window.zWaitForActive();
-
-				ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
-
-				window.zToolbarPressButton(Button.B_FORWARD);
-				SleepUtil.sleepMedium();
-				windowTitle = "Zimbra: Forward";
+				ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
 				
-				window.zSetWindowTitle(windowTitle);
-				SleepUtil.sleepMedium();
-				ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
+				window.zToolbarPressButton(Button.B_REPLY);
 
-				window.sSelectWindow(windowTitle);
-				String locator = FormMailNew.Locators.zToField;
-				window.sClick(locator);
-				window.sType(locator, ZimbraAccount.AccountB().EmailAddress);
-				window.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ENTER);
-				SleepUtil.sleepSmall();
-				window.zKeyboard.zTypeKeyEvent(KeyEvent.VK_TAB);
-				SleepUtil.sleepSmall();
-
-				window.sSelectWindow(windowTitle);
-				
 				// Add an attachment
 				window.zPressButton(Button.B_ATTACH);
 				zUpload(filePath, window);
 
 				// Click Send
 				window.zToolbarPressButton(Button.B_SEND);
-
+				
 			} finally {
 				app.zPageMain.zCloseWindow(window, windowTitle, app);
 			}
-			
+
 			// Verify UI for attachment
 			app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, sent);
 			app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
 			ZAssert.assertTrue(app.zPageMail.zVerifyAttachmentExistsInMail(fileName),"Verify attachment exists in the email");
 
-			MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountB(), "in:inbox subject:("+subject +")");
-
+			MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountA(), "in:inbox subject:("+subject +")");
 			ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress, "Verify the from field is correct");
-			ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountB().EmailAddress, "Verify the to field is correct");
-			ZAssert.assertStringContains(received.dSubject, "Fwd: " + subject, "Verify forward subject field is correct");
+			ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountA().EmailAddress, "Verify the to field is correct");
+			ZAssert.assertStringContains(received.dSubject, "Re: " + subject, "Verify Reply subject field is correct");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/CreateMailWithAnInlineImg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/CreateMailWithAnInlineImg.java
@@ -40,7 +40,7 @@ public class CreateMailWithAnInlineImg extends PrefGroupMailByMessageTest {
 	
 	public void CreateMailWithAnInlineImg_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -138,7 +138,7 @@ public class CreateMailWithAnInlineImg extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/EditAsNewWithAnInlineAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/EditAsNewWithAnInlineAttachment.java
@@ -39,7 +39,7 @@ public class EditAsNewWithAnInlineAttachment extends PrefGroupMailByMessageTest 
 	
 	public void EditAsNewWithAnInlineAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
@@ -139,7 +139,7 @@ public class EditAsNewWithAnInlineAttachment extends PrefGroupMailByMessageTest 
 			ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageAttachmentExistsInMail(),"Verify inline attachment exists in the email");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/FwdMailWithAnInlineAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/FwdMailWithAnInlineAttachment.java
@@ -29,7 +29,7 @@ public class FwdMailWithAnInlineAttachment extends PrefGroupMailByMessageTest {
 	
 	public void FwdMailWithAnInlineAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
 			String bodyText = "text" + ConfigProperties.getUniqueString();
@@ -116,7 +116,7 @@ public class FwdMailWithAnInlineAttachment extends PrefGroupMailByMessageTest {
 			ZAssert.assertStringContains(received.dSubject, "Fwd: " + subject, "Verify forward subject field is correct");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/OpenComposedMsgWithAnInlineAttachmentInNewWindow.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/OpenComposedMsgWithAnInlineAttachmentInNewWindow.java
@@ -38,7 +38,7 @@ PrefGroupMailByMessageTest {
 	
 	public void OpenComposedMsgWithAnAttachmentInNewWindow_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			// Create file item
 
@@ -72,7 +72,7 @@ PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/ReplyMailWithAnInlineAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/ReplyMailWithAnInlineAttachment.java
@@ -39,7 +39,7 @@ public class ReplyMailWithAnInlineAttachment extends PrefGroupMailByMessageTest 
 	
 	public void ReplyMailWithAnInlineAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
 			String bodyText = "text" + ConfigProperties.getUniqueString();
@@ -125,7 +125,7 @@ public class ReplyMailWithAnInlineAttachment extends PrefGroupMailByMessageTest 
 			ZAssert.assertStringContains(received.dSubject, "Re: " + subject, "Verify reply subject field is correct");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/importexport/ImportAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/importexport/ImportAccount.java
@@ -49,7 +49,7 @@ public class ImportAccount extends AjaxCommonTest {
 
 	public void ImportAccount_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			//-- File to import
 			final String fileName = "account.tgz";
@@ -133,7 +133,7 @@ public class ImportAccount extends AjaxCommonTest {
 			ZAssert.assertTrue(app.zPageBriefcase.isPresentInListView(docName), "Verify that document in briefcase is displayed");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/attachments/CreateTaskWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/attachments/CreateTaskWithAttachment.java
@@ -48,7 +48,7 @@ public class CreateTaskWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void CreateTaskWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -89,7 +89,7 @@ public class CreateTaskWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/briefcase/file/UploadFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/briefcase/file/UploadFile.java
@@ -80,7 +80,7 @@ public class UploadFile extends FeatureBriefcaseTest {
 	
 	public void UploadFile_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -121,7 +121,7 @@ public class UploadFile extends FeatureBriefcaseTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/attachments/CreateMeetingWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/attachments/CreateMeetingWithAttachment.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.organizer.singleday.create;
+package com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.organizer.singleday.create.attachments;
 
 import java.awt.event.KeyEvent;
 import java.util.Calendar;
@@ -27,8 +27,8 @@ import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.ajax.core.CalendarWorkWeekTest;
-import com.zimbra.qa.selenium.projects.ajax.ui.calendar.FormApptNew;
+import com.zimbra.qa.selenium.projects.universal.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.universal.ui.calendar.FormApptNew;
 
 public class CreateMeetingWithAttachment extends CalendarWorkWeekTest {
 
@@ -43,7 +43,7 @@ public class CreateMeetingWithAttachment extends CalendarWorkWeekTest {
 			
 	public void CreateMeetingWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 	
 			try {
 			
@@ -124,7 +124,7 @@ public class CreateMeetingWithAttachment extends CalendarWorkWeekTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/modify/ModifyByAddingAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/modify/ModifyByAddingAttachment.java
@@ -42,7 +42,7 @@ public class ModifyByAddingAttachment extends CalendarWorkWeekTest {
 
 	public void ModifyByAddingAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 				// Create a meeting
@@ -102,7 +102,7 @@ public class ModifyByAddingAttachment extends CalendarWorkWeekTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ComposeForwardMailWithAttachmentAndVariousOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ComposeForwardMailWithAttachmentAndVariousOptions.java
@@ -48,7 +48,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -126,7 +126,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -137,7 +137,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -205,7 +205,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -215,7 +215,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_03() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -288,7 +288,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ComposeReplyMailWithAttachmentAndVariousOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ComposeReplyMailWithAttachmentAndVariousOptions.java
@@ -34,10 +34,10 @@ import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest
 import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
 import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew.Locators;
 
-public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
+public class ComposeReplyMailWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
 
-	public ComposeReplyWithAttachmentAndVariousOptions() {
-		logger.info("New "+ ComposeReplyWithAttachmentAndVariousOptions.class.getCanonicalName());
+	public ComposeReplyMailWithAttachmentAndVariousOptions() {
+		logger.info("New "+ ComposeReplyMailWithAttachmentAndVariousOptions.class.getCanonicalName());
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
 	}
 
@@ -47,7 +47,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -126,7 +126,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -137,7 +137,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -203,7 +203,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -213,7 +213,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_03() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -286,7 +286,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/CreateMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/CreateMailWithAttachment.java
@@ -39,7 +39,7 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void CreateMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -105,7 +105,7 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ForwardMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ForwardMailWithAttachment.java
@@ -41,7 +41,7 @@ public class ForwardMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void ForwardMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -105,7 +105,7 @@ public class ForwardMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ReplyAllMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ReplyAllMailWithAttachment.java
@@ -41,7 +41,7 @@ public class ReplyAllMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void ReplyAllMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -139,7 +139,7 @@ public class ReplyAllMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ReplyMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/attachments/ReplyMailWithAttachment.java
@@ -41,7 +41,7 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void ReplyMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -115,7 +115,7 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/drafts/attachments/SaveDraftMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/drafts/attachments/SaveDraftMailWithAttachment.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.drafts;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.compose.drafts.attachments;
 
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -25,103 +25,100 @@ import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew.Field;
+import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew.Field;
 
-public class SaveDraftMailWithInlineImagettachment extends PrefGroupMailByMessageTest {
+public class SaveDraftMailWithAttachment extends PrefGroupMailByMessageTest {
 
-	public SaveDraftMailWithInlineImagettachment() {
-		logger.info("New "+ SaveDraftMailWithInlineImagettachment.class.getCanonicalName());
+	public SaveDraftMailWithAttachment() {
+		logger.info("New "+ SaveDraftMailWithAttachment.class.getCanonicalName());
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
-		super.startingAccountPreferences.put("zimbraPrefForwardReplyInOriginalFormat", "FALSE");
 	}
 
-	@Test( description = "Save draft a mail with inline attachment and send a mail",
-			groups = { "smoke", "L1" })
+	@Test( description = "Save draft a mail with attachment and send a mail",
+			groups = { "sanity", "L0" })
 
-	public void SaveDraftAndSendMailWithInlineImageAttachment_01() throws HarnessException {
+	public void SaveDraftMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
-	
+
 				// Create the message data to be sent
 				MailItem mail = new MailItem();
 				mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountA()));
 				mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 				mail.dBodyHtml = "body" + ConfigProperties.getUniqueString();
-	
+
 				FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
-	
+
 				// Create file item
-				final String fileName = "structure.jpg";
+				final String fileName = "testtextfile.txt";
 				final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
-	
+
 				// Open the new mail form
 				FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);
 				ZAssert.assertNotNull(mailform, "Verify the new form opened");
-	
+
 				// Fill out the form with the data
 				mailform.zFill(mail);
-	
-				app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
-				app.zPageMail.zPressButton(Button.B_ATTACH_INLINE);
-				zUploadInlineImageAttachment(filePath);
-	
-				ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageAttachmentExistsInComposeWindow(), "Verify inline attachment exists in the Compose window");
-	
+
+				// Upload the file
+				app.zPageMail.zPressButton(Button.B_ATTACH);
+				zUpload(filePath);
+
 				// Send the message after saving as draft
 				mailform.zToolbarPressButton(Button.B_SAVE_DRAFT);
 				mailform.zSubmit();
-	
+
 				ZimbraAccount.AccountA().soapSend(
 								"<SearchRequest types='message' xmlns='urn:zimbraMail'>"
 						+			"<query>subject:("+ mail.dSubject +")</query>"
 						+		"</SearchRequest>");
 				String id = ZimbraAccount.AccountA().soapSelectValue("//mail:m", "id");
-	
+
 				ZimbraAccount.AccountA().soapSend(
 								"<GetMsgRequest xmlns='urn:zimbraMail'>"
 						+			"<m id='"+ id +"' html='1'/>"
 						+		"</GetMsgRequest>");
-	
+
 				String from = ZimbraAccount.AccountA().soapSelectValue("//mail:e[@t='f']", "a");
 				String to = ZimbraAccount.AccountA().soapSelectValue("//mail:e[@t='t']", "a");
 				String subject = ZimbraAccount.AccountA().soapSelectValue("//mail:su", null);
 				String html = ZimbraAccount.AccountA().soapSelectValue("//mail:mp[@ct='text/html']//mail:content", null);
-	
+
 				ZAssert.assertEquals(from, app.zGetActiveAccount().EmailAddress, "Verify the from field is correct");
 				ZAssert.assertEquals(to, ZimbraAccount.AccountA().EmailAddress, "Verify the to field is correct");
 				ZAssert.assertEquals(subject, mail.dSubject, "Verify the subject field is correct");
 				ZAssert.assertStringContains(html, mail.dBodyHtml, "Verify the html content");
-	
+
 				Element[] nodes = ZimbraAccount.AccountA().soapSelectNodes("//mail:mp[@filename='" + fileName + "']");
 				ZAssert.assertEquals(nodes.length, 1, "Verify attachment exist in the sent mail");
-	
+
 				// Verify UI for attachment
 				app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, sent);
 				app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
-				ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageAttachmentExistsInMail(), "Verify attachment exists in the email");
-	
+				ZAssert.assertTrue(app.zPageMail.zVerifyAttachmentExistsInMail(fileName), "Verify attachment exists in the email");
+
 			} finally {
-	
+
 				app.zPageMain.zKeyboardKeyEvent(KeyEvent.VK_ESCAPE);
 
 			}
-			
+
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
 
-	@Test( description = "Open existing saved draft with attachment and send a mail with inline image attachment",
+	@Test( description = "Open existing saved draft with attachment and send a mail",
 			groups = { "functional", "L2" })
 
-	public void OpenExistingSavedDraftAndSendMailWithInlineImageAttachment_02() throws HarnessException {
+	public void OpenExistingSavedDraftMailWithAttachment_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -156,15 +153,13 @@ public class SaveDraftMailWithInlineImagettachment extends PrefGroupMailByMessag
 
 				mailform.zFillField(Field.To, ZimbraAccount.AccountA().EmailAddress);
 
-				final String anotherFileName = "structure.jpg";
+				// Upload another file and send mail
+				app.zPageMail.zPressButton(Button.B_ATTACH);
+
+				final String anotherFileName = "putty.log";
 				final String anotherFilePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + anotherFileName;
 
-				app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
-				app.zPageMail.zPressButton(Button.B_ATTACH_INLINE);
-				zUploadInlineImageAttachment(anotherFilePath);
-
-				ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageAttachmentExistsInComposeWindow(), "Verify inline attachment exists in the compose window");
-
+				zUpload(anotherFilePath);
 				mailform.zSubmit();
 
 				ZimbraAccount.AccountA().soapSend(
@@ -181,17 +176,17 @@ public class SaveDraftMailWithInlineImagettachment extends PrefGroupMailByMessag
 				String from = ZimbraAccount.AccountA().soapSelectValue("//mail:e[@t='f']", "a");
 				String to = ZimbraAccount.AccountA().soapSelectValue("//mail:e[@t='t'][2]", "a");
 				String subject = ZimbraAccount.AccountA().soapSelectValue("//mail:su", null);
-				String html = ZimbraAccount.AccountA().soapSelectValue("//mail:mp[@ct='text/html']//mail:content", null);
+				String html = ZimbraAccount.AccountA().soapSelectValue("//mail:mp[@ct='text/plain']//mail:content", null);
 
 				ZAssert.assertEquals(from, app.zGetActiveAccount().EmailAddress, "Verify the from field is correct");
 				ZAssert.assertEquals(to, ZimbraAccount.AccountA().EmailAddress, "Verify the to field is correct");
 				ZAssert.assertEquals(subject, "Re: " + mimeSubject, "Verify the subject field is correct");
 				ZAssert.assertStringContains(html, mimeSubject, "Verify the html content");
 
-				String getFilename = ZimbraAccount.AccountA().soapSelectValue("//mail:mp[@cd='inline']", "filename");
+				String getFilename = ZimbraAccount.AccountA().soapSelectValue("//mail:mp[@cd='attachment']", "filename");
 				ZAssert.assertEquals(getFilename, anotherFileName, "Verify existing attachment exists in the sent mail");
 
-				getFilename = ZimbraAccount.AccountA().soapSelectValue("//mail:mp[@cd='attachment']", "filename");
+				getFilename = ZimbraAccount.AccountA().soapSelectValue("//mail:mp[@cd='attachment'][2]", "filename");
 				ZAssert.assertEquals(getFilename, mimeAttachmentName, "Verify newly added attachment exists in the sent mail");
 
 				Element[] nodes = ZimbraAccount.AccountA().soapSelectNodes("//mail:mp[@filename='" + anotherFileName + "']");
@@ -204,7 +199,7 @@ public class SaveDraftMailWithInlineImagettachment extends PrefGroupMailByMessag
 				app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, sent);
 				app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
 				ZAssert.assertTrue(app.zPageMail.zVerifyAttachmentExistsInMail(mimeAttachmentName), "Verify attachment exists in the email");
-				ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageAttachmentExistsInMail(), "Verify inline attachment exists in the email");
+				ZAssert.assertTrue(app.zPageMail.zVerifyAttachmentExistsInMail(anotherFileName), "Verify attachment exists in the email");
 
 			} finally {
 
@@ -213,7 +208,7 @@ public class SaveDraftMailWithInlineImagettachment extends PrefGroupMailByMessag
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/drafts/attachments/SaveDraftMailWithIncludeOriginalAsAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/drafts/attachments/SaveDraftMailWithIncludeOriginalAsAttachment.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.drafts;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.compose.drafts.attachments;
 
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
@@ -26,10 +26,10 @@ import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.ajax.ui.DialogWarning;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew.Field;
+import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.universal.ui.DialogWarning;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew.Field;
 
 public class SaveDraftMailWithIncludeOriginalAsAttachment extends PrefGroupMailByMessageTest {
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/drafts/attachments/SaveDraftMailWithInlineImagettachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/drafts/attachments/SaveDraftMailWithInlineImagettachment.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.universal.tests.mail.compose.drafts;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.compose.drafts.attachments;
 
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -42,7 +42,7 @@ public class SaveDraftMailWithInlineImagettachment extends PrefGroupMailByMessag
 
 	public void SaveDraftAndSendMailWithInlineImageAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 	
@@ -111,7 +111,7 @@ public class SaveDraftMailWithInlineImagettachment extends PrefGroupMailByMessag
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -121,7 +121,7 @@ public class SaveDraftMailWithInlineImagettachment extends PrefGroupMailByMessag
 
 	public void OpenExistingSavedDraftAndSendMailWithInlineImageAttachment_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -213,7 +213,7 @@ public class SaveDraftMailWithInlineImagettachment extends PrefGroupMailByMessag
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/inlineimage/CreateMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/inlineimage/CreateMailWithInlineImageAttachment.java
@@ -40,7 +40,7 @@ public class CreateMailWithInlineImageAttachment extends PrefGroupMailByMessageT
 
 	public void CreateMailWithInlineImageAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -115,7 +115,7 @@ public class CreateMailWithInlineImageAttachment extends PrefGroupMailByMessageT
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/inlineimage/ForwardMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/inlineimage/ForwardMailWithInlineImageAttachment.java
@@ -42,7 +42,7 @@ public class ForwardMailWithInlineImageAttachment extends PrefGroupMailByMessage
 
 	public void ForwardMailWithInlineImageAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -115,7 +115,7 @@ public class ForwardMailWithInlineImageAttachment extends PrefGroupMailByMessage
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/inlineimage/ReplyMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/inlineimage/ReplyMailWithInlineImageAttachment.java
@@ -42,7 +42,7 @@ public class ReplyMailWithInlineImageAttachment extends PrefGroupMailByMessageTe
 
 	public void ReplyMailWithInlineImageAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -111,7 +111,7 @@ public class ReplyMailWithInlineImageAttachment extends PrefGroupMailByMessageTe
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/inlineimage/ReplyMailWithInlineImageBodyHtmlToText.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/inlineimage/ReplyMailWithInlineImageBodyHtmlToText.java
@@ -49,7 +49,7 @@ public class ReplyMailWithInlineImageBodyHtmlToText extends PrefGroupMailByMessa
 
 	public void ReplyMailWithInlineImageBodyHtmlToText_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -114,7 +114,7 @@ public class ReplyMailWithInlineImageBodyHtmlToText extends PrefGroupMailByMessa
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/group/messages/SortByDateGroupByDateAscending.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/group/messages/SortByDateGroupByDateAscending.java
@@ -55,7 +55,7 @@ public class SortByDateGroupByDateAscending extends PrefGroupMailByMessageTest {
 	
 	public void SortByDateGroupByDateAscending_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			// File (export of an Inbox which contained mail of different past dates) to import. 
 			// The is required so that mails can be grouped by date and issue can be reproduced.

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/ComposeForwardMailWithAttachmentAndVariousOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/ComposeForwardMailWithAttachmentAndVariousOptions.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachments;
 
 import java.awt.event.KeyEvent;
 import org.testng.SkipException;
@@ -29,10 +29,10 @@ import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowFormMailNew;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew.Locators;
+import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowFormMailNew;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew.Locators;
 
 public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
 
@@ -46,7 +46,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -98,13 +98,17 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
+					window.zWaitForWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
+
+					// Select the window
+					window.sSelectWindow(windowTitle);
 
 					// Verify that the message is included as attachment in new window
 					ZAssert.assertTrue(mailform.zHasAttachment(subject),"Original message is not present as attachment");
 
-					window.zPressButton(Button.O_ATTACH_DROPDOWN);
-					window.zPressButton(Button.B_MY_COMPUTER);
+					app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
+					app.zPageMail.zPressButton(Button.B_MY_COMPUTER);
 					zUploadFile(filePath);
 
 					SleepUtil.sleepSmall();
@@ -118,6 +122,13 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 				} finally {
 					app.zPageMain.zCloseWindow(window, windowTitle, app);
+					
+					// This is just for bug 106583
+					if (window != null) {
+						window.zCloseWindow(fileName);
+						window = null;
+					}
+					app.zPageMail.zSelectWindow(null);
 				}
 
 			} finally {
@@ -127,7 +138,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -138,7 +149,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -195,7 +206,11 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
+					window.zWaitForWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
+
+					// Select the window
+					window.sSelectWindow(windowTitle);
 
 					// Verify that the attachment is present in new window as well.
 					ZAssert.assertTrue(mailform.zHasAttachment(fileName),"Attachment is not present in new window!");
@@ -211,7 +226,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -221,7 +236,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 
 	public void ComposeForwardMailWithAttachmentAndVariousOptions_03() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -286,7 +301,11 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
+					window.zWaitForWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
+
+					// Select the window
+					window.sSelectWindow(windowTitle);
 
 					// Verify that the attachment is present in new window as well.
 					ZAssert.assertTrue(mailform.zHasAttachment(fileName),"Attachment is not present in new window!");
@@ -302,7 +321,7 @@ public class ComposeForwardMailWithAttachmentAndVariousOptions extends PrefGroup
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 	

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/ComposeReplyWithAttachmentAndVariousOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/ComposeReplyWithAttachmentAndVariousOptions.java
@@ -14,7 +14,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  * ***** END LICENSE BLOCK *****
  */
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachments;
 
 import java.awt.event.KeyEvent;
 import org.testng.SkipException;
@@ -29,10 +29,10 @@ import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowFormMailNew;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew.Locators;
+import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowFormMailNew;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew.Locators;
 
 public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailByMessageTest {
 
@@ -46,7 +46,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -98,8 +98,12 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
-					
+					window.zWaitForWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
+
+					// Select the window
+					window.sSelectWindow(windowTitle);
+
 					// Verify that the message is included as attachment in new window
 					ZAssert.assertTrue(mailform.zHasAttachment(subject),"Original message is not present as attachment");
 
@@ -134,7 +138,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -145,7 +149,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_02() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -202,7 +206,11 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
+					window.zWaitForWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
+
+					// Select the window
+					window.sSelectWindow(windowTitle);
 
 					// Verify that the attachment is present in new window as well.
 					ZAssert.assertTrue(mailform.zHasAttachment(fileName),"Attachment is not present in new window!");
@@ -218,7 +226,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 
@@ -228,7 +236,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 
 	public void ComposeReplyWithAttachmentAndVariousOptions_03() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject" + ConfigProperties.getUniqueString();
 
@@ -293,7 +301,11 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 					window.zSetWindowTitle(windowTitle);
-					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
+					window.zWaitForWindow(windowTitle);
+					ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
+
+					// Select the window
+					window.sSelectWindow(windowTitle);
 
 					// Verify that the attachment is present in new window as well.
 					ZAssert.assertTrue(mailform.zHasAttachment(fileName),"Attachment is not present in new window!");
@@ -309,7 +321,7 @@ public class ComposeReplyWithAttachmentAndVariousOptions extends PrefGroupMailBy
 			}
 			
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 	

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/CreateMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/CreateMailWithAttachment.java
@@ -15,7 +15,7 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachments;
 
 import java.awt.event.KeyEvent;
 import org.testng.SkipException;
@@ -25,8 +25,8 @@ import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowFormMailNew;
+import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowFormMailNew;
 
 public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 
@@ -40,7 +40,7 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 	
 	public void CreateMailWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -63,7 +63,11 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 					window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW_IN_NEW_WINDOW);
 
 					window.zSetWindowTitle(windowTitle);
-					ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
+					window.zWaitForActive();
+
+					window.waitForComposeWindow();
+
+					ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
 
 					// Fill out the form with the data
 					window.zFill(mail);
@@ -125,7 +129,7 @@ public class CreateMailWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/EditAsNewWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/EditAsNewWithAttachment.java
@@ -15,7 +15,7 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachments;
 
 import org.testng.SkipException;
 import org.testng.annotations.Test;
@@ -37,7 +37,7 @@ public class EditAsNewWithAttachment extends PrefGroupMailByMessageTest {
 	
 	public void EditAsNewWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
@@ -122,7 +122,7 @@ public class EditAsNewWithAttachment extends PrefGroupMailByMessageTest {
 			ZAssert.assertTrue(app.zPageMail.zVerifyAttachmentExistsInMail(fileName),"Verify attachment exists in the email");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/FwdMailWithAnAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/FwdMailWithAnAttachment.java
@@ -15,30 +15,33 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachments;
 
+import java.awt.event.KeyEvent;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowDisplayMail;
+import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowDisplayMail;
 
-public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
+public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
 
-	public ReplyMailWithAttachment() {
-		logger.info("New "+ ReplyMailWithAttachment.class.getCanonicalName());
+	public FwdMailWithAnAttachment() {
+		logger.info("New "+ FwdMailWithAnAttachment.class.getCanonicalName());
 	}
 
-	@Test( description = "Reply to a mail  with an attachment by pressing Reply button>>attach - in separate window",
+	@Test( description = "Forward a mail  with an attachment by pressing Forward button>>attach - in separate window",
 			groups = { "smoke", "L1" })
 	
-	public void ReplyMailWithAttachment_01() throws HarnessException {
+	public void FwdMailWithAnAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
+
 
 			// Send a message to the account
 			ZimbraAccount.AccountA().soapSend(
@@ -52,7 +55,6 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 							"</m>" +
 					"</SendMsgRequest>");
 
-
 			// Refresh current view
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 
@@ -63,7 +65,7 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 
 			// Create file item
 			final String fileName = "testtextfile.txt";
-			final String filePath = ConfigProperties.getBaseDirectory()	+ "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
 
 			SeparateWindowDisplayMail window = null;
 			String windowTitle = "Zimbra: " + subject;
@@ -74,33 +76,53 @@ public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 				window = (SeparateWindowDisplayMail)app.zPageMail.zToolbarPressPulldown(Button.B_ACTIONS, Button.B_LAUNCH_IN_SEPARATE_WINDOW);
 
 				window.zSetWindowTitle(windowTitle);
-				ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
-				
-				window.zToolbarPressButton(Button.B_REPLY);
+				window.zWaitForActive();
 
+				ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
+
+				window.zToolbarPressButton(Button.B_FORWARD);
+				SleepUtil.sleepMedium();
+				windowTitle = "Zimbra: Forward";
+				
+				window.zSetWindowTitle(windowTitle);
+				SleepUtil.sleepMedium();
+				ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
+
+				window.sSelectWindow(windowTitle);
+				String locator = FormMailNew.Locators.zToField;
+				window.sClick(locator);
+				window.sType(locator, ZimbraAccount.AccountB().EmailAddress);
+				window.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ENTER);
+				SleepUtil.sleepSmall();
+				window.zKeyboard.zTypeKeyEvent(KeyEvent.VK_TAB);
+				SleepUtil.sleepSmall();
+
+				window.sSelectWindow(windowTitle);
+				
 				// Add an attachment
 				window.zPressButton(Button.B_ATTACH);
 				zUpload(filePath, window);
 
 				// Click Send
 				window.zToolbarPressButton(Button.B_SEND);
-				
+
 			} finally {
 				app.zPageMain.zCloseWindow(window, windowTitle, app);
 			}
-
+			
 			// Verify UI for attachment
 			app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, sent);
 			app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
 			ZAssert.assertTrue(app.zPageMail.zVerifyAttachmentExistsInMail(fileName),"Verify attachment exists in the email");
 
-			MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountA(), "in:inbox subject:("+subject +")");
+			MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountB(), "in:inbox subject:("+subject +")");
+
 			ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress, "Verify the from field is correct");
-			ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountA().EmailAddress, "Verify the to field is correct");
-			ZAssert.assertStringContains(received.dSubject, "Re: " + subject, "Verify Reply subject field is correct");
+			ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountB().EmailAddress, "Verify the to field is correct");
+			ZAssert.assertStringContains(received.dSubject, "Fwd: " + subject, "Verify forward subject field is correct");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/OpenComposedMsgWithAnAttachmentInNewWindow.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/OpenComposedMsgWithAnAttachmentInNewWindow.java
@@ -1,4 +1,4 @@
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachments;
 
 /*
  * ***** BEGIN LICENSE BLOCK *****
@@ -20,15 +20,11 @@ package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.ui.Button;
-import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.OperatingSystem;
-import com.zimbra.qa.selenium.framework.util.ZAssert;
-import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowFormMailNew;
+import com.zimbra.qa.selenium.framework.util.*;
+import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.FormMailNew;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowFormMailNew;
 
 public class OpenComposedMsgWithAnAttachmentInNewWindow extends PrefGroupMailByMessageTest {
 
@@ -41,7 +37,7 @@ public class OpenComposedMsgWithAnAttachmentInNewWindow extends PrefGroupMailByM
 	
 	public void OpenComposedMsgWithAnAttachmentInNewWindow_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			// Create file item
 			final String fileName = "testtextfile.txt";
@@ -63,7 +59,11 @@ public class OpenComposedMsgWithAnAttachmentInNewWindow extends PrefGroupMailByM
 				window = (SeparateWindowFormMailNew) app.zPageMail.zToolbarPressButton(Button.B_DETACH_COMPOSE);
 
 				window.zSetWindowTitle(windowTitle);
-				ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
+				window.waitForComposeWindow();
+				ZAssert.assertTrue(window.zIsActive(),"Verify the window is active");
+
+				// Select the window
+				window.sSelectWindow(windowTitle);
 				
 				// Verify Attachment should not disappeared  New compose window
 				Assert.assertTrue(window.zIsVisiblePerPosition("css=a[id^='COMPOSE']:contains(" + fileName + ")", 0, 0),"vcf attachment link present");
@@ -73,7 +73,7 @@ public class OpenComposedMsgWithAnAttachmentInNewWindow extends PrefGroupMailByM
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/ReplyMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/attachments/ReplyMailWithAttachment.java
@@ -15,40 +15,30 @@
  * ***** END LICENSE BLOCK *****
  */
 
-package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.attachment;
+package com.zimbra.qa.selenium.projects.universal.tests.mail.newwindow.attachments;
 
 import org.testng.SkipException;
 import org.testng.annotations.Test;
+import com.zimbra.qa.selenium.framework.items.*;
+import com.zimbra.qa.selenium.framework.ui.*;
+import com.zimbra.qa.selenium.framework.util.*;
+import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
+import com.zimbra.qa.selenium.projects.universal.ui.mail.SeparateWindowDisplayMail;
 
-import com.zimbra.qa.selenium.framework.items.FolderItem;
-import com.zimbra.qa.selenium.framework.items.MailItem;
-import com.zimbra.qa.selenium.framework.ui.Action;
-import com.zimbra.qa.selenium.framework.ui.Button;
-import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.OperatingSystem;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
-import com.zimbra.qa.selenium.framework.util.ZAssert;
-import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
-import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.FormMailNew;
-import com.zimbra.qa.selenium.projects.ajax.ui.mail.SeparateWindowDisplayMail;
+public class ReplyMailWithAttachment extends PrefGroupMailByMessageTest {
 
-public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
-
-	public FwdMailWithAnAttachment() {
-		logger.info("New "+ FwdMailWithAnAttachment.class.getCanonicalName());
+	public ReplyMailWithAttachment() {
+		logger.info("New "+ ReplyMailWithAttachment.class.getCanonicalName());
 	}
 
-	@Test( description = "Forward a mail  with an attachment by pressing Forward button>>attach - in separate window",
+	@Test( description = "Reply to a mail  with an attachment by pressing Reply button>>attach - in separate window",
 			groups = { "smoke", "L1" })
+	
+	public void ReplyMailWithAttachment_01() throws HarnessException {
 
-	public void FwdMailWithAnAttachment_01() throws HarnessException {
-
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
-
 
 			// Send a message to the account
 			ZimbraAccount.AccountA().soapSend(
@@ -62,6 +52,7 @@ public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
 							"</m>" +
 					"</SendMsgRequest>");
 
+
 			// Refresh current view
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 
@@ -72,7 +63,7 @@ public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
 
 			// Create file item
 			final String fileName = "testtextfile.txt";
-			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory()	+ "\\data\\public\\other\\" + fileName;
 
 			SeparateWindowDisplayMail window = null;
 			String windowTitle = "Zimbra: " + subject;
@@ -83,20 +74,25 @@ public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
 				window = (SeparateWindowDisplayMail)app.zPageMail.zToolbarPressPulldown(Button.B_ACTIONS, Button.B_LAUNCH_IN_SEPARATE_WINDOW);
 
 				window.zSetWindowTitle(windowTitle);
-				ZAssert.assertTrue(window.zIsWindowOpen(windowTitle),"Verify the window is opened and switch to it");
-				
-				window.zToolbarPressButton(Button.B_FORWARD);
-				String locator = FormMailNew.Locators.zToField;
-				window.sType(locator, ZimbraAccount.AccountB().EmailAddress+",");
-				SleepUtil.sleepSmall();
-				
+				window.zWaitForActive();
+
+				ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
+
+				window.zToolbarPressButton(Button.B_REPLY);
+				SleepUtil.sleepMedium();
+				windowTitle = "Zimbra: Reply";
+
+				window.zSetWindowTitle(windowTitle);
+				SleepUtil.sleepMedium();
+				ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
+
 				// Add an attachment
 				window.zPressButton(Button.B_ATTACH);
 				zUpload(filePath, window);
 
 				// Click Send
 				window.zToolbarPressButton(Button.B_SEND);
-
+				
 			} finally {
 				app.zPageMain.zCloseWindow(window, windowTitle, app);
 			}
@@ -106,14 +102,13 @@ public class FwdMailWithAnAttachment extends PrefGroupMailByMessageTest {
 			app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
 			ZAssert.assertTrue(app.zPageMail.zVerifyAttachmentExistsInMail(fileName),"Verify attachment exists in the email");
 
-			MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountB(), "in:inbox subject:("+subject +")");
-
+			MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountA(), "in:inbox subject:("+subject +")");
 			ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress, "Verify the from field is correct");
-			ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountB().EmailAddress, "Verify the to field is correct");
-			ZAssert.assertStringContains(received.dSubject, "Fwd: " + subject, "Verify forward subject field is correct");
+			ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountA().EmailAddress, "Verify the to field is correct");
+			ZAssert.assertStringContains(received.dSubject, "Re: " + subject, "Verify Reply subject field is correct");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/CreateMailWithAnInlineImg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/CreateMailWithAnInlineImg.java
@@ -40,7 +40,7 @@ public class CreateMailWithAnInlineImg extends PrefGroupMailByMessageTest {
 	
 	public void CreateMailWithAnInlineImg_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -143,7 +143,7 @@ public class CreateMailWithAnInlineImg extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/EditAsNewWithAnInlineAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/EditAsNewWithAnInlineAttachment.java
@@ -38,7 +38,7 @@ public class EditAsNewWithAnInlineAttachment extends PrefGroupMailByMessageTest 
 	
 	public void EditAsNewWithAnInlineAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
@@ -149,7 +149,7 @@ public class EditAsNewWithAnInlineAttachment extends PrefGroupMailByMessageTest 
 			ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageAttachmentExistsInMail(),"Verify inline attachment exists in the email");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/FwdMailWithAnInlineAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/FwdMailWithAnInlineAttachment.java
@@ -41,7 +41,7 @@ public class FwdMailWithAnInlineAttachment extends PrefGroupMailByMessageTest {
 	
 	public void FwdMailWithAnInlineAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
 			String bodyText = "text" + ConfigProperties.getUniqueString();
@@ -147,7 +147,7 @@ public class FwdMailWithAnInlineAttachment extends PrefGroupMailByMessageTest {
 			ZAssert.assertStringContains(received.dSubject, "Fwd: " + subject, "Verify forward subject field is correct");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/OpenComposedMsgWithAnInlineAttachmentInNewWindow.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/OpenComposedMsgWithAnInlineAttachmentInNewWindow.java
@@ -38,7 +38,7 @@ PrefGroupMailByMessageTest {
 	
 	public void OpenComposedMsgWithAnAttachmentInNewWindow_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			// Create file item
 
@@ -73,7 +73,7 @@ PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/ReplyMailWithAnInlineAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newwindow/inlineimage/ReplyMailWithAnInlineAttachment.java
@@ -39,7 +39,7 @@ public class ReplyMailWithAnInlineAttachment extends PrefGroupMailByMessageTest 
 	
 	public void ReplyMailWithAnInlineAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			String subject = "subject"+ ConfigProperties.getUniqueString();
 			String bodyText = "text" + ConfigProperties.getUniqueString();
@@ -134,7 +134,7 @@ public class ReplyMailWithAnInlineAttachment extends PrefGroupMailByMessageTest 
 			ZAssert.assertStringContains(received.dSubject, "Re: " + subject, "Verify reply subject field is correct");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/importexport/ImportAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/importexport/ImportAccount.java
@@ -49,7 +49,7 @@ public class ImportAccount extends UniversalCommonTest {
 
 	public void ImportAccount_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			//-- File to import
 			final String fileName = "account.tgz";
@@ -133,7 +133,7 @@ public class ImportAccount extends UniversalCommonTest {
 			ZAssert.assertTrue(app.zPageBriefcase.isPresentInListView(docName), "Verify that document in briefcase is displayed");
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/tasks/attachments/CreateTaskWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/tasks/attachments/CreateTaskWithAttachment.java
@@ -48,7 +48,7 @@ public class CreateTaskWithAttachment extends PrefGroupMailByMessageTest {
 
 	public void CreateTaskWithAttachment_01() throws HarnessException {
 
-		if (OperatingSystem.isWindows() == true) {
+		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
 
 			try {
 
@@ -89,7 +89,7 @@ public class CreateTaskWithAttachment extends PrefGroupMailByMessageTest {
 			}
 
 		} else {
-			throw new SkipException("File upload operation is allowed only for Windows OS, skipping this test...");
+			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
 	}
 }


### PR DESCRIPTION
ZCS-3290: Skip all attachment adding testcases for MS Edge till IE driver fixes this issue or to have better solution

- Added condition if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("msedge")) {
** In future if MS Edge/selenium come up with some kind of solution by leaving control from file explorer dialog then we will see. Also we will revisit if we find some work around but currently it affects to entire suite for MS Edge.

- Organized attachments related testcases for missing apps to manage like: app/<area>/attachments

- Renamed one of the file name, which was missing "Mail" word

- Changes are done for Ajax and Universal project both