### PR TITLE
ZCS-3217: Fixed selenium test-skip issue due to print preview dialog while running Ajax-full suite

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeleniumObject.java
+++ b/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeleniumObject.java
@@ -2148,7 +2148,7 @@ public abstract class AbsSeleniumObject {
 						}
 						url = webDriver().getCurrentUrl();
 
-						if (windowName != null && (windowName.equals(name) || url.contains("/" + name + "?")) && !(url.contains("//print/"))) {
+						if (windowName != null && (windowName.equals(name) || url.contains("/" + name + "?")) && !(url.contains("//print/"))) { // Checking of "//print/" in URL is to avoid selection of print preview dialog in chrome  
 							found = true;
 							logger.info("Found window: " + windowName);
 							break;

--- a/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeleniumObject.java
+++ b/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeleniumObject.java
@@ -2148,7 +2148,7 @@ public abstract class AbsSeleniumObject {
 						}
 						url = webDriver().getCurrentUrl();
 
-						if (windowName != null && (windowName.contentEquals(name) || url.contains("/" + name + "?"))) {
+						if (windowName != null && (windowName.equals(name) || url.contains("/" + name + "?")) && !(url.contains("//print/"))) {
 							found = true;
 							logger.info("Found window: " + windowName);
 							break;

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/PrintTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/PrintTask.java
@@ -102,6 +102,7 @@ public class PrintTask extends AjaxCommonTest {
 			ZAssert.assertStringContains(printContent, bodyText, "Verify content in Print view");
 
 		} finally {
+			window.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ESCAPE);		// to close the print preview dialog in case it is still open
 			app.zPageMain.zCloseWindow(window, windowTitle, app);
 		}
 	}
@@ -163,6 +164,7 @@ public class PrintTask extends AjaxCommonTest {
 			ZAssert.assertStringContains(printContent, bodyText, "Verify content in Print view");
 
 		} finally {
+			window.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ESCAPE);
 			app.zPageMain.zCloseWindow(window, windowTitle, app);
 		}
 	}
@@ -257,6 +259,7 @@ public class PrintTask extends AjaxCommonTest {
 			ZAssert.assertStringContains(printContent, subject3, "Verify subject2 in Print view");
 
 		} finally {
+			window.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ESCAPE);
 			app.zPageMain.zCloseWindow(window, windowTitle, app);
 		}
 


### PR DESCRIPTION
In case of chrome, the print preview window, and print preview chrome dialog have the same title.
To distinguish between the two and switch to the print preview window, we need to use URL of the window.
So added one more condition to check for URL to avoid switching to incorrect chrome print preview dialog.
This works in FF as well. 
