### PR TITLE
ZCS-3363: Use single AccountZCS instead of ZWC/ZUC/ZMC/ZTC/ZHC to decrease the maintenance and replace ajax reference with universal

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxQuickCommandTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxQuickCommandTest.java
@@ -69,22 +69,22 @@ public class AjaxQuickCommandTest extends AjaxCommonTest {
 		
 		// Create a tag
 		String tagname = "tag" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateTagRequest xmlns='urn:zimbraMail'>"
 				+		"<tag name='"+ tagname +"' color='1' />"
 				+	"</CreateTagRequest>");
 
-		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZWC(), tagname);
+		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZCS(), tagname);
 		ZAssert.assertNotNull(tag, "Verify the tag was created");
 
 		// Create a subfolder
 		String foldername = "folder" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 				+		"<folder name='"+ foldername +"' l='1' view='message'/>"
 				+	"</CreateFolderRequest>");
 
-		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), foldername);
+		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), foldername);
 		ZAssert.assertNotNull(folder, "Verify the subfolder is available");
 
 		// Create the list of actions
@@ -122,22 +122,22 @@ public class AjaxQuickCommandTest extends AjaxCommonTest {
 		
 		// Create a tag
 		String tagname = "tag" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateTagRequest xmlns='urn:zimbraMail'>"
 				+		"<tag name='"+ tagname +"' color='1' />"
 				+	"</CreateTagRequest>");
 
-		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZWC(), tagname);
+		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZCS(), tagname);
 		ZAssert.assertNotNull(tag, "Verify the tag was created");
 
 		// Create a subfolder
 		String foldername = "folder" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 				+		"<folder name='"+ foldername +"' l='1' view='contact'/>"
 				+	"</CreateFolderRequest>");
 
-		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), foldername);
+		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), foldername);
 		ZAssert.assertNotNull(folder, "Verify the subfolder is available");
 
 		// Create the list of actions
@@ -174,22 +174,22 @@ public class AjaxQuickCommandTest extends AjaxCommonTest {
 		
 		// Create a tag
 		String tagname = "tag" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateTagRequest xmlns='urn:zimbraMail'>"
 				+		"<tag name='"+ tagname +"' color='1' />"
 				+	"</CreateTagRequest>");
 
-		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZWC(), tagname);
+		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZCS(), tagname);
 		ZAssert.assertNotNull(tag, "Verify the tag was created");
 
 		// Create a subfolder
 		String foldername = "folder" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 				+		"<folder name='"+ foldername +"' l='1' view='appointment'/>"
 				+	"</CreateFolderRequest>");
 
-		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), foldername);
+		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), foldername);
 		ZAssert.assertNotNull(folder, "Verify the subfolder is available");
 
 		// Create the list of actions
@@ -221,7 +221,7 @@ public class AjaxQuickCommandTest extends AjaxCommonTest {
 		
 
 		// Create a quick command in the user preferences
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 				+		"<pref name='zimbraPrefQuickCommand'>"+ this.getQuickCommand01().toString() +"</pref>"
 				+		"<pref name='zimbraPrefQuickCommand'>"+ this.getQuickCommand02().toString() +"</pref>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/allday/ModifyMultipleDayAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/allday/ModifyMultipleDayAppointment.java
@@ -172,6 +172,6 @@ public class ModifyMultipleDayAppointment extends CalendarWorkWeekTest {
 		//Verify that multi-day appointments are displayed correctly in month view 
 		boolean displayed = app.zPageCalendar.zVerifyMultidayAllDayAppointmentInMonthView(now, noOfDays, subject);
 		ZAssert.assertTrue(displayed, "Multi-day all-day appointments are not created and displayed correctly in month view");
-		ZimbraAccount.ResetAccountZWC();
+		ZimbraAccount.ResetAccountZCS();
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/Forward.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/Forward.java
@@ -205,12 +205,12 @@ public class Forward extends CalendarWorkWeekTest {
 	public void ForwardMeeting_03() throws HarnessException {
 		
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		String attendee2 = ZimbraAccount.Account2().EmailAddress;
 		
@@ -252,12 +252,12 @@ public class Forward extends CalendarWorkWeekTest {
 	public void ForwardMeeting_04() throws HarnessException {
 		
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		String attendee2 = ZimbraAccount.Account3().EmailAddress;
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/actions/Forward.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/actions/Forward.java
@@ -256,12 +256,12 @@ public class Forward extends CalendarWorkWeekTest {
 	public void ForwardMeeting_04() throws HarnessException {
 		
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		app.zPageCalendar.zNavigateTo();
 		String attendee2 = ZimbraAccount.Account2().EmailAddress;
 		// Create appointment data

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
@@ -104,7 +104,7 @@ public class CreateMeeting extends CalendarWorkWeekTest {
 
 		// Set mail Compose preference to Text format
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "text");
-		ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
+		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 
 		// Refresh UI
 		app.zPageMain.sRefresh();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingByChangingBodyTextFormat.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingByChangingBodyTextFormat.java
@@ -43,7 +43,7 @@ public class CreateMeetingByChangingBodyTextFormat extends CalendarWorkWeekTest 
     	
 		// Set mail Compose preference to Text format
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "text");
-		ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
+		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 		
 		// Refresh UI
 		app.zPageMain.sRefresh();
@@ -88,7 +88,7 @@ public class CreateMeetingByChangingBodyTextFormat extends CalendarWorkWeekTest 
     	
 		// Set mail Compose preference to Text format
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
-		ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
+		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 		
 		// Refresh UI
 		app.zPageMain.sRefresh();
@@ -134,7 +134,7 @@ public class CreateMeetingByChangingBodyTextFormat extends CalendarWorkWeekTest 
     	
 		// Set mail Compose preference to Text format
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "text");
-		ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
+		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 		
 		// Refresh UI
 		app.zPageMain.sRefresh();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingUsingMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingUsingMessage.java
@@ -41,12 +41,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_01() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeHtmlOnly1.txt";
 		final String subject = "1 html mail";
@@ -102,12 +102,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_02() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeHtmlOnly2.txt";
 		final String subject = "2 html mail";
@@ -161,12 +161,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_03() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeTextOnly1.txt";
 		final String subject = "1 plain mail";
@@ -221,12 +221,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_04() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeTextOnly2.txt";
 		final String subject = "2 plain mail";
@@ -281,12 +281,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_05() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeHtmlOnly3.txt";
 		final String subject = "3 html mail";
@@ -340,12 +340,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_06() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeHtmlOnly4.txt";
 		final String subject = "4 html mail";
@@ -399,12 +399,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_07() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeTextOnly3.txt";
 		final String subject = "3 plain mail";
@@ -459,12 +459,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_08() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeTextOnly4.txt";
 		final String subject = "4 plain mail";
@@ -520,12 +520,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_09() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email00/mime.txt";
 		final String subject = "ZCS 8 triage";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingAttendee.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingAttendee.java
@@ -79,7 +79,7 @@ public class ResetStatusAfterAddingAttendee extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Add attendee2 and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingEquipment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingEquipment.java
@@ -77,7 +77,7 @@ public class ResetStatusAfterAddingEquipment extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Add Equipment and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingLocation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingLocation.java
@@ -79,7 +79,7 @@ public class ResetStatusAfterAddingLocation extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Add Location and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingCalendar.java
@@ -85,7 +85,7 @@ public class ResetStatusAfterModifyingCalendar extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Add attendee2 and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingContent.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingContent.java
@@ -78,7 +78,7 @@ public class ResetStatusAfterModifyingContent extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);
 		app.zPageMain.zLogout();
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Modify Body and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingSubject.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingSubject.java
@@ -78,7 +78,7 @@ public class ResetStatusAfterModifyingSubject extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());	
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());	
 		
         // Modify Subject and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingTime.java
@@ -80,7 +80,7 @@ public class ResetStatusAfterModifyingTime extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());	
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());	
         
         // Modify time and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingAttendee.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingAttendee.java
@@ -79,7 +79,7 @@ public class ResetStatusAfterRemovingAttendee extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
         
         // Remove attendee2 and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingEquipment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingEquipment.java
@@ -77,7 +77,7 @@ public class ResetStatusAfterRemovingEquipment extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Remove Equipment and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingLocation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingLocation.java
@@ -80,7 +80,7 @@ public class ResetStatusAfterRemovingLocation extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
         
         // Remove location and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingAttendee.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingAttendee.java
@@ -81,7 +81,7 @@ public class ResetStatusAfterUpdatingAttendee extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());   
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());   
         
         // Remove one attendee, add another and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingEquipment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingEquipment.java
@@ -80,7 +80,7 @@ public class ResetStatusAfterUpdatingEquipment extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Update Equipment and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingLocation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingLocation.java
@@ -83,7 +83,7 @@ public class ResetStatusAfterUpdatingLocation extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Remove location1, add location2 and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/ViewInviteWithSchedulePolicyofEquipment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/ViewInviteWithSchedulePolicyofEquipment.java
@@ -83,7 +83,7 @@ public class ViewInviteWithSchedulePolicyofEquipment extends CalendarWorkWeekTes
 		ZAssert.assertStringContains(display.zGetMailProperty(Field.Body), apptContent, "Verify the text content");
 		
 		// Verify the attendee and organizer header		
-		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZWC().EmailAddress + "')";		
+		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZCS().EmailAddress + "')";		
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(organizer), "Organizer is present");
 
 	//	String attendee = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.Account3().EmailAddress + "')";		
@@ -161,7 +161,7 @@ public class ViewInviteWithSchedulePolicyofEquipment extends CalendarWorkWeekTes
 		ZAssert.assertStringContains(display.zGetMailProperty(Field.Body), apptContent, "Verify the text content");
 		
 		// Verify the attendee and organizer header		
-		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZWC().EmailAddress + "')";		
+		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZCS().EmailAddress + "')";		
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(organizer), "Organizer is present");
 
 	//	String attendee = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.Account3().EmailAddress + "')";		
@@ -218,7 +218,7 @@ public class ViewInviteWithSchedulePolicyofEquipment extends CalendarWorkWeekTes
 		ZAssert.assertStringContains(display.zGetMailProperty(Field.Body), apptContent, "Verify the text content");
 		
 		// Verify the attendee and organizer header		
-		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZWC().EmailAddress + "')";		
+		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZCS().EmailAddress + "')";		
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(organizer), "Organizer is present");
 
 		//String attendee = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.Account3().EmailAddress + "')";		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/ViewInviteWithSchedulePolicyofLocation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/ViewInviteWithSchedulePolicyofLocation.java
@@ -89,7 +89,7 @@ public class ViewInviteWithSchedulePolicyofLocation extends CalendarWorkWeekTest
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(locationLocator), "Location header present");
 		
 		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']";
-		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZWC().EmailAddress, "Verify the From matches the 'Sender:' header");
+		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZCS().EmailAddress, "Verify the From matches the 'Sender:' header");
 
 		//Accept the invite
 		display.zPressButton(Button.B_ACCEPT);
@@ -168,7 +168,7 @@ public class ViewInviteWithSchedulePolicyofLocation extends CalendarWorkWeekTest
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(locationLocator), "Location header present");
 		
 		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']";
-		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZWC().EmailAddress, "Verify the From matches the 'Sender:' header");
+		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZCS().EmailAddress, "Verify the From matches the 'Sender:' header");
 
 	}
 
@@ -225,7 +225,7 @@ public class ViewInviteWithSchedulePolicyofLocation extends CalendarWorkWeekTest
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(locationLocator), "Location header present");
 		
 		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']";
-		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZWC().EmailAddress, "Verify the From matches the 'Sender:' header");
+		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZCS().EmailAddress, "Verify the From matches the 'Sender:' header");
 		
 		display.zPressButton(Button.B_ACCEPT);
 		SleepUtil.sleepMedium();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/ContactContextMenu.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/ContactContextMenu.java
@@ -178,7 +178,7 @@ public class ContactContextMenu extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		String lastName = "lastname " + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountB to the ZWC user
+		// Send the message from AccountB to the ZCS user
 		ZimbraAccount.AccountB()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
@@ -218,7 +218,7 @@ public class ContactContextMenu extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		String lastName = "lastname " + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/TagContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/TagContact.java
@@ -37,7 +37,7 @@ public class TagContact extends ContactsPrefShowSelectionCheckbox {
 	@BeforeClass(groups = { "always" })
 	public void TagContactBeforeClass() throws HarnessException {
 		logger.info("TagContactBeforeClass: start");
-		ZimbraAccount.ResetAccountZWC();
+		ZimbraAccount.ResetAccountZCS();
 		logger.info("TagContactBeforeClass: finish");
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToCalendar.java
@@ -187,7 +187,7 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 	public void AddToCalendar_NewWindow_03() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// -- Data Setup
 		String subject = "new window invite ics attachment";
@@ -199,7 +199,7 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email08/mime06.txt";
 		
 		// Inject the message
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mimeFile));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mimeFile));
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 		SleepUtil.sleepMedium();
 
@@ -239,7 +239,7 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 			}
 			
 			// Make sure the folder was created on the server
-			FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(),foldername);
+			FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(),foldername);
 			dialog.zChooseCalendarFolder(folder.getId());
 			dialog.zClickButton(Button.B_OK);
 			SleepUtil.sleepLong(); //sometime client takes longer time to add the appointment
@@ -254,13 +254,13 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 			+		"<query>"+ "in:" + foldername + " " + apptSubject +"</query>"
 			+	"</SearchRequest>");
 		
-		String organizerInvId = ZimbraAccount.AccountZWC().soapSelectValue("//mail:appt", "invId");
+		String organizerInvId = ZimbraAccount.AccountZCS().soapSelectValue("//mail:appt", "invId");
 		
 		// Get the appointment details
 		app.zGetActiveAccount().soapSend(
 					"<GetAppointmentRequest xmlns='urn:zimbraMail' id='"+ organizerInvId +"'/>");
 		
-		String apptName = ZimbraAccount.AccountZWC().soapSelectValue("//mail:comp", "name");
+		String apptName = ZimbraAccount.AccountZCS().soapSelectValue("//mail:comp", "name");
 		ZAssert.assertEquals(apptName, apptSubject, "Verify correct appointment returned'");
 	
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/ReplyingMessageDoesntCreateDraft.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/ReplyingMessageDoesntCreateDraft.java
@@ -45,7 +45,7 @@ public class ReplyingMessageDoesntCreateDraft extends PrefGroupMailByMessageTest
 		String subject = "subject13690880312762";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug67686";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		//-- GUI
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/conversations/CheckFromHeaderInConversationView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/conversations/CheckFromHeaderInConversationView.java
@@ -60,7 +60,7 @@ public class CheckFromHeaderInConversationView extends AjaxCommonTest {
 		String to = "ljk20k00k1je";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug16213";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Click on folder in the tree
 		FolderItem inbox = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Inbox);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmMailApp.java
@@ -49,8 +49,8 @@ public class ZmMailApp extends AjaxCommonTest {
 	public void ZmMailApp_01() throws HarnessException {
 		
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, conversation view, initial load");
 
@@ -70,11 +70,11 @@ public class ZmMailApp extends AjaxCommonTest {
 	public void ZmMailApp_02() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mime));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, conversation view, 1 conversations");
 
@@ -94,11 +94,11 @@ public class ZmMailApp extends AjaxCommonTest {
 	public void ZmMailApp_03() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mime));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, conversation view, 100 conversations");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/feeds/CheckFeedGeneratedMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/feeds/CheckFeedGeneratedMessage.java
@@ -44,7 +44,7 @@ public class CheckFeedGeneratedMessage extends PrefGroupMailByMessageTest {
 		String bodytext = "Barbara's suggestion:";
 	
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug52121";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 				
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/CheckExpandCollaseFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/CheckExpandCollaseFolders.java
@@ -40,8 +40,8 @@ public class CheckExpandCollaseFolders extends PrefGroupMailByMessageTest {
 		logger.info("bug57468AfterClass: start");
 		
 		// Since we collapsed the folder tree, it may cause problems for other tests
-		// Rest the ZWC user
-		ZimbraAccount.ResetAccountZWC();
+		// Rest the ZCS user
+		ZimbraAccount.ResetAccountZCS();
 		
 		logger.info("bug57468AfterClass: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/gui/features/ZimbraFeatureMailEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/gui/features/ZimbraFeatureMailEnabled.java
@@ -53,7 +53,7 @@ public class ZimbraFeatureMailEnabled extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckAcceptDeclineButtonsForInvite.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckAcceptDeclineButtonsForInvite.java
@@ -45,7 +45,7 @@ public class CheckAcceptDeclineButtonsForInvite extends PrefGroupMailByMessageTe
 		String subject = "all-hands";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21013";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckMailContentForSpecificMimes.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckMailContentForSpecificMimes.java
@@ -44,7 +44,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String bodyAfterImage = "Problemet best\u00E5r";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug13911";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 		
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -69,7 +69,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String endingContent = "Esta mensagem";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21415";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 		
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -96,7 +96,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String endingContent = "SkinResources.java";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21415";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -121,7 +121,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String subject = "subject13001430504373";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug25624";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -141,7 +141,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String subject = "subject13001430504374";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug27796";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		
 		// Refresh current view
@@ -164,7 +164,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String subject = "subject13002239738283";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug31535";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -186,7 +186,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String bodytext = "Kind regards,";
 	
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug66192";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 				
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/GetMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/GetMail.java
@@ -80,7 +80,7 @@ public class GetMail extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/MessageDisplayShowsFromAsUnknown.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/MessageDisplayShowsFromAsUnknown.java
@@ -57,7 +57,7 @@ public class MessageDisplayShowsFromAsUnknown extends AjaxCommonTest {
 		String from = "Unknown";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug16213";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/OpenMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/OpenMail.java
@@ -39,7 +39,7 @@ public class OpenMail extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/PriorityMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/PriorityMail.java
@@ -40,7 +40,7 @@ public class PriorityMail extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m f='!'>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newtab/OpenInTabMailFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newtab/OpenInTabMailFolder.java
@@ -48,7 +48,7 @@ public class OpenInTabMailFolder extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 				"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailApp.java
@@ -49,8 +49,8 @@ public class ZmMailApp extends AjaxCommonTest {
 	public void ZmMailApp_01() throws HarnessException {
 		
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, message view, initial load");
 
@@ -70,11 +70,11 @@ public class ZmMailApp extends AjaxCommonTest {
 	public void ZmMailApp_02() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mime));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, message view, 1 message");
 
@@ -94,11 +94,11 @@ public class ZmMailApp extends AjaxCommonTest {
 	public void ZmMailApp_03() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mime));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, message view, 100 messages");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailAppFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailAppFolders.java
@@ -53,16 +53,16 @@ public class ZmMailAppFolders extends AjaxCommonTest {
 	public void ZmMailAppFolder_01() throws HarnessException {
 
 		// Create a folder
-		FolderItem root = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), FolderItem.SystemFolder.UserRoot);
-		ZimbraAccount.AccountZWC().soapSend(
+		FolderItem root = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), FolderItem.SystemFolder.UserRoot);
+		ZimbraAccount.AccountZCS().soapSend(
 				"<CreateFolderRequest xmlns='urn:zimbraMail'>" +
 	                	"<folder name='folder"+ ConfigProperties.getUniqueString() + "' view='message' l='"+ root.getId() +"'/>" +
 	                "</CreateFolderRequest>");
 
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailAppOverviewPanel, "Load the mail app, message view, 1 folder");
 
@@ -82,9 +82,9 @@ public class ZmMailAppFolders extends AjaxCommonTest {
 	public void ZmMailAppFolder_02() throws HarnessException {
 
 		// Create 100 folders
-		FolderItem root = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), FolderItem.SystemFolder.UserRoot);
+		FolderItem root = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), FolderItem.SystemFolder.UserRoot);
 		for (int i = 0; i < 100; i++) {
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>" +
 							"<folder name='folder"+ ConfigProperties.getUniqueString() + "' view='message' l='"+ root.getId() +"'/>" +
 					"</CreateFolderRequest>");
@@ -92,8 +92,8 @@ public class ZmMailAppFolders extends AjaxCommonTest {
 
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailAppOverviewPanel, "Load the mail app, message view, 100 folders");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/readingpane/VerifyReadingPaneOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/readingpane/VerifyReadingPaneOptions.java
@@ -56,7 +56,7 @@ public class VerifyReadingPaneOptions extends PrefGroupMailByConversationTest {
 		String subject = "subject"+ ConfigProperties.getUniqueString();
 		
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 						"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
 						"<e t='t' a='"+ app.zGetActiveAccount().EmailAddress +"'/>" +
@@ -68,7 +68,7 @@ public class VerifyReadingPaneOptions extends PrefGroupMailByConversationTest {
 						"</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(),"in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(),"in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/readreceipt/SendReadReceiptsAlways.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/readreceipt/SendReadReceiptsAlways.java
@@ -49,7 +49,7 @@ public class SendReadReceiptsAlways extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		sender.soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>"
 				+		"<m>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/readreceipt/SendReadReceiptsNever.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/readreceipt/SendReadReceiptsNever.java
@@ -48,7 +48,7 @@ public class SendReadReceiptsNever extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		sender.soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>"
 				+		"<m>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/readreceipt/SendReadReceiptsPrompt.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/readreceipt/SendReadReceiptsPrompt.java
@@ -48,7 +48,7 @@ public class SendReadReceiptsPrompt extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		sender.soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>"
 				+		"<m>"
@@ -100,7 +100,7 @@ public class SendReadReceiptsPrompt extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		sender.soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>"
 				+		"<m>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/external/register/BasicRegistration.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/external/register/BasicRegistration.java
@@ -42,18 +42,18 @@ public class BasicRegistration extends AjaxCommonTest {
 			ZimbraExternalAccount external = new ZimbraExternalAccount();
 			external.setEmailAddress("external" + ConfigProperties.getUniqueString() + "@example.com");
 			
-			FolderItem inbox = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), FolderItem.SystemFolder.Inbox);
+			FolderItem inbox = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), FolderItem.SystemFolder.Inbox);
 			String foldername = "folder" + ConfigProperties.getUniqueString();
 	
 			// Create a subfolder in Inbox
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 					+		"<folder name='" + foldername +"' l='" + inbox.getId() +"' view='message'/>"
 					+	"</CreateFolderRequest>");
-			String folderid = ZimbraAccount.AccountZWC().soapSelectValue("//mail:folder", "id");
+			String folderid = ZimbraAccount.AccountZCS().soapSelectValue("//mail:folder", "id");
 	
 			// Share the subfolder
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<FolderActionRequest xmlns='urn:zimbraMail'>"
 					+		"<action id='"+ folderid +"' op='grant'>"
 					+			"<grant d='"+ external.EmailAddress +"' inh='1' gt='guest' pw='' perm='r'/>"
@@ -61,7 +61,7 @@ public class BasicRegistration extends AjaxCommonTest {
 					+	"</FolderActionRequest>");
 	
 			// Send the notification
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<SendShareNotificationRequest xmlns='urn:zimbraMail'>"
 					+		"<item id='"+ folderid +"'/>"
 					+		"<e a='"+ external.EmailAddress +"'/>"
@@ -70,19 +70,19 @@ public class BasicRegistration extends AjaxCommonTest {
 	
 	
 			// Parse the URL From the sent message
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 					+		"<query>in:sent "+ external.EmailAddress +"</query>"
 					+	"</SearchRequest>");
-			String messageid = ZimbraAccount.AccountZWC().soapSelectValue("//mail:m", "id");
+			String messageid = ZimbraAccount.AccountZCS().soapSelectValue("//mail:m", "id");
 			
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<GetMsgRequest xmlns='urn:zimbraMail'>"
 					+		"<m id='"+ messageid +"' html='1'/>"
 					+	"</GetMsgRequest>");
 			
 			// Based on the content of the sent message, the URL's can be determined
-			Element response = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+			Element response = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 			external.setURL(response);
 			
 			

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/BasicLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/BasicLogin.java
@@ -36,7 +36,7 @@ public class BasicLogin extends AjaxCommonTest {
 	public void BasicLogin01() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Login.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Login.java
@@ -36,7 +36,7 @@ public class Login extends AjaxCommonTest {
 	public void Login01() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");
@@ -69,7 +69,7 @@ public class Login extends AjaxCommonTest {
 		ZimbraAccount.AccountA().soapSend(
 					"<FolderActionRequest xmlns='urn:zimbraMail'>"
 				+		"<action id='"+ folder.getId() +"' op='grant'>"
-				+			"<grant d='"+ ZimbraAccount.AccountZWC().EmailAddress +"' gt='usr' perm='r'/>"
+				+			"<grant d='"+ ZimbraAccount.AccountZCS().EmailAddress +"' gt='usr' perm='r'/>"
 				+		"</action>"
 				+	"</FolderActionRequest>");
 		
@@ -102,16 +102,16 @@ public class Login extends AjaxCommonTest {
 					+	"</MsgActionRequest>");
 		
 		// Mount it
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateMountpointRequest xmlns='urn:zimbraMail'>"
 				+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 				+	"</CreateMountpointRequest>");
 		
-		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(ZimbraAccount.AccountZWC(), mountpointname);
+		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(ZimbraAccount.AccountZCS(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify active account's mountpoint is created");
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");
@@ -151,7 +151,7 @@ public class Login extends AjaxCommonTest {
 		account.soapSend(
 					"<FolderActionRequest xmlns='urn:zimbraMail'>"
 				+		"<action id='"+ folder.getId() +"' op='grant'>"
-				+			"<grant d='"+ ZimbraAccount.AccountZWC().EmailAddress +"' gt='usr' perm='r'/>"
+				+			"<grant d='"+ ZimbraAccount.AccountZCS().EmailAddress +"' gt='usr' perm='r'/>"
 				+		"</action>"
 				+	"</FolderActionRequest>");
 		
@@ -178,12 +178,12 @@ public class Login extends AjaxCommonTest {
 
 		
 		// Mount it
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateMountpointRequest xmlns='urn:zimbraMail'>"
 				+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ account.ZimbraId +"'/>"
 				+	"</CreateMountpointRequest>");
 		
-		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(ZimbraAccount.AccountZWC(), mountpointname);
+		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(ZimbraAccount.AccountZCS(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify active account's mountpoint is created");
 		
 		// Delete other account
@@ -194,7 +194,7 @@ public class Login extends AjaxCommonTest {
 		
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");
@@ -249,7 +249,7 @@ public class Login extends AjaxCommonTest {
 			app.zPageLogin.sOpen(ConfigProperties.getBaseURL());
 			
 			// Login
-			app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());		
+			app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());		
 			
 			// Verify main page becomes active
 			ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
@@ -66,7 +66,7 @@ public class LoginWithCsrfTokenCheckDisabled extends AjaxCommonTest {
 			}
 
 			// Login
-			app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+			app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 			// Verify main page becomes active
 			ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/performance/ZmMailApp.java
@@ -44,8 +44,8 @@ public class ZmMailApp extends AjaxCommonTest {
 		
 		app.zPageLogin.zNavigateTo();
 
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Login to the ajax client (mail app)");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/attributes/ZimbraFeatureMailForwardingEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/attributes/ZimbraFeatureMailForwardingEnabled.java
@@ -47,7 +47,7 @@ public class ZimbraFeatureMailForwardingEnabled extends AjaxCommonTest {
 			groups = { "functional", "L2" })
 	public void zimbraFeatureMailForwardingEnabled_01() throws HarnessException {
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		// Go to preferences - mail
 		app.zPagePreferences.zNavigateTo();
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.Mail);
@@ -68,7 +68,7 @@ public class ZimbraFeatureMailForwardingEnabled extends AjaxCommonTest {
 			groups = { "functional", "L2" })
 	public void zimbraFeatureMailForwardingEnabled_02() throws HarnessException {
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		// Go to preferences - mail
 		app.zPagePreferences.zNavigateTo();
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.Mail);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/attributes/ZimbraFeaturePortalEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/attributes/ZimbraFeaturePortalEnabled.java
@@ -50,7 +50,7 @@ public class ZimbraFeaturePortalEnabled extends AjaxCommonTest {
 	public void BasicLogin01() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse.java
@@ -41,8 +41,8 @@ public class ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse extends A
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -75,7 +75,7 @@ public class ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse extends A
 
 		// Create the message data to be sent
 		MailItem mail = new MailItem();
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyText = "body" + ConfigProperties.getUniqueString();
 
@@ -92,14 +92,14 @@ public class ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse extends A
 		// Send the message
 		mailform.zSubmit();
 
-		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(),
+		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(),
 				"in:inbox subject:(" + mail.dSubject + ")");
 
 		// Verify TO, Subject, Body,Signature
 
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertEquals(received.dSubject, mail.dSubject, "Verify the subject field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ComposeHtmlMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ComposeHtmlMsgWithHtmlSignature.java
@@ -52,8 +52,8 @@ public class ComposeHtmlMsgWithHtmlSignature extends AjaxCommonTest {
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
 		System.out.println(this.sigName);
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTML + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -80,7 +80,7 @@ public class ComposeHtmlMsgWithHtmlSignature extends AjaxCommonTest {
 
 		// Create the message data to be sent
 		MailItem mail = new MailItem();
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyHtml = "bodybold" + ConfigProperties.getUniqueString() + "body";
 
@@ -97,19 +97,19 @@ public class ComposeHtmlMsgWithHtmlSignature extends AjaxCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
 
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' html='1'/>" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertEquals(received.dSubject, mail.dSubject, "Verify the subject field is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(),

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ComposeMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ComposeMsgWithTextSignature.java
@@ -47,8 +47,8 @@ public class ComposeMsgWithTextSignature extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -76,7 +76,7 @@ public class ComposeMsgWithTextSignature extends AjaxCommonTest {
 
 		// Create the message data to be sent
 		MailItem mail = new MailItem();
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyText = "body" + ConfigProperties.getUniqueString();
 
@@ -93,13 +93,13 @@ public class ComposeMsgWithTextSignature extends AjaxCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(),
+		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(),
 				"in:inbox subject:(" + mail.dSubject + ")");
 
 		// Verify TO, Subject, Body, Signature
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertEquals(received.dSubject, mail.dSubject, "Verify the subject field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/CreateTextSignatureAndAddInComposedHtmlMesage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/CreateTextSignatureAndAddInComposedHtmlMesage.java
@@ -40,8 +40,8 @@ public class CreateTextSignatureAndAddInComposedHtmlMesage extends AjaxCommonTes
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -69,7 +69,7 @@ public class CreateTextSignatureAndAddInComposedHtmlMesage extends AjaxCommonTes
 
 		// Create the message data to be sent
 		MailItem mail = new MailItem();
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyHtml = "body" + ConfigProperties.getUniqueString();
 
@@ -86,13 +86,13 @@ public class CreateTextSignatureAndAddInComposedHtmlMesage extends AjaxCommonTes
 		// Send the message
 		mailform.zSubmit();
 
-		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(),
+		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(),
 				"in:inbox subject:(" + mail.dSubject + ")");
 
 		// Verify TO, Subject, Body, Signature
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertEquals(received.dSubject, mail.dSubject, "Verify the subject field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyHtml, "Verify the body content is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/DeleteHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/DeleteHtmlSignature.java
@@ -54,8 +54,8 @@ public class DeleteHtmlSignature extends AjaxCommonTest {
 	@BeforeMethod(groups = { "always" })
 	public void CreateHtmlSignature() throws HarnessException {
 
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigHtmlName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTML + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/DeleteTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/DeleteTextSignature.java
@@ -48,8 +48,8 @@ public class DeleteTextSignature extends AjaxCommonTest {
 	 */
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/EditHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/EditHtmlSignature.java
@@ -50,8 +50,8 @@ public class EditHtmlSignature extends AjaxCommonTest {
 	 */
 	@BeforeMethod(groups = { "always" })
 	public void CreateHtmlSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "'>" + "<content type='text/html'>" + this.contentHTML + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/EditTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/EditTextSignature.java
@@ -47,8 +47,8 @@ public class EditTextSignature extends AjaxCommonTest {
 	 */
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "'>" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ForwardMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ForwardMsgWithHtmlSignature.java
@@ -53,8 +53,8 @@ public class ForwardMsgWithHtmlSignature extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -91,7 +91,7 @@ public class ForwardMsgWithHtmlSignature extends AjaxCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + signature.dBodyHtmlText + "</body>" + "</html>");
 
 		// Send a message to the account with html signature
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -99,7 +99,7 @@ public class ForwardMsgWithHtmlSignature extends AjaxCommonTest {
 						+ "\n</content>" + "</mp>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ForwardMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ForwardMsgWithTextSignature.java
@@ -50,8 +50,8 @@ public class ForwardMsgWithTextSignature extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -81,14 +81,14 @@ public class ForwardMsgWithTextSignature extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString() + "\n\n"
 						+ signature.dBodyText + "\n</content>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyHtmlSignatureAboveIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyHtmlSignatureAboveIncludeMsg.java
@@ -50,7 +50,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -84,7 +84,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends AjaxCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -134,7 +134,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends AjaxCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -185,7 +185,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends AjaxCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyHtmlSignatureBelowIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyHtmlSignatureBelowIncludeMsg.java
@@ -52,7 +52,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -88,7 +88,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends AjaxCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -137,7 +137,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends AjaxCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -188,7 +188,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends AjaxCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyTextSignatureAboveIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyTextSignatureAboveIncludeMsg.java
@@ -50,7 +50,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends AjaxCommonTest {
 	public void CreateSignature() throws HarnessException {
 		logger.info("CreateSignature: start");
 
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -81,7 +81,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()
@@ -128,7 +128,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()
@@ -174,7 +174,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyTextSignatureBelowIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyTextSignatureBelowIncludeMsg.java
@@ -49,7 +49,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -80,7 +80,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()
@@ -127,7 +127,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()
@@ -172,7 +172,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyAllMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyAllMsgWithHtmlSignature.java
@@ -45,8 +45,8 @@ public class ReplyAllMsgWithHtmlSignature extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -83,7 +83,7 @@ public class ReplyAllMsgWithHtmlSignature extends AjaxCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + signature.dBodyHtmlText + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -91,7 +91,7 @@ public class ReplyAllMsgWithHtmlSignature extends AjaxCommonTest {
 						+ "\n</content>" + "</mp>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -107,21 +107,21 @@ public class ReplyAllMsgWithHtmlSignature extends AjaxCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
 
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' html='1'/>" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Reply'ed Subject, HtmlBody,HtmlSignature
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Re' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(), bodyHTML, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(), this.sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyAllMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyAllMsgWithTextSignature.java
@@ -50,8 +50,8 @@ public class ReplyAllMsgWithTextSignature extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -82,14 +82,14 @@ public class ReplyAllMsgWithTextSignature extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString() + "\n\n"
 						+ signature.dBodyText + "\n</content>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -105,20 +105,20 @@ public class ReplyAllMsgWithTextSignature extends AjaxCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
-		ZimbraAccount.AccountZWC()
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		ZimbraAccount.AccountZCS()
 				.soapSend("<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' />" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Subject, Text Body,Text Signature for replied msg
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Fwd' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyText, this.sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithHtmlSignature.java
@@ -45,8 +45,8 @@ public class ReplyMsgWithHtmlSignature extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -82,7 +82,7 @@ public class ReplyMsgWithHtmlSignature extends AjaxCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + signature.dBodyHtmlText + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -90,7 +90,7 @@ public class ReplyMsgWithHtmlSignature extends AjaxCommonTest {
 						+ "\n</content>" + "</mp>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -106,21 +106,21 @@ public class ReplyMsgWithHtmlSignature extends AjaxCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
 
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' html='1'/>" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Reply'ed Subject, HtmlBody,HtmlSignature
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Re' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(), bodyHTML, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(), this.sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithTextSignature.java
@@ -50,8 +50,8 @@ public class ReplyMsgWithTextSignature extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -81,14 +81,14 @@ public class ReplyMsgWithTextSignature extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString() + "\n\n"
 						+ signature.dBodyText + "\n</content>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -104,20 +104,20 @@ public class ReplyMsgWithTextSignature extends AjaxCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
-		ZimbraAccount.AccountZWC()
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		ZimbraAccount.AccountZCS()
 				.soapSend("<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' />" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Subject, Text Body,Text Signature for replied msg
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Fwd' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyText, this.sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithTwoThreeLineTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithTwoThreeLineTextSignature.java
@@ -73,7 +73,7 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends AjaxCommonTest {
 						+ "<content type='text/plain'>" + sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
 
-		String SignatureId = ZimbraAccount.AccountZWC().soapSelectValue("//acct:CreateSignatureResponse/acct:signature",
+		String SignatureId = ZimbraAccount.AccountZCS().soapSelectValue("//acct:CreateSignatureResponse/acct:signature",
 				"id");
 
 		app.zGetActiveAccount()
@@ -81,13 +81,13 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends AjaxCommonTest {
 						+ "<content type='text/plain'>" + sigBody1 + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
 
-		String SignatureId1 = ZimbraAccount.AccountZWC()
+		String SignatureId1 = ZimbraAccount.AccountZCS()
 				.soapSelectValue("//acct:CreateSignatureResponse/acct:signature", "id");
 
 		app.zGetActiveAccount()
 				.soapSend("<GetIdentitiesRequest xmlns='urn:zimbraAccount'>" + "</GetIdentitiesRequest>");
 
-		String IdentityId = ZimbraAccount.AccountZWC().soapSelectValue("//acct:GetIdentitiesResponse/acct:identity",
+		String IdentityId = ZimbraAccount.AccountZCS().soapSelectValue("//acct:GetIdentitiesResponse/acct:identity",
 				"id");
 
 		app.zGetActiveAccount()
@@ -107,14 +107,14 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString() + "\n\n"
 						+ signature.dBodyText + "\n</content>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -136,20 +136,20 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends AjaxCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
-		ZimbraAccount.AccountZWC()
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		ZimbraAccount.AccountZCS()
 				.soapSend("<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' />" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Subject, Text Body,Text Signature for replied msg
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Fwd' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyText, sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyToMsgWithSignatureContainingImage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyToMsgWithSignatureContainingImage.java
@@ -47,7 +47,7 @@ public class ReplyToMsgWithSignatureContainingImage extends AjaxCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount account = ZimbraAccount.AccountZWC();
+		ZimbraAccount account = ZimbraAccount.AccountZCS();
 		account.authenticate();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/SignatureVcard.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/SignatureVcard.java
@@ -99,7 +99,7 @@ public class SignatureVcard extends AjaxCommonTest {
 		MailItem mail = new MailItem();
 
 		FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyHtml = "body" + ConfigProperties.getUniqueString();
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/toaster/DeleteSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/toaster/DeleteSignature.java
@@ -49,8 +49,8 @@ public class DeleteSignature extends AjaxCommonTest {
 	 */
 	@BeforeClass(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/toaster/EditSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/toaster/EditSignature.java
@@ -52,8 +52,8 @@ public class EditSignature extends AjaxCommonTest {
 	 */
 	@BeforeClass(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainConvView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainConvView.java
@@ -71,7 +71,7 @@ public class TrustedDomainConvView extends AjaxCommonTest {
 				+ "/data/public/mime/ExternalImg.txt";
 		FolderItem inboxFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(),SystemFolder.Inbox);
 		//Verify domain through soap- GetPrefsRequest
-		String PrefMailTrustedAddr = ZimbraAccount.AccountZWC().getPreference(
+		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference(
 				"zimbraPrefMailTrustedSenderList");
 		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdoamin.com"),
 				"Verify doamin is present /Pref/TrustedAddr");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainMsgView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainMsgView.java
@@ -67,7 +67,7 @@ public class TrustedDomainMsgView extends AjaxCommonTest {
 				+ "/data/public/mime/ExternalImg.txt";
 
 		//Verify domain through soap- GetPrefsRequest
-		String PrefMailTrustedAddr = ZimbraAccount.AccountZWC().getPreference(
+		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference(
 				"zimbraPrefMailTrustedSenderList");
 		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdoamin.com"),
 				"Verify doamin is present /Pref/TrustedAddr");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedEmailAddrMsgView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedEmailAddrMsgView.java
@@ -66,7 +66,7 @@ public class TrustedEmailAddrMsgView extends AjaxCommonTest {
 		+ "/data/public/mime/ExternalImg.txt";
 
 		// Verify Email id through soap GetPrefsRequest
-		String PrefMailTrustedAddr = ZimbraAccount.AccountZWC().getPreference(
+		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference(
 				"zimbraPrefMailTrustedSenderList");
 		ZAssert.assertTrue(PrefMailTrustedAddr
 				.equals("admintest@testdoamin.com"),

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/search/search/SearchMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/search/search/SearchMail.java
@@ -55,7 +55,7 @@ public class SearchMail extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/date/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/date/GetMessage.java
@@ -54,7 +54,7 @@ public class GetMessage extends AjaxCommonTest {
 		String date = "12/25/2014";
 		String body = "text " + date + " text";
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -92,7 +92,7 @@ public class GetMessage extends AjaxCommonTest {
 		String date2 = "1/1/2015";
 		String body = "date1: " + date1 + " date2: "+ date2;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -196,7 +196,7 @@ public class GetMessage extends AjaxCommonTest {
 		String date = "12/25/2016";
 		String subject = "subject " + date;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 			"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 				"<m>" +
@@ -271,7 +271,7 @@ format7.rule = now week={weekord},{dayname}
 		}
 		String subject = "subject " + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/date/HoverOverDate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/date/HoverOverDate.java
@@ -90,7 +90,7 @@ public class HoverOverDate extends PrefGroupMailByMessageTest {
 		}
 		String subject = "subject " + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/phone/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/phone/GetMessage.java
@@ -53,7 +53,7 @@ public class GetMessage extends AjaxCommonTest {
 		String phonenumber = "1-877-486-9273";
 		String body = "text " + System.getProperty("line.separator") + phonenumber + System.getProperty("line.separator") + "text"+ ConfigProperties.getUniqueString() + System.getProperty("line.separator") ;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -95,7 +95,7 @@ public class GetMessage extends AjaxCommonTest {
 		String phonenumber2 = "1-877-555-9273";
 		String body = "phone1: " + phonenumber1 + " phone2: "+ phonenumber2;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -240,7 +240,7 @@ public class GetMessage extends AjaxCommonTest {
 		String phonenumber = "1-877-486-9273";
 		String subject = "subject " + phonenumber;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -280,7 +280,7 @@ public class GetMessage extends AjaxCommonTest {
 		String phonenumber = "16504755345";
 		String body = "text " + System.getProperty("line.separator") + phonenumber + System.getProperty("line.separator") + "text"+ ConfigProperties.getUniqueString() + System.getProperty("line.separator") ;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/srchhighlighter/ViewMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/srchhighlighter/ViewMessage.java
@@ -52,7 +52,7 @@ import com.zimbra.qa.selenium.projects.ajax.ui.search.*;
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		String term = "search" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/GetMessage.java
@@ -52,7 +52,7 @@ public class GetMessage extends AjaxCommonTest {
 		String url = "http://www.zimbra.com";
 		String body = "text " + System.getProperty("line.separator") + url + System.getProperty("line.separator") + "text"+ ConfigProperties.getUniqueString() + System.getProperty("line.separator") ;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -94,7 +94,7 @@ public class GetMessage extends AjaxCommonTest {
 		String url2 = "http://www.google.com";
 		String body = "url1: " + url1 + " url2: "+ url2;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -204,7 +204,7 @@ public class GetMessage extends AjaxCommonTest {
 		String url = "http://www.zimbra.com";
 		String subject = "subject " + url;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -245,7 +245,7 @@ public class GetMessage extends AjaxCommonTest {
 		String body = "text &lt;" + url + "&gt; text "+ ConfigProperties.getUniqueString();
 				
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/HoverOverURL.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/HoverOverURL.java
@@ -51,7 +51,7 @@ public class HoverOverURL extends AjaxCommonTest {
 		String server = "synacor";
 		String body = "http://www." + server + ".com";
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -90,7 +90,7 @@ public class HoverOverURL extends AjaxCommonTest {
 		String server = "synacor";
 		String body = "http://www." + server + ".com";
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/ymemoticons/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/ymemoticons/GetMessage.java
@@ -55,7 +55,7 @@ public class GetMessage extends AjaxCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		String body = "text " + Emoticons.HAPPY + " text";
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 			"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 				"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/html/core/HtmlCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/html/core/HtmlCommonTest.java
@@ -142,13 +142,13 @@ public class HtmlCommonTest {
 			}
 			ZimbraAdminAccount.GlobalAdmin().soapSend(
 					"<ModifyAccountRequest xmlns='urn:zimbraAdmin'>"
-					+		"<id>"+ ZimbraAccount.AccountHTML().ZimbraId +"</id>"
+					+		"<id>"+ ZimbraAccount.AccountZCS().ZimbraId +"</id>"
 					+		settings.toString()
 					+	"</ModifyAccountRequest>");
 
 
 			// Set the flag so the account is reset for the next test
-			ZimbraAccount.AccountHTML().accountIsDirty = true;
+			ZimbraAccount.AccountZCS().accountIsDirty = true;
 		}
 
 		// If test account zimlet preferences are defined, then make sure the test account
@@ -156,21 +156,21 @@ public class HtmlCommonTest {
 		//
 		if ( (startingAccountZimletPreferences != null) && (!startingAccountZimletPreferences.isEmpty()) ) {
 			logger.debug("commonTestBeforeMethod: startingAccountPreferences are defined");
-			ZimbraAccount.AccountHTML().modifyUserZimletPreferences(startingAccountZimletPreferences);
+			ZimbraAccount.AccountZCS().modifyUserZimletPreferences(startingAccountZimletPreferences);
 		}
 
-		// If AccountHTML is not currently logged in, then login now
-		if ( !ZimbraAccount.AccountHTML().equals(app.zGetActiveAccount()) ) {
-			logger.debug("commonTestBeforeMethod: AccountHTML is not currently logged in");
+		// If AccountZCS is not currently logged in, then login now
+		if ( !ZimbraAccount.AccountZCS().equals(app.zGetActiveAccount()) ) {
+			logger.debug("commonTestBeforeMethod: AccountZCS is not currently logged in");
 
 			if ( app.zPageMain.zIsActive() )
 				app.zPageMain.zLogout();
 
-			app.zPageLogin.zLogin(ZimbraAccount.AccountHTML());
+			app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 			// Confirm
-			if ( !ZimbraAccount.AccountHTML().equals(app.zGetActiveAccount())) {
-				throw new HarnessException("Unable to authenticate as "+ ZimbraAccount.AccountHTML().EmailAddress);
+			if ( !ZimbraAccount.AccountZCS().equals(app.zGetActiveAccount())) {
+				throw new HarnessException("Unable to authenticate as "+ ZimbraAccount.AccountZCS().EmailAddress);
 			}
 
 		}
@@ -211,9 +211,9 @@ public class HtmlCommonTest {
 		ZimbraAccount currentAccount = app.zGetActiveAccount();
 		if (currentAccount != null 
 				&& currentAccount.accountIsDirty 
-				&& currentAccount == ZimbraAccount.AccountHTML()) {
+				&& currentAccount == ZimbraAccount.AccountZCS()) {
 
-			ZimbraAccount.ResetAccountHTML();
+			ZimbraAccount.ResetAccountZCS();
 
 		}
 

--- a/src/java/com/zimbra/qa/selenium/projects/html/tests/login/BasicLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/html/tests/login/BasicLogin.java
@@ -39,7 +39,7 @@ public class BasicLogin extends HtmlCommonTest {
 	public void BasicLogin01() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountHTML());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/html/tests/mail/mail/GetMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/html/tests/mail/mail/GetMail.java
@@ -56,7 +56,7 @@ public class GetMail extends HtmlCommonTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/html/ui/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/html/ui/PageMain.java
@@ -109,7 +109,7 @@ public class PageMain extends AbsTab {
 		if ( !((AppHtmlClient)MyApplication).zPageLogin.zIsActive() ) {
 			((AppHtmlClient)MyApplication).zPageLogin.zNavigateTo();
 		}
-		((AppHtmlClient)MyApplication).zPageLogin.zLogin(ZimbraAccount.AccountHTML());
+		((AppHtmlClient)MyApplication).zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		zWaitForActive();
 		
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/mobile/core/MobileCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/mobile/core/MobileCommonTest.java
@@ -59,7 +59,7 @@ public class MobileCommonTest {
 		app = new AppMobileClient();
 		
 		startingPage = app.zPageMain;
-		startingAccount = ZimbraAccount.AccountZMC();
+		startingAccount = ZimbraAccount.AccountZCS();
 		
 		app.zPageLogin.DefaultLoginAccount = startingAccount;
 		
@@ -79,7 +79,7 @@ public class MobileCommonTest {
 
 
       	// Make sure there is a new default account
-		ZimbraAccount.ResetAccountZMC();
+		ZimbraAccount.ResetAccountZCS();
 				
 		// Set the app type
 		ConfigProperties.setAppType(ConfigProperties.AppType.MOBILE);

--- a/src/java/com/zimbra/qa/selenium/projects/mobile/tests/login/BasicLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/mobile/tests/login/BasicLogin.java
@@ -40,7 +40,7 @@ public class BasicLogin extends MobileCommonTest {
 	public void BasicLogin01() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZMC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/touch/core/TouchCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/core/TouchCommonTest.java
@@ -65,7 +65,7 @@ public class TouchCommonTest {
 	public void commonTestBeforeSuite()
 	throws HarnessException, IOException, InterruptedException, SAXException {
 		logger.info("commonTestBeforeSuite: start");
-		ZimbraAccount.ResetAccountZTC();
+		ZimbraAccount.ResetAccountZCS();
 
 		try
 		{
@@ -169,25 +169,25 @@ public class TouchCommonTest {
 			logger.debug("commonTestBeforeMethod: startingAccountPreferences are defined");
 
 			// If the current test accounts preferences match, then the account can be used
-			if ( !ZimbraAccount.AccountZTC().compareAccountPreferences(startingAccountPreferences) ) {
+			if ( !ZimbraAccount.AccountZCS().compareAccountPreferences(startingAccountPreferences) ) {
 
 				logger.debug("commonTestBeforeMethod: startingAccountPreferences do not match active account");
 
 				// Reset the account
-				ZimbraAccount.ResetAccountZTC();
+				ZimbraAccount.ResetAccountZCS();
 
 				// Create a new account
 				// Set the preferences accordingly
-				ZimbraAccount.AccountZTC().modifyAccountPreferences(startingAccountPreferences);
-				ZimbraAccount.AccountZTC().modifyUserZimletPreferences(startingUserZimletPreferences);
+				ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
+				ZimbraAccount.AccountZCS().modifyUserZimletPreferences(startingUserZimletPreferences);
 
 			}
 
 		}
 
-		// If AccountZTC is not currently logged in, then login now
-		if ( !ZimbraAccount.AccountZTC().equals(app.zGetActiveAccount()) ) {
-			logger.debug("commonTestBeforeMethod: AccountZTC is not currently logged in");
+		// If AccountZCS is not currently logged in, then login now
+		if ( !ZimbraAccount.AccountZCS().equals(app.zGetActiveAccount()) ) {
+			logger.debug("commonTestBeforeMethod: AccountZCS is not currently logged in");
 
 			if ( app.zPageMain.zIsActive() )
 				try {
@@ -240,9 +240,9 @@ public class TouchCommonTest {
 		// preferences has to be reset to default, all core zimlets are enabled
 		ZimbraAccount currentAccount = app.zGetActiveAccount();
 		if (currentAccount != null && currentAccount.accountIsDirty &&
-				currentAccount == ZimbraAccount.AccountZTC()) {
+				currentAccount == ZimbraAccount.AccountZCS()) {
 			// Reset the account
-			ZimbraAccount.ResetAccountZTC();
+			ZimbraAccount.ResetAccountZCS();
 
 		}
 
@@ -300,7 +300,7 @@ public class TouchCommonTest {
 
        // Resetting the account to flush after each performance test method,
        // so that the next test is running with new account
-       ZimbraAccount.ResetAccountZTC();
+       ZimbraAccount.ResetAccountZCS();
 
     }
 

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/login/BasicLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/login/BasicLogin.java
@@ -39,7 +39,7 @@ public class BasicLogin extends TouchCommonTest {
 	public void BasicLogin01() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZTC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/folders/DeleteFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/folders/DeleteFolder.java
@@ -38,7 +38,7 @@ public class DeleteFolder extends PrefGroupMailByMessageTest {
 	
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mail/message/SwitchToConversationView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mail/message/SwitchToConversationView.java
@@ -38,7 +38,7 @@ public class SwitchToConversationView extends PrefGroupMailByMessageTest{
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 				"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mail/message/SwitchToMessageView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mail/message/SwitchToMessageView.java
@@ -38,7 +38,7 @@ public class SwitchToMessageView extends PrefGroupMailByConversationTest{
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 				"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/search/mail/conversation/DeleteMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/search/mail/conversation/DeleteMail.java
@@ -34,7 +34,7 @@ public class DeleteMail extends PrefGroupMailByConversationTest {
 	// Create the message data to be sent
 	String subject = "subject" + ConfigProperties.getUniqueString();
 	
-	// Send the message from AccountA to the ZWC user
+	// Send the message from AccountA to the ZCS user
 	ZimbraAccount.AccountA().soapSend(
 		"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 			"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/search/mail/message/DeleteMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/search/mail/message/DeleteMail.java
@@ -40,7 +40,7 @@ public class DeleteMail extends PrefGroupMailByMessageTest {
 	// Create the message data to be sent
 	String subject = "subject" + ConfigProperties.getUniqueString();
 	
-	// Send the message from AccountA to the ZWC user
+	// Send the message from AccountA to the ZCS user
 	ZimbraAccount.AccountA().soapSend(
 		"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 			"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/touch/ui/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/ui/PageMain.java
@@ -84,7 +84,7 @@ public class PageMain extends AbsTab {
 		if ( !((AppTouchClient)MyApplication).zPageLogin.zIsActive() ) {
 			((AppTouchClient)MyApplication).zPageLogin.zNavigateTo();
 		}
-		((AppTouchClient)MyApplication).zPageLogin.zLogin(ZimbraAccount.AccountZTC());
+		((AppTouchClient)MyApplication).zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		zWaitForActive(120000);
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalCommonTest.java
@@ -90,7 +90,7 @@ public class UniversalCommonTest {
 	public void commonTestBeforeSuite() throws HarnessException, IOException, InterruptedException, SAXException {
 
 		logger.info("BeforeSuite: start");
-		ZimbraAccount.ResetAccountZUC();
+		ZimbraAccount.ResetAccountZCS();
 
 		try {
 
@@ -168,17 +168,17 @@ public class UniversalCommonTest {
 
 			// If the current test accounts preferences match, then the account
 			// can be used
-			if (!ZimbraAccount.AccountZUC().compareAccountPreferences(startingAccountPreferences)) {
+			if (!ZimbraAccount.AccountZCS().compareAccountPreferences(startingAccountPreferences)) {
 
 				logger.info("BeforeMethod: startingAccountPreferences do not match active account");
 
 				// Reset the account
-				ZimbraAccount.ResetAccountZUC();
+				ZimbraAccount.ResetAccountZCS();
 
 				// Create a new account
 				// Set the preferences accordingly
-				ZimbraAccount.AccountZUC().modifyAccountPreferences(startingAccountPreferences);
-				ZimbraAccount.AccountZUC().modifyUserZimletPreferences(startingUserZimletPreferences);
+				ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
+				ZimbraAccount.AccountZCS().modifyUserZimletPreferences(startingUserZimletPreferences);
 			}
 
 		}
@@ -190,20 +190,20 @@ public class UniversalCommonTest {
 
 			// If the current test accounts preferences match, then the account
 			// can be used
-			if (!ZimbraAccount.AccountZUC().compareUserZimletPreferences(startingUserZimletPreferences)) {
+			if (!ZimbraAccount.AccountZCS().compareUserZimletPreferences(startingUserZimletPreferences)) {
 
 				logger.info("BeforeMethod: startingAccountZimletPreferences do not match active account");
-				ZimbraAccount.ResetAccountZUC();
-				ZimbraAccount.AccountZUC().modifyAccountPreferences(startingAccountPreferences);
-				ZimbraAccount.AccountZUC().modifyUserZimletPreferences(startingUserZimletPreferences);
+				ZimbraAccount.ResetAccountZCS();
+				ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
+				ZimbraAccount.AccountZCS().modifyUserZimletPreferences(startingUserZimletPreferences);
 			}
 
-			ZimbraAccount.AccountZUC().modifyUserZimletPreferences(startingUserZimletPreferences);
+			ZimbraAccount.AccountZCS().modifyUserZimletPreferences(startingUserZimletPreferences);
 		}
 
-		// If AccountZUC is not currently logged in, then login now
-		if (!ZimbraAccount.AccountZUC().equals(app.zGetActiveAccount())) {
-			logger.info("BeforeMethod: AccountZUC is not currently logged in");
+		// If AccountZCS is not currently logged in, then login now
+		if (!ZimbraAccount.AccountZCS().equals(app.zGetActiveAccount())) {
+			logger.info("BeforeMethod: AccountZCS is not currently logged in");
 
 			if (app.zPageMain.zIsActive())
 				try {
@@ -284,8 +284,8 @@ public class UniversalCommonTest {
 		logger.info("AfterClass: start");
 
 		ZimbraAccount currentAccount = app.zGetActiveAccount();
-		if (currentAccount != null && currentAccount.accountIsDirty && currentAccount == ZimbraAccount.AccountZUC()) {
-			ZimbraAccount.ResetAccountZUC();
+		if (currentAccount != null && currentAccount.accountIsDirty && currentAccount == ZimbraAccount.AccountZCS()) {
+			ZimbraAccount.ResetAccountZCS();
 		}
 
 		logger.info("AfterClass: finish");
@@ -468,7 +468,7 @@ public class UniversalCommonTest {
 
 	@AfterMethod(groups = { "performance" })
 	public void performanceTestAfterMethod() {
-		ZimbraAccount.ResetAccountZUC();
+		ZimbraAccount.ResetAccountZCS();
 	}
 
 	@DataProvider(name = "DataProviderSupportedCharsets")
@@ -632,7 +632,7 @@ public class UniversalCommonTest {
 
 	public void zFreshLogin() {
 
-		ZimbraAccount.ResetAccountZUC();
+		ZimbraAccount.ResetAccountZCS();
 
 		try {
 			ConfigProperties.setAppType(ConfigProperties.AppType.UNIVERSAL);
@@ -645,8 +645,8 @@ public class UniversalCommonTest {
 
 		try {
 			((AppUniversalClient) app).zPageLogin.sOpen(ConfigProperties.getLogoutURL());
-			if (ZimbraAccount.AccountZUC() != null) {
-				((AppUniversalClient) app).zPageLogin.zLogin(ZimbraAccount.AccountZUC());
+			if (ZimbraAccount.AccountZCS() != null) {
+				((AppUniversalClient) app).zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 			} else {
 				((AppUniversalClient) app).zPageLogin.zLogin(ZimbraAccount.Account10());
 			}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalQuickCommandTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalQuickCommandTest.java
@@ -69,22 +69,22 @@ public class UniversalQuickCommandTest extends UniversalCommonTest {
 		
 		// Create a tag
 		String tagname = "tag" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateTagRequest xmlns='urn:zimbraMail'>"
 				+		"<tag name='"+ tagname +"' color='1' />"
 				+	"</CreateTagRequest>");
 
-		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZWC(), tagname);
+		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZCS(), tagname);
 		ZAssert.assertNotNull(tag, "Verify the tag was created");
 
 		// Create a subfolder
 		String foldername = "folder" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 				+		"<folder name='"+ foldername +"' l='1' view='message'/>"
 				+	"</CreateFolderRequest>");
 
-		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), foldername);
+		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), foldername);
 		ZAssert.assertNotNull(folder, "Verify the subfolder is available");
 
 		// Create the list of actions
@@ -122,22 +122,22 @@ public class UniversalQuickCommandTest extends UniversalCommonTest {
 		
 		// Create a tag
 		String tagname = "tag" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateTagRequest xmlns='urn:zimbraMail'>"
 				+		"<tag name='"+ tagname +"' color='1' />"
 				+	"</CreateTagRequest>");
 
-		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZWC(), tagname);
+		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZCS(), tagname);
 		ZAssert.assertNotNull(tag, "Verify the tag was created");
 
 		// Create a subfolder
 		String foldername = "folder" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 				+		"<folder name='"+ foldername +"' l='1' view='contact'/>"
 				+	"</CreateFolderRequest>");
 
-		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), foldername);
+		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), foldername);
 		ZAssert.assertNotNull(folder, "Verify the subfolder is available");
 
 		// Create the list of actions
@@ -174,22 +174,22 @@ public class UniversalQuickCommandTest extends UniversalCommonTest {
 		
 		// Create a tag
 		String tagname = "tag" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateTagRequest xmlns='urn:zimbraMail'>"
 				+		"<tag name='"+ tagname +"' color='1' />"
 				+	"</CreateTagRequest>");
 
-		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZWC(), tagname);
+		TagItem tag = TagItem.importFromSOAP(ZimbraAccount.AccountZCS(), tagname);
 		ZAssert.assertNotNull(tag, "Verify the tag was created");
 
 		// Create a subfolder
 		String foldername = "folder" + ConfigProperties.getUniqueString();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 				+		"<folder name='"+ foldername +"' l='1' view='appointment'/>"
 				+	"</CreateFolderRequest>");
 
-		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), foldername);
+		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), foldername);
 		ZAssert.assertNotNull(folder, "Verify the subfolder is available");
 
 		// Create the list of actions
@@ -221,7 +221,7 @@ public class UniversalQuickCommandTest extends UniversalCommonTest {
 		
 
 		// Create a quick command in the user preferences
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 				+		"<pref name='zimbraPrefQuickCommand'>"+ this.getQuickCommand01().toString() +"</pref>"
 				+		"<pref name='zimbraPrefQuickCommand'>"+ this.getQuickCommand02().toString() +"</pref>"

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/month/allday/ModifyMultipleDayAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/month/allday/ModifyMultipleDayAppointment.java
@@ -172,6 +172,6 @@ public class ModifyMultipleDayAppointment extends CalendarWorkWeekTest {
 		//Verify that multi-day appointments are displayed correctly in month view 
 		boolean displayed = app.zPageCalendar.zVerifyMultidayAllDayAppointmentInMonthView(now, noOfDays, subject);
 		ZAssert.assertTrue(displayed, "Multi-day all-day appointments are not created and displayed correctly in month view");
-		ZimbraAccount.ResetAccountZWC();
+		ZimbraAccount.ResetAccountZCS();
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/Forward.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/Forward.java
@@ -205,12 +205,12 @@ public class Forward extends CalendarWorkWeekTest {
 	public void ForwardMeeting_03() throws HarnessException {
 		
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		String attendee2 = ZimbraAccount.Account2().EmailAddress;
 		
@@ -252,12 +252,12 @@ public class Forward extends CalendarWorkWeekTest {
 	public void ForwardMeeting_04() throws HarnessException {
 		
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		String attendee2 = ZimbraAccount.Account3().EmailAddress;
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/actions/Forward.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/actions/Forward.java
@@ -256,12 +256,12 @@ public class Forward extends CalendarWorkWeekTest {
 	public void ForwardMeeting_04() throws HarnessException {
 		
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		app.zPageCalendar.zNavigateTo();
 		String attendee2 = ZimbraAccount.Account2().EmailAddress;
 		// Create appointment data

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
@@ -104,7 +104,7 @@ public class CreateMeeting extends CalendarWorkWeekTest {
 
 		// Set mail Compose preference to Text format
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "text");
-		ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
+		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 
 		// Refresh UI
 		app.zPageMain.sRefresh();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingByChangingBodyTextFormat.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingByChangingBodyTextFormat.java
@@ -43,7 +43,7 @@ public class CreateMeetingByChangingBodyTextFormat extends CalendarWorkWeekTest 
     	
 		// Set mail Compose preference to Text format
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "text");
-		ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
+		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 		
 		// Refresh UI
 		app.zPageMain.sRefresh();
@@ -88,7 +88,7 @@ public class CreateMeetingByChangingBodyTextFormat extends CalendarWorkWeekTest 
     	
 		// Set mail Compose preference to Text format
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
-		ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
+		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 		
 		// Refresh UI
 		app.zPageMain.sRefresh();
@@ -134,7 +134,7 @@ public class CreateMeetingByChangingBodyTextFormat extends CalendarWorkWeekTest 
     	
 		// Set mail Compose preference to Text format
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "text");
-		ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
+		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 		
 		// Refresh UI
 		app.zPageMain.sRefresh();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingUsingMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingUsingMessage.java
@@ -41,12 +41,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_01() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeHtmlOnly1.txt";
 		final String subject = "1 html mail";
@@ -102,12 +102,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_02() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeHtmlOnly2.txt";
 		final String subject = "2 html mail";
@@ -161,12 +161,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_03() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeTextOnly1.txt";
 		final String subject = "1 plain mail";
@@ -221,12 +221,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_04() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "text" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeTextOnly2.txt";
 		final String subject = "2 plain mail";
@@ -281,12 +281,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_05() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeHtmlOnly3.txt";
 		final String subject = "3 html mail";
@@ -340,12 +340,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_06() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeHtmlOnly4.txt";
 		final String subject = "4 html mail";
@@ -399,12 +399,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_07() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeTextOnly3.txt";
 		final String subject = "3 plain mail";
@@ -459,12 +459,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_08() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "FALSE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email10/mimeTextOnly4.txt";
 		final String subject = "4 plain mail";
@@ -520,12 +520,12 @@ public class CreateMeetingUsingMessage extends CalendarWorkWeekTest {
 	public void CreateMeetingUsingMessage_09() throws HarnessException {
 
 		app.zPageMain.zLogout();
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<ModifyPrefsRequest xmlns='urn:zimbraAccount'>"
 			+		"<pref name='zimbraPrefComposeFormat'>"+ "html" +"</pref>"
 			+		"<pref name='zimbraPrefForwardReplyInOriginalFormat'>"+ "TRUE" +"</pref>"
 			+	"</ModifyPrefsRequest>");
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email00/mime.txt";
 		final String subject = "ZCS 8 triage";

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingAttendee.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingAttendee.java
@@ -79,7 +79,7 @@ public class ResetStatusAfterAddingAttendee extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Add attendee2 and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingEquipment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingEquipment.java
@@ -77,7 +77,7 @@ public class ResetStatusAfterAddingEquipment extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Add Equipment and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingLocation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterAddingLocation.java
@@ -79,7 +79,7 @@ public class ResetStatusAfterAddingLocation extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Add Location and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingCalendar.java
@@ -85,7 +85,7 @@ public class ResetStatusAfterModifyingCalendar extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Add attendee2 and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingContent.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingContent.java
@@ -78,7 +78,7 @@ public class ResetStatusAfterModifyingContent extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);
 		app.zPageMain.zLogout();
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Modify Body and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingSubject.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingSubject.java
@@ -78,7 +78,7 @@ public class ResetStatusAfterModifyingSubject extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());	
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());	
 		
         // Modify Subject and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingTime.java
@@ -80,7 +80,7 @@ public class ResetStatusAfterModifyingTime extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());	
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());	
         
         // Modify time and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingAttendee.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingAttendee.java
@@ -79,7 +79,7 @@ public class ResetStatusAfterRemovingAttendee extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
         
         // Remove attendee2 and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingEquipment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingEquipment.java
@@ -77,7 +77,7 @@ public class ResetStatusAfterRemovingEquipment extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Remove Equipment and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingLocation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterRemovingLocation.java
@@ -80,7 +80,7 @@ public class ResetStatusAfterRemovingLocation extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
         
         // Remove location and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingAttendee.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingAttendee.java
@@ -81,7 +81,7 @@ public class ResetStatusAfterUpdatingAttendee extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());   
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());   
         
         // Remove one attendee, add another and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingEquipment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingEquipment.java
@@ -80,7 +80,7 @@ public class ResetStatusAfterUpdatingEquipment extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Update Equipment and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingLocation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterUpdatingLocation.java
@@ -83,7 +83,7 @@ public class ResetStatusAfterUpdatingLocation extends CalendarWorkWeekTest {
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_ACCEPT_MENU, apptSubject);		
 		app.zPageMain.zLogout();			
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
         // Remove location1, add location2 and re-send the appointment
 		app.zPageCalendar.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/resources/ViewInviteWithSchedulePolicyofEquipment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/resources/ViewInviteWithSchedulePolicyofEquipment.java
@@ -83,7 +83,7 @@ public class ViewInviteWithSchedulePolicyofEquipment extends CalendarWorkWeekTes
 		ZAssert.assertStringContains(display.zGetMailProperty(Field.Body), apptContent, "Verify the text content");
 		
 		// Verify the attendee and organizer header		
-		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZWC().EmailAddress + "')";		
+		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZCS().EmailAddress + "')";		
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(organizer), "Organizer is present");
 
 	//	String attendee = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.Account3().EmailAddress + "')";		
@@ -161,7 +161,7 @@ public class ViewInviteWithSchedulePolicyofEquipment extends CalendarWorkWeekTes
 		ZAssert.assertStringContains(display.zGetMailProperty(Field.Body), apptContent, "Verify the text content");
 		
 		// Verify the attendee and organizer header		
-		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZWC().EmailAddress + "')";		
+		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZCS().EmailAddress + "')";		
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(organizer), "Organizer is present");
 
 	//	String attendee = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.Account3().EmailAddress + "')";		
@@ -218,7 +218,7 @@ public class ViewInviteWithSchedulePolicyofEquipment extends CalendarWorkWeekTes
 		ZAssert.assertStringContains(display.zGetMailProperty(Field.Body), apptContent, "Verify the text content");
 		
 		// Verify the attendee and organizer header		
-		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZWC().EmailAddress + "')";		
+		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.AccountZCS().EmailAddress + "')";		
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(organizer), "Organizer is present");
 
 		//String attendee = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']:contains('" + ZimbraAccount.Account3().EmailAddress + "')";		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/resources/ViewInviteWithSchedulePolicyofLocation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/resources/ViewInviteWithSchedulePolicyofLocation.java
@@ -89,7 +89,7 @@ public class ViewInviteWithSchedulePolicyofLocation extends CalendarWorkWeekTest
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(locationLocator), "Location header present");
 		
 		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']";
-		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZWC().EmailAddress, "Verify the From matches the 'Sender:' header");
+		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZCS().EmailAddress, "Verify the From matches the 'Sender:' header");
 
 		//Accept the invite
 		display.zPressButton(Button.B_ACCEPT);
@@ -168,7 +168,7 @@ public class ViewInviteWithSchedulePolicyofLocation extends CalendarWorkWeekTest
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(locationLocator), "Location header present");
 		
 		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']";
-		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZWC().EmailAddress, "Verify the From matches the 'Sender:' header");
+		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZCS().EmailAddress, "Verify the From matches the 'Sender:' header");
 
 	}
 
@@ -225,7 +225,7 @@ public class ViewInviteWithSchedulePolicyofLocation extends CalendarWorkWeekTest
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(locationLocator), "Location header present");
 		
 		String organizer = "css=table[id='zv__TV__TV-main_MSG_hdrTable'] span[class='addrBubble']";
-		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZWC().EmailAddress, "Verify the From matches the 'Sender:' header");
+		ZAssert.assertEquals(app.zPageMail.sGetText(organizer).trim(), ZimbraAccount.AccountZCS().EmailAddress, "Verify the From matches the 'Sender:' header");
 		
 		display.zPressButton(Button.B_ACCEPT);
 		SleepUtil.sleepMedium();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/contacts/ContactContextMenu.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/contacts/ContactContextMenu.java
@@ -178,7 +178,7 @@ public class ContactContextMenu extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		String lastName = "lastname " + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountB to the ZWC user
+		// Send the message from AccountB to the ZCS user
 		ZimbraAccount.AccountB()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
@@ -218,7 +218,7 @@ public class ContactContextMenu extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		String lastName = "lastname " + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/TagContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/TagContact.java
@@ -37,7 +37,7 @@ public class TagContact extends ContactsPrefShowSelectionCheckbox {
 	@BeforeClass(groups = { "always" })
 	public void TagContactBeforeClass() throws HarnessException {
 		logger.info("TagContactBeforeClass: start");
-		ZimbraAccount.ResetAccountZWC();
+		ZimbraAccount.ResetAccountZCS();
 		logger.info("TagContactBeforeClass: finish");
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/attachments/AddToCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/attachments/AddToCalendar.java
@@ -187,7 +187,7 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 	public void AddToCalendar_NewWindow_03() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// -- Data Setup
 		String subject = "new window invite ics attachment";
@@ -199,7 +199,7 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email08/mime06.txt";
 		
 		// Inject the message
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mimeFile));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mimeFile));
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 		SleepUtil.sleepMedium();
 
@@ -239,7 +239,7 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 			}
 			
 			// Make sure the folder was created on the server
-			FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(),foldername);
+			FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(),foldername);
 			dialog.zChooseCalendarFolder(folder.getId());
 			dialog.zClickButton(Button.B_OK);
 			SleepUtil.sleepLong(); //sometime client takes longer time to add the appointment
@@ -254,13 +254,13 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 			+		"<query>"+ "in:" + foldername + " " + apptSubject +"</query>"
 			+	"</SearchRequest>");
 		
-		String organizerInvId = ZimbraAccount.AccountZWC().soapSelectValue("//mail:appt", "invId");
+		String organizerInvId = ZimbraAccount.AccountZCS().soapSelectValue("//mail:appt", "invId");
 		
 		// Get the appointment details
 		app.zGetActiveAccount().soapSend(
 					"<GetAppointmentRequest xmlns='urn:zimbraMail' id='"+ organizerInvId +"'/>");
 		
-		String apptName = ZimbraAccount.AccountZWC().soapSelectValue("//mail:comp", "name");
+		String apptName = ZimbraAccount.AccountZCS().soapSelectValue("//mail:comp", "name");
 		ZAssert.assertEquals(apptName, apptSubject, "Verify correct appointment returned'");
 	
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/drafts/ReplyingMessageDoesntCreateDraft.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/drafts/ReplyingMessageDoesntCreateDraft.java
@@ -45,7 +45,7 @@ public class ReplyingMessageDoesntCreateDraft extends PrefGroupMailByMessageTest
 		String subject = "subject13690880312762";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug67686";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		//-- GUI
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/conversation/conversations/CheckFromHeaderInConversationView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/conversation/conversations/CheckFromHeaderInConversationView.java
@@ -60,7 +60,7 @@ public class CheckFromHeaderInConversationView extends UniversalCommonTest {
 		String to = "ljk20k00k1je";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug16213";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Click on folder in the tree
 		FolderItem inbox = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Inbox);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/conversation/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/conversation/performance/ZmMailApp.java
@@ -49,8 +49,8 @@ public class ZmMailApp extends UniversalCommonTest {
 	public void ZmMailApp_01() throws HarnessException {
 		
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, conversation view, initial load");
 
@@ -70,11 +70,11 @@ public class ZmMailApp extends UniversalCommonTest {
 	public void ZmMailApp_02() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mime));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, conversation view, 1 conversations");
 
@@ -94,11 +94,11 @@ public class ZmMailApp extends UniversalCommonTest {
 	public void ZmMailApp_03() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mime));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, conversation view, 100 conversations");
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/feeds/CheckFeedGeneratedMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/feeds/CheckFeedGeneratedMessage.java
@@ -36,7 +36,7 @@ public class CheckFeedGeneratedMessage extends PrefGroupMailByMessageTest {
 
 	@Bugs( ids = "52121")
 	
-	@Test( description = "Verify bug 52121:  feed-generated messages do not render in AJAX client ", groups = { "functional", "L2" })
+	@Test( description = "Verify bug 52121:  feed-generated messages do not render in UNIVERSAL client ", groups = { "functional", "L2" })
 	
 	public void CheckFeedGeneratedMessage_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/feeds/CheckFeedGeneratedMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/feeds/CheckFeedGeneratedMessage.java
@@ -44,7 +44,7 @@ public class CheckFeedGeneratedMessage extends PrefGroupMailByMessageTest {
 		String bodytext = "Barbara's suggestion:";
 	
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug52121";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 				
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/CheckExpandCollaseFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/CheckExpandCollaseFolders.java
@@ -40,8 +40,8 @@ public class CheckExpandCollaseFolders extends PrefGroupMailByMessageTest {
 		logger.info("bug57468AfterClass: start");
 		
 		// Since we collapsed the folder tree, it may cause problems for other tests
-		// Rest the ZWC user
-		ZimbraAccount.ResetAccountZWC();
+		// Rest the ZCS user
+		ZimbraAccount.ResetAccountZCS();
 		
 		logger.info("bug57468AfterClass: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/HoverOverFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/HoverOverFolder.java
@@ -145,8 +145,6 @@ public class HoverOverFolder extends PrefGroupMailByMessageTest {
 		 * 200 B
 		 * The computed size depends on the server.  So, just use not "0 B" (and hope
 		 * that some implementation won't use 0.2 MB)
-		 *  
-		 * Ex: http://server/testlogs/UBUNTU10_64/main/20121202000101_NETWORK/SelNG-projects-ajax-tests/1354441149664/server/AJAX/firefox_12.0/en_US/debug/projects/ajax/tests/mail/folders/HoverOverFolder/TooltipFolder_02ss51.png
 		 * 
 		 */
 		// Verify "201 B" message size

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetExternalIMAP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetExternalIMAP.java
@@ -41,7 +41,7 @@ public class GetExternalIMAP extends PrefGroupMailByMessageTest {
 	 * 
 	 * 1. Create an account on the server
 	 * 2. Put a message in the inbox
-	 * 3. Login to ajax
+	 * 3. Login to universal
 	 * 4. Create a folder
 	 * 5. Add a data source to the account from step 1, associate with the folder in step 4
 	 * 6. Right click on the folder -> Get external mail

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetExternalPOP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetExternalPOP.java
@@ -39,7 +39,7 @@ public class GetExternalPOP extends PrefGroupMailByMessageTest {
 	 * 
 	 * 1. Create an account on the server
 	 * 2. Put a message in the inbox
-	 * 3. Login to ajax
+	 * 3. Login to universal
 	 * 4. Create a folder
 	 * 5. Add a data source to the account from step 1, associate with the folder in step 4
 	 * 6. Right click on the folder -> Get external mail
@@ -147,7 +147,7 @@ public class GetExternalPOP extends PrefGroupMailByMessageTest {
 	 * 
 	 * 1. Create an account on the server
 	 * 2. Put a message in the inbox
-	 * 3. Login to ajax
+	 * 3. Login to universal
 	 * 4. Create a folder
 	 * 5. Add a data source to the account from step 1, associate with the folder in step 4
 	 * 6. Select the folder (http://bugzilla.zimbra.com/show_bug.cgi?id=66528#c5)

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetGmailImap.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetGmailImap.java
@@ -40,7 +40,7 @@ public class GetGmailImap extends PrefGroupMailByMessageTest {
 	/**
 	 * Objective: View an Gmail folder - IMAP
 	 * 
-	 * 1. Login to ajax
+	 * 1. Login to universal
 	 * 2. Create a folder
 	 * 3. Add external account as Gmail
 	 * 4. Right click on the folder -> Get external mail

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/gui/features/ZimbraFeatureMailEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/gui/features/ZimbraFeatureMailEnabled.java
@@ -53,7 +53,7 @@ public class ZimbraFeatureMailEnabled extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/CheckAcceptDeclineButtonsForInvite.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/CheckAcceptDeclineButtonsForInvite.java
@@ -45,7 +45,7 @@ public class CheckAcceptDeclineButtonsForInvite extends PrefGroupMailByMessageTe
 		String subject = "all-hands";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21013";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/CheckMailContentForSpecificMimes.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/CheckMailContentForSpecificMimes.java
@@ -44,7 +44,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String bodyAfterImage = "Problemet best\u00E5r";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug13911";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 		
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -69,7 +69,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String endingContent = "Esta mensagem";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21415";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 		
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -96,7 +96,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String endingContent = "SkinResources.java";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21415";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -121,7 +121,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String subject = "subject13001430504373";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug25624";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -141,7 +141,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String subject = "subject13001430504374";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug27796";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		
 		// Refresh current view
@@ -164,7 +164,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String subject = "subject13002239738283";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug31535";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -186,7 +186,7 @@ public class CheckMailContentForSpecificMimes extends PrefGroupMailByMessageTest
 		String bodytext = "Kind regards,";
 	
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug66192";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 				
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/GetMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/GetMail.java
@@ -80,7 +80,7 @@ public class GetMail extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/MessageDisplayShowsFromAsUnknown.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/MessageDisplayShowsFromAsUnknown.java
@@ -57,7 +57,7 @@ public class MessageDisplayShowsFromAsUnknown extends UniversalCommonTest {
 		String from = "Unknown";
 
 		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug16213";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(MimeFolder));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/OpenMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/OpenMail.java
@@ -45,7 +45,7 @@ public class OpenMail extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/PriorityMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/PriorityMail.java
@@ -40,7 +40,7 @@ public class PriorityMail extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m f='!'>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newtab/OpenInTabMailFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/newtab/OpenInTabMailFolder.java
@@ -48,7 +48,7 @@ public class OpenInTabMailFolder extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 				"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/performance/ZmMailApp.java
@@ -49,8 +49,8 @@ public class ZmMailApp extends UniversalCommonTest {
 	public void ZmMailApp_01() throws HarnessException {
 		
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, message view, initial load");
 
@@ -70,11 +70,11 @@ public class ZmMailApp extends UniversalCommonTest {
 	public void ZmMailApp_02() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mime));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, message view, 1 message");
 
@@ -94,11 +94,11 @@ public class ZmMailApp extends UniversalCommonTest {
 	public void ZmMailApp_03() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";
-		LmtpInject.injectFile(ZimbraAccount.AccountZWC(), new File(mime));
+		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Load the mail app, message view, 100 messages");
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/performance/ZmMailAppFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/performance/ZmMailAppFolders.java
@@ -53,16 +53,16 @@ public class ZmMailAppFolders extends UniversalCommonTest {
 	public void ZmMailAppFolder_01() throws HarnessException {
 
 		// Create a folder
-		FolderItem root = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), FolderItem.SystemFolder.UserRoot);
-		ZimbraAccount.AccountZWC().soapSend(
+		FolderItem root = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), FolderItem.SystemFolder.UserRoot);
+		ZimbraAccount.AccountZCS().soapSend(
 				"<CreateFolderRequest xmlns='urn:zimbraMail'>" +
 	                	"<folder name='folder"+ ConfigProperties.getUniqueString() + "' view='message' l='"+ root.getId() +"'/>" +
 	                "</CreateFolderRequest>");
 
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailAppOverviewPanel, "Load the mail app, message view, 1 folder");
 
@@ -82,9 +82,9 @@ public class ZmMailAppFolders extends UniversalCommonTest {
 	public void ZmMailAppFolder_02() throws HarnessException {
 
 		// Create 100 folders
-		FolderItem root = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), FolderItem.SystemFolder.UserRoot);
+		FolderItem root = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), FolderItem.SystemFolder.UserRoot);
 		for (int i = 0; i < 100; i++) {
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>" +
 							"<folder name='folder"+ ConfigProperties.getUniqueString() + "' view='message' l='"+ root.getId() +"'/>" +
 					"</CreateFolderRequest>");
@@ -92,8 +92,8 @@ public class ZmMailAppFolders extends UniversalCommonTest {
 
 
 		// Fill out the login page
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailAppOverviewPanel, "Load the mail app, message view, 100 folders");
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/readingpane/VerifyReadingPaneOptions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/readingpane/VerifyReadingPaneOptions.java
@@ -56,7 +56,7 @@ public class VerifyReadingPaneOptions extends PrefGroupMailByConversationTest {
 		String subject = "subject"+ ConfigProperties.getUniqueString();
 		
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 						"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
 						"<e t='t' a='"+ app.zGetActiveAccount().EmailAddress +"'/>" +
@@ -68,7 +68,7 @@ public class VerifyReadingPaneOptions extends PrefGroupMailByConversationTest {
 						"</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(),"in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(),"in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/readreceipt/SendReadReceiptsAlways.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/readreceipt/SendReadReceiptsAlways.java
@@ -49,7 +49,7 @@ public class SendReadReceiptsAlways extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		sender.soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>"
 				+		"<m>"

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/readreceipt/SendReadReceiptsNever.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/readreceipt/SendReadReceiptsNever.java
@@ -48,7 +48,7 @@ public class SendReadReceiptsNever extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		sender.soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>"
 				+		"<m>"

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/readreceipt/SendReadReceiptsPrompt.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/readreceipt/SendReadReceiptsPrompt.java
@@ -48,7 +48,7 @@ public class SendReadReceiptsPrompt extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		sender.soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>"
 				+		"<m>"
@@ -100,7 +100,7 @@ public class SendReadReceiptsPrompt extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		sender.soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>"
 				+		"<m>"

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/tags/DisableTagFromAdmin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/tags/DisableTagFromAdmin.java
@@ -11,7 +11,7 @@ public class DisableTagFromAdmin extends PrefGroupMailByMessageTest {
 		logger.info("New "+ CreateTag.class.getCanonicalName());		
 	}
 	
-	@Test( description = "Bug # 80892 - Disable tag from admin and check in AJAX client",groups = { "functional", "L2" })
+	@Test( description = "Bug # 80892 - Disable tag from admin and check in UNIVERSAL client",groups = { "functional", "L2" })
 	public void DisableTagFromAdmin_01() throws HarnessException {	
 		
 		ZimbraAdminAccount.GlobalAdmin().soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/external/register/BasicRegistration.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/external/register/BasicRegistration.java
@@ -42,18 +42,18 @@ public class BasicRegistration extends UniversalCommonTest {
 			ZimbraExternalAccount external = new ZimbraExternalAccount();
 			external.setEmailAddress("external" + ConfigProperties.getUniqueString() + "@example.com");
 			
-			FolderItem inbox = FolderItem.importFromSOAP(ZimbraAccount.AccountZWC(), FolderItem.SystemFolder.Inbox);
+			FolderItem inbox = FolderItem.importFromSOAP(ZimbraAccount.AccountZCS(), FolderItem.SystemFolder.Inbox);
 			String foldername = "folder" + ConfigProperties.getUniqueString();
 	
 			// Create a subfolder in Inbox
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 					+		"<folder name='" + foldername +"' l='" + inbox.getId() +"' view='message'/>"
 					+	"</CreateFolderRequest>");
-			String folderid = ZimbraAccount.AccountZWC().soapSelectValue("//mail:folder", "id");
+			String folderid = ZimbraAccount.AccountZCS().soapSelectValue("//mail:folder", "id");
 	
 			// Share the subfolder
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<FolderActionRequest xmlns='urn:zimbraMail'>"
 					+		"<action id='"+ folderid +"' op='grant'>"
 					+			"<grant d='"+ external.EmailAddress +"' inh='1' gt='guest' pw='' perm='r'/>"
@@ -61,7 +61,7 @@ public class BasicRegistration extends UniversalCommonTest {
 					+	"</FolderActionRequest>");
 	
 			// Send the notification
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<SendShareNotificationRequest xmlns='urn:zimbraMail'>"
 					+		"<item id='"+ folderid +"'/>"
 					+		"<e a='"+ external.EmailAddress +"'/>"
@@ -70,19 +70,19 @@ public class BasicRegistration extends UniversalCommonTest {
 	
 	
 			// Parse the URL From the sent message
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 					+		"<query>in:sent "+ external.EmailAddress +"</query>"
 					+	"</SearchRequest>");
-			String messageid = ZimbraAccount.AccountZWC().soapSelectValue("//mail:m", "id");
+			String messageid = ZimbraAccount.AccountZCS().soapSelectValue("//mail:m", "id");
 			
-			ZimbraAccount.AccountZWC().soapSend(
+			ZimbraAccount.AccountZCS().soapSend(
 						"<GetMsgRequest xmlns='urn:zimbraMail'>"
 					+		"<m id='"+ messageid +"' html='1'/>"
 					+	"</GetMsgRequest>");
 			
 			// Based on the content of the sent message, the URL's can be determined
-			Element response = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+			Element response = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 			external.setURL(response);
 			
 			

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/BasicLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/BasicLogin.java
@@ -36,7 +36,7 @@ public class BasicLogin extends UniversalCommonTest {
 	public void BasicLogin01() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/BasicLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/BasicLogin.java
@@ -30,7 +30,7 @@ public class BasicLogin extends UniversalCommonTest {
 		super.startingPage = app.zPageLogin;
 	}
 	
-	@Test( description = "Login to the Ajax Client",
+	@Test( description = "Login to the Universal Client",
 			groups = { "sanity", "L0"})
 	
 	public void BasicLogin01() throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/BasicLogout.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/BasicLogout.java
@@ -28,7 +28,7 @@ public class BasicLogout extends UniversalCommonTest {
 		logger.info("New "+ BasicLogout.class.getCanonicalName());
 	}
 	
-	@Test( description = "Logout of the Ajax Client", 
+	@Test( description = "Logout of the Universal Client", 
 			groups = { "sanity", "L0"})
 	
 	public void BasicLogout01() throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/Login.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/Login.java
@@ -30,7 +30,7 @@ public class Login extends UniversalCommonTest {
 		
 	}
 	
-	@Test( description = "Login to the Ajax Client", 
+	@Test( description = "Login to the Universal Client", 
 			groups = { "sanity", "L0"})
 	
 	public void Login01() throws HarnessException {
@@ -44,7 +44,7 @@ public class Login extends UniversalCommonTest {
 	}
 
 	
-	@Test( description = "Login to the Ajax Client, with a mounted folder",
+	@Test( description = "Login to the Universal Client, with a mounted folder",
 			groups = { "functional", "L3" })
 	
 	public void Login02() throws HarnessException {
@@ -120,7 +120,7 @@ public class Login extends UniversalCommonTest {
 
 	
 	@Bugs( ids = "59847")
-	@Test( description = "Login to the Ajax Client, with a mounted folder of a deleted account",
+	@Test( description = "Login to the Universal Client, with a mounted folder of a deleted account",
 			groups = { "functional", "L3" })
 	
 	public void Login03() throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/Login.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/Login.java
@@ -36,7 +36,7 @@ public class Login extends UniversalCommonTest {
 	public void Login01() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");
@@ -69,7 +69,7 @@ public class Login extends UniversalCommonTest {
 		ZimbraAccount.AccountA().soapSend(
 					"<FolderActionRequest xmlns='urn:zimbraMail'>"
 				+		"<action id='"+ folder.getId() +"' op='grant'>"
-				+			"<grant d='"+ ZimbraAccount.AccountZWC().EmailAddress +"' gt='usr' perm='r'/>"
+				+			"<grant d='"+ ZimbraAccount.AccountZCS().EmailAddress +"' gt='usr' perm='r'/>"
 				+		"</action>"
 				+	"</FolderActionRequest>");
 		
@@ -102,16 +102,16 @@ public class Login extends UniversalCommonTest {
 					+	"</MsgActionRequest>");
 		
 		// Mount it
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateMountpointRequest xmlns='urn:zimbraMail'>"
 				+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 				+	"</CreateMountpointRequest>");
 		
-		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(ZimbraAccount.AccountZWC(), mountpointname);
+		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(ZimbraAccount.AccountZCS(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify active account's mountpoint is created");
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");
@@ -151,7 +151,7 @@ public class Login extends UniversalCommonTest {
 		account.soapSend(
 					"<FolderActionRequest xmlns='urn:zimbraMail'>"
 				+		"<action id='"+ folder.getId() +"' op='grant'>"
-				+			"<grant d='"+ ZimbraAccount.AccountZWC().EmailAddress +"' gt='usr' perm='r'/>"
+				+			"<grant d='"+ ZimbraAccount.AccountZCS().EmailAddress +"' gt='usr' perm='r'/>"
 				+		"</action>"
 				+	"</FolderActionRequest>");
 		
@@ -178,12 +178,12 @@ public class Login extends UniversalCommonTest {
 
 		
 		// Mount it
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 					"<CreateMountpointRequest xmlns='urn:zimbraMail'>"
 				+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ account.ZimbraId +"'/>"
 				+	"</CreateMountpointRequest>");
 		
-		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(ZimbraAccount.AccountZWC(), mountpointname);
+		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(ZimbraAccount.AccountZCS(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify active account's mountpoint is created");
 		
 		// Delete other account
@@ -194,7 +194,7 @@ public class Login extends UniversalCommonTest {
 		
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");
@@ -249,7 +249,7 @@ public class Login extends UniversalCommonTest {
 			app.zPageLogin.sOpen(ConfigProperties.getBaseURL());
 			
 			// Login
-			app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());		
+			app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());		
 			
 			// Verify main page becomes active
 			ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/LoginScreen.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/LoginScreen.java
@@ -41,7 +41,7 @@ public class LoginScreen extends UniversalCommonTest {
 
 	}
 
-	@Test( description = "Verify the label text on the ajax client login screen",
+	@Test( description = "Verify the label text on the universal client login screen",
 			groups = { "smoke", "L0"})
 	public void LoginScreen01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
@@ -69,7 +69,7 @@ public class LoginWithCsrfTokenCheckDisabled extends UniversalCommonTest {
 			SleepUtil.sleepMedium();
 
 			// Login
-			app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+			app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 
 			// Verify main page becomes active
 			ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountClosed.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountClosed.java
@@ -47,7 +47,7 @@ public class OwnerAccountClosed extends UniversalCommonTest {
 	}
 	
 	
-	@Test( description = "Login to the Ajax Client - with a mountpoint to a closed account",
+	@Test( description = "Login to the Universal Client - with a mountpoint to a closed account",
 			groups = { "functional", "L3"})
 	public void OwnerAccountClosed01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountDeleted.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountDeleted.java
@@ -47,7 +47,7 @@ public class OwnerAccountDeleted extends UniversalCommonTest {
 	}
 	
 	
-	@Test( description = "Login to the Ajax Client - with a mountpoint to a deleted account",
+	@Test( description = "Login to the Universal Client - with a mountpoint to a deleted account",
 			groups = { "functional", "L3"})
 	public void OwnerAccountDeleted01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountLocked.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountLocked.java
@@ -47,7 +47,7 @@ public class OwnerAccountLocked extends UniversalCommonTest {
 	}
 	
 	
-	@Test( description = "Login to the Ajax Client - with a mountpoint to a 'locked' account",
+	@Test( description = "Login to the Universal Client - with a mountpoint to a 'locked' account",
 			groups = { "functional", "L3"})
 	public void OwnerAccountLocked01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountMaintenance.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountMaintenance.java
@@ -47,7 +47,7 @@ public class OwnerAccountMaintenance extends UniversalCommonTest {
 	}
 	
 	
-	@Test( description = "Login to the Ajax Client - with a mountpoint to a 'in-maintenance' account",
+	@Test( description = "Login to the Universal Client - with a mountpoint to a 'in-maintenance' account",
 			groups = { "functional", "L3"})
 	public void OwnerAccountMaintenance01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountPending.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/OwnerAccountPending.java
@@ -47,7 +47,7 @@ public class OwnerAccountPending extends UniversalCommonTest {
 	}
 	
 	
-	@Test( description = "Login to the Ajax Client - with a mountpoint to a 'pending' account",
+	@Test( description = "Login to the Universal Client - with a mountpoint to a 'pending' account",
 			groups = { "functional", "L3"})
 	public void OwnerAccountPending01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/ShareDeleted.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/ShareDeleted.java
@@ -47,7 +47,7 @@ public class ShareDeleted extends UniversalCommonTest {
 	}
 	
 	
-	@Test( description = "Login to the Ajax Client - with a mountpoint to a deleted share",
+	@Test( description = "Login to the Universal Client - with a mountpoint to a deleted share",
 			groups = { "functional" , "L3"})
 	public void ShareDeleted01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/ShareRevoked.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/mountpoints/folders/ShareRevoked.java
@@ -47,7 +47,7 @@ public class ShareRevoked extends UniversalCommonTest {
 	}
 	
 	
-	@Test( description = "Login to the Ajax Client - with a mountpoint to a revoked share",
+	@Test( description = "Login to the Universal Client - with a mountpoint to a revoked share",
 			groups = { "functional", "L3"})
 	public void ShareRevoked01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/performance/ZmMailApp.java
@@ -37,7 +37,7 @@ public class ZmMailApp extends UniversalCommonTest {
 		
 	}
 	
-	@Test( description = "Measure the time to load the ajax client",
+	@Test( description = "Measure the time to load the universal client",
 			groups = { "performance", "L4"})
 	public void ZmMailApp01() throws HarnessException {
 		
@@ -47,7 +47,7 @@ public class ZmMailApp extends UniversalCommonTest {
 		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
 		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
-		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Login to the ajax client (mail app)");
+		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Login to the universal client (mail app)");
 
 		// Click the Login button
 		app.zPageLogin.sClick(Locators.zBtnLogin);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/performance/ZmMailApp.java
@@ -44,8 +44,8 @@ public class ZmMailApp extends UniversalCommonTest {
 		
 		app.zPageLogin.zNavigateTo();
 
-		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZWC().EmailAddress);
-		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZWC().Password);
+		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
+		app.zPageLogin.zSetLoginPassword(ZimbraAccount.AccountZCS().Password);
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailApp, "Login to the ajax client (mail app)");
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/attributes/ZimbraFeatureMailForwardingEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/attributes/ZimbraFeatureMailForwardingEnabled.java
@@ -47,7 +47,7 @@ public class ZimbraFeatureMailForwardingEnabled extends UniversalCommonTest {
 			groups = { "functional", "L2" })
 	public void zimbraFeatureMailForwardingEnabled_01() throws HarnessException {
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		// Go to preferences - mail
 		app.zPagePreferences.zNavigateTo();
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.Mail);
@@ -68,7 +68,7 @@ public class ZimbraFeatureMailForwardingEnabled extends UniversalCommonTest {
 			groups = { "functional", "L2" })
 	public void zimbraFeatureMailForwardingEnabled_02() throws HarnessException {
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		// Go to preferences - mail
 		app.zPagePreferences.zNavigateTo();
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.Mail);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/attributes/ZimbraFeaturePortalEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/attributes/ZimbraFeaturePortalEnabled.java
@@ -50,7 +50,7 @@ public class ZimbraFeaturePortalEnabled extends UniversalCommonTest {
 	public void BasicLogin01() throws HarnessException {
 		
 		// Login
-		app.zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		app.zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 		
 		// Verify main page becomes active
 		ZAssert.assertTrue(app.zPageMain.zIsActive(), "Verify that the account is logged in");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/attributes/ZimbraFeaturePortalEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/attributes/ZimbraFeaturePortalEnabled.java
@@ -45,7 +45,7 @@ public class ZimbraFeaturePortalEnabled extends UniversalCommonTest {
 	}
 	
 	@Bugs(ids = "67462")
-	@Test( description = "Login to the Ajax Client with the 'example' portal enabled",
+	@Test( description = "Login to the Universal Client with the 'example' portal enabled",
 			groups = { "functional", "L2" })
 	public void BasicLogin01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse.java
@@ -41,8 +41,8 @@ public class ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse extends U
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -75,7 +75,7 @@ public class ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse extends U
 
 		// Create the message data to be sent
 		MailItem mail = new MailItem();
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyText = "body" + ConfigProperties.getUniqueString();
 
@@ -92,14 +92,14 @@ public class ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse extends U
 		// Send the message
 		mailform.zSubmit();
 
-		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(),
+		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(),
 				"in:inbox subject:(" + mail.dSubject + ")");
 
 		// Verify TO, Subject, Body,Signature
 
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertEquals(received.dSubject, mail.dSubject, "Verify the subject field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ComposeHtmlMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ComposeHtmlMsgWithHtmlSignature.java
@@ -52,8 +52,8 @@ public class ComposeHtmlMsgWithHtmlSignature extends UniversalCommonTest {
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
 		System.out.println(this.sigName);
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTML + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -80,7 +80,7 @@ public class ComposeHtmlMsgWithHtmlSignature extends UniversalCommonTest {
 
 		// Create the message data to be sent
 		MailItem mail = new MailItem();
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyHtml = "bodybold" + ConfigProperties.getUniqueString() + "body";
 
@@ -97,19 +97,19 @@ public class ComposeHtmlMsgWithHtmlSignature extends UniversalCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
 
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' html='1'/>" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertEquals(received.dSubject, mail.dSubject, "Verify the subject field is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(),

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ComposeMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ComposeMsgWithTextSignature.java
@@ -47,8 +47,8 @@ public class ComposeMsgWithTextSignature extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -76,7 +76,7 @@ public class ComposeMsgWithTextSignature extends UniversalCommonTest {
 
 		// Create the message data to be sent
 		MailItem mail = new MailItem();
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyText = "body" + ConfigProperties.getUniqueString();
 
@@ -93,13 +93,13 @@ public class ComposeMsgWithTextSignature extends UniversalCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(),
+		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(),
 				"in:inbox subject:(" + mail.dSubject + ")");
 
 		// Verify TO, Subject, Body, Signature
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertEquals(received.dSubject, mail.dSubject, "Verify the subject field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/CreateTextSignatureAndAddInComposedHtmlMesage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/CreateTextSignatureAndAddInComposedHtmlMesage.java
@@ -40,8 +40,8 @@ public class CreateTextSignatureAndAddInComposedHtmlMesage extends UniversalComm
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -69,7 +69,7 @@ public class CreateTextSignatureAndAddInComposedHtmlMesage extends UniversalComm
 
 		// Create the message data to be sent
 		MailItem mail = new MailItem();
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyHtml = "body" + ConfigProperties.getUniqueString();
 
@@ -86,13 +86,13 @@ public class CreateTextSignatureAndAddInComposedHtmlMesage extends UniversalComm
 		// Send the message
 		mailform.zSubmit();
 
-		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(),
+		MailItem received = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(),
 				"in:inbox subject:(" + mail.dSubject + ")");
 
 		// Verify TO, Subject, Body, Signature
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertEquals(received.dSubject, mail.dSubject, "Verify the subject field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyHtml, "Verify the body content is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/DeleteHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/DeleteHtmlSignature.java
@@ -54,8 +54,8 @@ public class DeleteHtmlSignature extends UniversalCommonTest {
 	@BeforeMethod(groups = { "always" })
 	public void CreateHtmlSignature() throws HarnessException {
 
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigHtmlName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTML + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/DeleteTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/DeleteTextSignature.java
@@ -48,8 +48,8 @@ public class DeleteTextSignature extends UniversalCommonTest {
 	 */
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/EditHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/EditHtmlSignature.java
@@ -50,8 +50,8 @@ public class EditHtmlSignature extends UniversalCommonTest {
 	 */
 	@BeforeMethod(groups = { "always" })
 	public void CreateHtmlSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "'>" + "<content type='text/html'>" + this.contentHTML + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/EditTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/EditTextSignature.java
@@ -47,8 +47,8 @@ public class EditTextSignature extends UniversalCommonTest {
 	 */
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "'>" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ForwardMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ForwardMsgWithHtmlSignature.java
@@ -53,8 +53,8 @@ public class ForwardMsgWithHtmlSignature extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -91,7 +91,7 @@ public class ForwardMsgWithHtmlSignature extends UniversalCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + signature.dBodyHtmlText + "</body>" + "</html>");
 
 		// Send a message to the account with html signature
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -99,7 +99,7 @@ public class ForwardMsgWithHtmlSignature extends UniversalCommonTest {
 						+ "\n</content>" + "</mp>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ForwardMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ForwardMsgWithTextSignature.java
@@ -50,8 +50,8 @@ public class ForwardMsgWithTextSignature extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -81,14 +81,14 @@ public class ForwardMsgWithTextSignature extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString() + "\n\n"
 						+ signature.dBodyText + "\n</content>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyHtmlSignatureAboveIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyHtmlSignatureAboveIncludeMsg.java
@@ -50,7 +50,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -84,7 +84,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends UniversalCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -134,7 +134,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends UniversalCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -185,7 +185,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends UniversalCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyHtmlSignatureBelowIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyHtmlSignatureBelowIncludeMsg.java
@@ -52,7 +52,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -88,7 +88,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends UniversalCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -137,7 +137,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends UniversalCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -188,7 +188,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends UniversalCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + bodyHTML + "<br></br>" + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyTextSignatureAboveIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyTextSignatureAboveIncludeMsg.java
@@ -50,7 +50,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends UniversalCommonTest {
 	public void CreateSignature() throws HarnessException {
 		logger.info("CreateSignature: start");
 
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -81,7 +81,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()
@@ -128,7 +128,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()
@@ -174,7 +174,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyTextSignatureBelowIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyTextSignatureBelowIncludeMsg.java
@@ -49,7 +49,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -80,7 +80,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()
@@ -127,7 +127,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()
@@ -172,7 +172,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString()

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyAllMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyAllMsgWithHtmlSignature.java
@@ -45,8 +45,8 @@ public class ReplyAllMsgWithHtmlSignature extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -83,7 +83,7 @@ public class ReplyAllMsgWithHtmlSignature extends UniversalCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + signature.dBodyHtmlText + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -91,7 +91,7 @@ public class ReplyAllMsgWithHtmlSignature extends UniversalCommonTest {
 						+ "\n</content>" + "</mp>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -107,21 +107,21 @@ public class ReplyAllMsgWithHtmlSignature extends UniversalCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
 
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' html='1'/>" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Reply'ed Subject, HtmlBody,HtmlSignature
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Re' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(), bodyHTML, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(), this.sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyAllMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyAllMsgWithTextSignature.java
@@ -50,8 +50,8 @@ public class ReplyAllMsgWithTextSignature extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -82,14 +82,14 @@ public class ReplyAllMsgWithTextSignature extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString() + "\n\n"
 						+ signature.dBodyText + "\n</content>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -105,20 +105,20 @@ public class ReplyAllMsgWithTextSignature extends UniversalCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
-		ZimbraAccount.AccountZWC()
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		ZimbraAccount.AccountZCS()
 				.soapSend("<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' />" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Subject, Text Body,Text Signature for replied msg
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Fwd' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyText, this.sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithHtmlSignature.java
@@ -45,8 +45,8 @@ public class ReplyMsgWithHtmlSignature extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/html'>'" + this.contentHTMLSig + "'</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -82,7 +82,7 @@ public class ReplyMsgWithHtmlSignature extends UniversalCommonTest {
 				.escapeXml("<html>" + "<head></head>" + "<body>" + signature.dBodyHtmlText + "</body>" + "</html>");
 
 		// Send a message to the account
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='multipart/alternative'>" + "<mp ct='text/plain'>" + "<content>" + bodyText
@@ -90,7 +90,7 @@ public class ReplyMsgWithHtmlSignature extends UniversalCommonTest {
 						+ "\n</content>" + "</mp>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -106,21 +106,21 @@ public class ReplyMsgWithHtmlSignature extends UniversalCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
 
-		ZimbraAccount.AccountZWC().soapSend(
+		ZimbraAccount.AccountZCS().soapSend(
 				"<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' html='1'/>" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Reply'ed Subject, HtmlBody,HtmlSignature
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Re' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(), bodyHTML, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyHtml.toLowerCase(), this.sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithTextSignature.java
@@ -50,8 +50,8 @@ public class ReplyMsgWithTextSignature extends UniversalCommonTest {
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
@@ -81,14 +81,14 @@ public class ReplyMsgWithTextSignature extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString() + "\n\n"
 						+ signature.dBodyText + "\n</content>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -104,20 +104,20 @@ public class ReplyMsgWithTextSignature extends UniversalCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
-		ZimbraAccount.AccountZWC()
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		ZimbraAccount.AccountZCS()
 				.soapSend("<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' />" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Subject, Text Body,Text Signature for replied msg
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Fwd' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyText, this.sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithTwoThreeLineTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithTwoThreeLineTextSignature.java
@@ -73,7 +73,7 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends UniversalCommonTest {
 						+ "<content type='text/plain'>" + sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
 
-		String SignatureId = ZimbraAccount.AccountZWC().soapSelectValue("//acct:CreateSignatureResponse/acct:signature",
+		String SignatureId = ZimbraAccount.AccountZCS().soapSelectValue("//acct:CreateSignatureResponse/acct:signature",
 				"id");
 
 		app.zGetActiveAccount()
@@ -81,13 +81,13 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends UniversalCommonTest {
 						+ "<content type='text/plain'>" + sigBody1 + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");
 
-		String SignatureId1 = ZimbraAccount.AccountZWC()
+		String SignatureId1 = ZimbraAccount.AccountZCS()
 				.soapSelectValue("//acct:CreateSignatureResponse/acct:signature", "id");
 
 		app.zGetActiveAccount()
 				.soapSend("<GetIdentitiesRequest xmlns='urn:zimbraAccount'>" + "</GetIdentitiesRequest>");
 
-		String IdentityId = ZimbraAccount.AccountZWC().soapSelectValue("//acct:GetIdentitiesResponse/acct:identity",
+		String IdentityId = ZimbraAccount.AccountZCS().soapSelectValue("//acct:GetIdentitiesResponse/acct:identity",
 				"id");
 
 		app.zGetActiveAccount()
@@ -107,14 +107,14 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
 		// Send a message to the account(self)
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS()
 				.soapSend("<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>" + "<e t='t' a='"
 						+ app.zGetActiveAccount().EmailAddress + "'/>" + "<su>" + subject + "</su>"
 						+ "<mp ct='text/plain'>" + "<content>content" + ConfigProperties.getUniqueString() + "\n\n"
 						+ signature.dBodyText + "\n</content>" + "</mp>" + "</m>" + "</SendMsgRequest>");
 
 		// Get the mail item for the new message
-		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZWC(), "in:inbox subject:(" + subject + ")");
+		MailItem mail = MailItem.importFromSOAP(ZimbraAccount.AccountZCS(), "in:inbox subject:(" + subject + ")");
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -136,20 +136,20 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends UniversalCommonTest {
 		// Send the message
 		mailform.zSubmit();
 
-		ZimbraAccount.AccountZWC().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
+		ZimbraAccount.AccountZCS().soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>"
 				+ "<query>in:inbox subject:(" + mail.dSubject + ")</query>" + "</SearchRequest>");
 
-		String id = ZimbraAccount.AccountZWC().soapSelectValue("//mail:SearchResponse/mail:m", "id");
-		ZimbraAccount.AccountZWC()
+		String id = ZimbraAccount.AccountZCS().soapSelectValue("//mail:SearchResponse/mail:m", "id");
+		ZimbraAccount.AccountZCS()
 				.soapSend("<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + id + "' />" + "</GetMsgRequest>");
-		Element getMsgResponse = ZimbraAccount.AccountZWC().soapSelectNode("//mail:GetMsgResponse", 1);
+		Element getMsgResponse = ZimbraAccount.AccountZCS().soapSelectNode("//mail:GetMsgResponse", 1);
 		MailItem received = MailItem.importFromSOAP(getMsgResponse);
 
 		// Verify TO, Subject, Text Body,Text Signature for replied msg
 		ZAssert.assertStringContains(received.dSubject, "Re", "Verify the subject field contains the 'Fwd' prefix");
 		ZAssert.assertEquals(received.dFromRecipient.dEmailAddress, app.zGetActiveAccount().EmailAddress,
 				"Verify the from field is correct");
-		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZWC().EmailAddress,
+		ZAssert.assertEquals(received.dToRecipients.get(0).dEmailAddress, ZimbraAccount.AccountZCS().EmailAddress,
 				"Verify the to field is correct");
 		ZAssert.assertStringContains(received.dBodyText, mail.dBodyText, "Verify the body content is correct");
 		ZAssert.assertStringContains(received.dBodyText, sigBody, "Verify the signature is correct");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyToMsgWithSignatureContainingImage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyToMsgWithSignatureContainingImage.java
@@ -47,7 +47,7 @@ public class ReplyToMsgWithSignatureContainingImage extends UniversalCommonTest 
 
 	@BeforeMethod(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount account = ZimbraAccount.AccountZWC();
+		ZimbraAccount account = ZimbraAccount.AccountZCS();
 		account.authenticate();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/SignatureVcard.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/SignatureVcard.java
@@ -99,7 +99,7 @@ public class SignatureVcard extends UniversalCommonTest {
 		MailItem mail = new MailItem();
 
 		FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
-		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZWC()));
+		mail.dToRecipients.add(new RecipientItem(ZimbraAccount.AccountZCS()));
 		mail.dSubject = "subject" + ConfigProperties.getUniqueString();
 		mail.dBodyHtml = "body" + ConfigProperties.getUniqueString();
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/toaster/DeleteSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/toaster/DeleteSignature.java
@@ -49,8 +49,8 @@ public class DeleteSignature extends UniversalCommonTest {
 	 */
 	@BeforeClass(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/toaster/EditSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/toaster/EditSignature.java
@@ -52,8 +52,8 @@ public class EditSignature extends UniversalCommonTest {
 	 */
 	@BeforeClass(groups = { "always" })
 	public void CreateSignature() throws HarnessException {
-		ZimbraAccount.AccountZWC().authenticate();
-		ZimbraAccount.AccountZWC()
+		ZimbraAccount.AccountZCS().authenticate();
+		ZimbraAccount.AccountZCS()
 				.soapSend("<CreateSignatureRequest xmlns='urn:zimbraAccount'>" + "<signature name='" + this.sigName
 						+ "' >" + "<content type='text/plain'>" + this.sigBody + "</content>" + "</signature>"
 						+ "</CreateSignatureRequest>");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/trustedaddresses/TrustedDomainConvView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/trustedaddresses/TrustedDomainConvView.java
@@ -71,7 +71,7 @@ public class TrustedDomainConvView extends UniversalCommonTest {
 				+ "/data/public/mime/ExternalImg.txt";
 		FolderItem inboxFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(),SystemFolder.Inbox);
 		//Verify domain through soap- GetPrefsRequest
-		String PrefMailTrustedAddr = ZimbraAccount.AccountZWC().getPreference(
+		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference(
 				"zimbraPrefMailTrustedSenderList");
 		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdoamin.com"),
 				"Verify doamin is present /Pref/TrustedAddr");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/trustedaddresses/TrustedDomainMsgView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/trustedaddresses/TrustedDomainMsgView.java
@@ -67,7 +67,7 @@ public class TrustedDomainMsgView extends UniversalCommonTest {
 				+ "/data/public/mime/ExternalImg.txt";
 
 		//Verify domain through soap- GetPrefsRequest
-		String PrefMailTrustedAddr = ZimbraAccount.AccountZWC().getPreference(
+		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference(
 				"zimbraPrefMailTrustedSenderList");
 		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdoamin.com"),
 				"Verify doamin is present /Pref/TrustedAddr");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/trustedaddresses/TrustedEmailAddrMsgView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/trustedaddresses/TrustedEmailAddrMsgView.java
@@ -66,7 +66,7 @@ public class TrustedEmailAddrMsgView extends UniversalCommonTest {
 		+ "/data/public/mime/ExternalImg.txt";
 
 		// Verify Email id through soap GetPrefsRequest
-		String PrefMailTrustedAddr = ZimbraAccount.AccountZWC().getPreference(
+		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference(
 				"zimbraPrefMailTrustedSenderList");
 		ZAssert.assertTrue(PrefMailTrustedAddr
 				.equals("admintest@testdoamin.com"),

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/search/search/SearchMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/search/search/SearchMail.java
@@ -55,7 +55,7 @@ public class SearchMail extends PrefGroupMailByMessageTest {
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/date/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/date/GetMessage.java
@@ -54,7 +54,7 @@ public class GetMessage extends UniversalCommonTest {
 		String date = "12/25/2014";
 		String body = "text " + date + " text";
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -92,7 +92,7 @@ public class GetMessage extends UniversalCommonTest {
 		String date2 = "1/1/2015";
 		String body = "date1: " + date1 + " date2: "+ date2;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -196,7 +196,7 @@ public class GetMessage extends UniversalCommonTest {
 		String date = "12/25/2016";
 		String subject = "subject " + date;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 			"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 				"<m>" +
@@ -271,7 +271,7 @@ format7.rule = now week={weekord},{dayname}
 		}
 		String subject = "subject " + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/date/HoverOverDate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/date/HoverOverDate.java
@@ -90,7 +90,7 @@ public class HoverOverDate extends PrefGroupMailByMessageTest {
 		}
 		String subject = "subject " + ConfigProperties.getUniqueString();
 
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/phone/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/phone/GetMessage.java
@@ -53,7 +53,7 @@ public class GetMessage extends UniversalCommonTest {
 		String phonenumber = "1-877-486-9273";
 		String body = "text " + System.getProperty("line.separator") + phonenumber + System.getProperty("line.separator") + "text"+ ConfigProperties.getUniqueString() + System.getProperty("line.separator") ;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -95,7 +95,7 @@ public class GetMessage extends UniversalCommonTest {
 		String phonenumber2 = "1-877-555-9273";
 		String body = "phone1: " + phonenumber1 + " phone2: "+ phonenumber2;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -240,7 +240,7 @@ public class GetMessage extends UniversalCommonTest {
 		String phonenumber = "1-877-486-9273";
 		String subject = "subject " + phonenumber;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -280,7 +280,7 @@ public class GetMessage extends UniversalCommonTest {
 		String phonenumber = "16504755345";
 		String body = "text " + System.getProperty("line.separator") + phonenumber + System.getProperty("line.separator") + "text"+ ConfigProperties.getUniqueString() + System.getProperty("line.separator") ;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/srchhighlighter/ViewMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/srchhighlighter/ViewMessage.java
@@ -52,7 +52,7 @@ import com.zimbra.qa.selenium.projects.universal.ui.search.*;
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		String term = "search" + ConfigProperties.getUniqueString();
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/url/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/url/GetMessage.java
@@ -52,7 +52,7 @@ public class GetMessage extends UniversalCommonTest {
 		String url = "http://www.zimbra.com";
 		String body = "text " + System.getProperty("line.separator") + url + System.getProperty("line.separator") + "text"+ ConfigProperties.getUniqueString() + System.getProperty("line.separator") ;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -94,7 +94,7 @@ public class GetMessage extends UniversalCommonTest {
 		String url2 = "http://www.google.com";
 		String body = "url1: " + url1 + " url2: "+ url2;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -204,7 +204,7 @@ public class GetMessage extends UniversalCommonTest {
 		String url = "http://www.zimbra.com";
 		String subject = "subject " + url;
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -245,7 +245,7 @@ public class GetMessage extends UniversalCommonTest {
 		String body = "text &lt;" + url + "&gt; text "+ ConfigProperties.getUniqueString();
 				
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/url/HoverOverURL.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/url/HoverOverURL.java
@@ -51,7 +51,7 @@ public class HoverOverURL extends UniversalCommonTest {
 		String server = "synacor";
 		String body = "http://www." + server + ".com";
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -90,7 +90,7 @@ public class HoverOverURL extends UniversalCommonTest {
 		String server = "synacor";
 		String body = "http://www." + server + ".com";
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/ymemoticons/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/ymemoticons/GetMessage.java
@@ -55,7 +55,7 @@ public class GetMessage extends UniversalCommonTest {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		String body = "text " + Emoticons.HAPPY + " text";
 		
-		// Send the message from AccountA to the ZWC user
+		// Send the message from AccountA to the ZCS user
 		ZimbraAccount.AccountA().soapSend(
 			"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 				"<m>" +

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/AppUniversalClient.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/AppUniversalClient.java
@@ -39,10 +39,10 @@ import com.zimbra.qa.selenium.projects.universal.ui.social.PageSocial;
 import com.zimbra.qa.selenium.projects.universal.ui.tasks.*;
 
 /**
- * The <code>AppUniversalClient</code> class defines the Zimbra Ajax client.
+ * The <code>AppUniversalClient</code> class defines the Zimbra Universal client.
  * <p>
  * The <code>AppUniversalClient</code> contains all pages, folder trees,
- * dialog boxes, forms, menus for the Ajax client.
+ * dialog boxes, forms, menus for the Universal client.
  * <p>
  * In {@link UniversalCommonTest}, there is one
  * AppUniversalClient object created per test case class (ensuring
@@ -201,7 +201,7 @@ public class AppUniversalClient extends AbsApplication {
 	 */
 	@Override
 	public String myApplicationName() {
-		return ("Ajax Client");
+		return ("Universal Client");
 	}
 
 	/* (non-Javadoc)

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/FormRecoverDeletedItems.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/FormRecoverDeletedItems.java
@@ -29,7 +29,6 @@ import com.zimbra.qa.selenium.framework.util.HarnessException;
  * <p>
  * 
  * @author Matt Rhoades
- * @see http://wiki.zimbra.com/wiki/File:ZimbraSeleniumScreenshotAjaxMail7.JPG
  * 
  */
 public class FormRecoverDeletedItems extends AbsForm {

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/PageLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/PageLogin.java
@@ -122,8 +122,8 @@ public class PageLogin extends AbsTab {
 			// 1st login retry (sometime account creation remains fast and entire execution stuck due to non-existence of the account)
 			if (zIsVisiblePerPosition(Locators.zBtnLogin, 0, 0) == true || zIsVisiblePerPosition("css=div[id='ZLoginErrorPanel'] td:contains('The username or password is incorrect')", 0, 0) == true) {
 				logger.error("1st login failed or account not created successfully, retried using " + account.EmailAddress);
-				ZimbraAccount.ResetAccountZWC();
-				account = ZimbraAccount.AccountZWC();
+				ZimbraAccount.ResetAccountZCS();
+				account = ZimbraAccount.AccountZCS();
 				zSetLoginName(account.EmailAddress);
 				SleepUtil.sleepVerySmall();
 				zSetLoginPassword(account.Password);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/PageLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/PageLogin.java
@@ -55,7 +55,7 @@ public class PageLogin extends AbsTab {
 		String locator = null;
 
 		switch (appType) {
-		case AJAX:
+		case UNIVERSAL:
 			locator = Locators.zBtnLogin;
 			break;
 		default:

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/PageMain.java
@@ -148,7 +148,7 @@ public class PageMain extends AbsTab {
 			((AppUniversalClient) MyApplication).zPageLogin.zNavigateTo();
 		}
 		
-		((AppUniversalClient) MyApplication).zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		((AppUniversalClient) MyApplication).zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 	}
 
 	public void zLogout() throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/briefcase/DocumentPreview.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/briefcase/DocumentPreview.java
@@ -21,7 +21,7 @@ import com.zimbra.qa.selenium.framework.util.HarnessException;
 
 /**
  * The <code>PreviewDocument<code> object defines a read-only view of a document
- * in the Zimbra Ajax client.
+ * in the Zimbra Universal client.
  * <p>
  * This class can be used to extract data from the document, such as Name,
  * message body. 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/calendar/FormApptNew.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/calendar/FormApptNew.java
@@ -33,7 +33,7 @@ import com.zimbra.qa.selenium.projects.universal.ui.AutocompleteEntry.Icon;
 
 /**
  * The <code>FormApptNew<code> object defines a compose new appointment view in
- * the Zimbra Ajax client.
+ * the Zimbra Universal client.
  * <p>
  * This class can be used to compose a new appointment.
  * <p>

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/calendar/PageCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/calendar/PageCalendar.java
@@ -1137,11 +1137,11 @@ public class PageCalendar extends AbsTab {
 					SleepUtil.sleepMedium();
 				}
 
-				if (com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.attendee.singleday.actions.Open.organizerTest == false ||
-						com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.attendee.singleday.viewappt.Close.organizerTest == false ||
-						com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.attendee.singleday.actions.Open.organizerTest == false ||
-						com.zimbra.qa.selenium.projects.ajax.tests.calendar.mountpoints.viewer.viewappt.VerifyDisabledUI.organizerTest == false ||
-						com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.organizer.singleday.create.CreateMeetingWithDL.organizerTest == false) {
+				if (com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.attendee.singleday.actions.Open.organizerTest == false ||
+						com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.attendee.singleday.viewappt.Close.organizerTest == false ||
+						com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.attendee.singleday.actions.Open.organizerTest == false ||
+						com.zimbra.qa.selenium.projects.universal.tests.calendar.mountpoints.viewer.viewappt.VerifyDisabledUI.organizerTest == false ||
+						com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.organizer.singleday.create.CreateMeetingWithDL.organizerTest == false) {
 					page = null;
 				} else {
 					page = new FormApptNew(this.MyApplication);
@@ -1348,8 +1348,8 @@ public class PageCalendar extends AbsTab {
 					this.zWaitForBusyOverlay();
 				}
 
-				if (com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.attendee.singleday.actions.CreateACopy.organizerTest == false ||
-						com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.attendee.singleday.viewappt.CreateACopy.organizerTest == false) {
+				if (com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.attendee.singleday.actions.CreateACopy.organizerTest == false ||
+						com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.attendee.singleday.viewappt.CreateACopy.organizerTest == false) {
 					page = new DialogInformational(DialogInformational.DialogWarningID.InformationalDialog, MyApplication, ((AppUniversalClient) MyApplication).zPageCalendar);
 				} else {
 					page = null;

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/calendar/QuickAddAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/calendar/QuickAddAppointment.java
@@ -293,8 +293,8 @@ public class QuickAddAppointment extends AbsTab {
 		if (appt.getStartTime() != null) {
 			zFillField(Field.StartDate, appt.getStartTime());
 
-			if (com.zimbra.qa.selenium.projects.ajax.tests.calendar.appointments.quickadd.CreateAllDayAppointment.allDayTest == false
-					|| com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.organizer.allday.minicalendar.CreateAllDayMeeting.allDayTest == false) {
+			if (com.zimbra.qa.selenium.projects.universal.tests.calendar.appointments.quickadd.CreateAllDayAppointment.allDayTest == false
+					|| com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.organizer.allday.minicalendar.CreateAllDayMeeting.allDayTest == false) {
 				zFillField(Field.StartTime, appt.getStartTime());
 			}
 		}
@@ -303,8 +303,8 @@ public class QuickAddAppointment extends AbsTab {
 		if (appt.getEndTime() != null) {
 			zFillField(Field.EndDate, appt.getEndTime());
 
-			if (com.zimbra.qa.selenium.projects.ajax.tests.calendar.appointments.quickadd.CreateAllDayAppointment.allDayTest == false
-					|| com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.organizer.allday.minicalendar.CreateAllDayMeeting.allDayTest == false) {
+			if (com.zimbra.qa.selenium.projects.universal.tests.calendar.appointments.quickadd.CreateAllDayAppointment.allDayTest == false
+					|| com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.organizer.allday.minicalendar.CreateAllDayMeeting.allDayTest == false) {
 				zFillField(Field.EndTime, appt.getEndTime());
 			}
 		}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/DisplayMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/DisplayMail.java
@@ -31,7 +31,7 @@ import com.zimbra.qa.selenium.projects.universal.ui.calendar.FormApptNew;
 
 /**
  * The <code>DisplayMail<code> object defines a read-only view of a message in
- * the Zimbra Ajax client.
+ * the Zimbra Universal client.
  * <p>
  * This class can be used to extract data from the message, such as To, From,
  * Subject, Received Date, message body. Additionally, it can be used to click

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/FormAddressPicker.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/FormAddressPicker.java
@@ -32,7 +32,6 @@ import com.zimbra.qa.selenium.framework.util.SleepUtil;
  * <p>
  * 
  * @author Matt Rhoades
- * @see http://wiki.zimbra.com/wiki/File:ZimbraSeleniumScreenshotAjaxMail6.JPG
  * 
  */
 public class FormAddressPicker extends AbsForm {

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/FormMailNew.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/FormMailNew.java
@@ -40,7 +40,7 @@ import com.zimbra.qa.selenium.projects.universal.ui.DialogWarning;
 
 /**
  * The <code>FormMailNew<code> object defines a compose new message view in the
- * Zimbra Ajax client.
+ * Zimbra Universal client.
  * <p>
  * This class can be used to compose a new message.
  * <p>

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/tasks/DisplayTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/tasks/DisplayTask.java
@@ -24,7 +24,7 @@ import com.zimbra.qa.selenium.framework.util.HarnessException;
 
 /**
  * The <code>DisplayMail<code> object defines a read-only view of a message
- * in the Zimbra Ajax client.
+ * in the Zimbra Universal client.
  * <p>
  * This class can be used to extract data from the message, such as To,
  * From, Subject, Received Date, message body.  Additionally, it can

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/tasks/FormTaskNew.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/tasks/FormTaskNew.java
@@ -25,7 +25,7 @@ import com.zimbra.qa.selenium.projects.universal.ui.*;
 
 /**
  * The <code>FormMailNew<code> object defines a compose new message view
- * in the Zimbra Ajax client.
+ * in the Zimbra Universal client.
  * <p>
  * This class can be used to compose a new message.
  * <p>


### PR DESCRIPTION
ZCS-3363: Use single AccountZCS instead of ZWC/ZUC/ZMC/ZTC/ZHC to decrease the maintenance and replace ajax reference with universal.

1. There are 100s of places where either:
- Ajax code is called
- Ajax account is used
- Testcase objective refers to Ajax client

First, we need to replace all the code accordingly for Universal UI selenium tests before we do anything else.

2. We are creating initial account with ZWC (for Ajax), ZUC (for Universal), ZHC, ZTC & ZMT for respective clients but that is just initial account. We just need to have one initial account ZCS otherwise we will end up doing lot of maintenance for same code in Ajax and Universal.