### PR TITLE
ZCS-3368: Dynamically select ports for multi-node/single-code environment & remove static reference from configuration 

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -30,8 +30,6 @@ browser=chrome
 server.scheme=https
 server.host=zqa-206.eng.zimbra.com
 mta.host=zqa-206.eng.zimbra.com
-server.port=443
-admin.port=7071
 
 # For dev environment, globaladmin will send SOAP to https://adminHost:7071/service/admin/soap/
 #adminHost=host.local

--- a/src/java/com/zimbra/qa/selenium/framework/util/CommandLineUtility.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/CommandLineUtility.java
@@ -219,10 +219,10 @@ public class CommandLineUtility {
 	}
 
 	 public static String cmdExecOnServer(String email, String secret) {
-        String host = ZimbraAccount.AccountZWC().zGetAccountStoreHost();
+        String host = ZimbraAccount.AccountZCS().zGetAccountStoreHost();
         String user = "root";
         String password = "zimbra";
-        String command1 = "su - zimbra -c 'zmtotp -a " + email + " -s " + secret + "'";
+        String command = "su - zimbra -c 'zmtotp -a " + email + " -s " + secret + "'";
         String totp = "0";
         try {
 
@@ -234,10 +234,10 @@ public class CommandLineUtility {
             session.setConfig(config);
             session.connect();
             System.out.println("Connected");
-            System.out.println(command1);
+            System.out.println(command);
 
             Channel channel=session.openChannel("exec");
-            ((ChannelExec)channel).setCommand(command1);
+            ((ChannelExec)channel).setCommand(command);
             channel.setInputStream(null);
             ((ChannelExec)channel).setErrStream(System.err);
 
@@ -265,10 +265,10 @@ public class CommandLineUtility {
 	 }
 
 	 public static ArrayList<String> runCommandOnZimbraServer(String zimbraCommand) {
-        String host = ZimbraAccount.AccountZWC().zGetAccountStoreHost();
+        String host = ConfigProperties.getStringProperty("server.host");
         String user = "root";
         String password = "zimbra";
-        String command1 = "su - zimbra -c '" + zimbraCommand + "'";
+        String command = "su - zimbra -c '" + zimbraCommand + "'";
         ArrayList<String> out=null;
         try {
 
@@ -280,10 +280,10 @@ public class CommandLineUtility {
             session.setConfig(config);
             session.connect();
             System.out.println("Connected");
-            System.out.println(command1);
+            System.out.println(command);
 
             Channel channel=session.openChannel("exec");
-            ((ChannelExec)channel).setCommand(command1);
+            ((ChannelExec)channel).setCommand(command);
             channel.setInputStream(null);
             ((ChannelExec)channel).setErrStream(System.err);
 

--- a/src/java/com/zimbra/qa/selenium/framework/util/RestUtil.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/RestUtil.java
@@ -66,7 +66,7 @@ public class RestUtil {
 	protected String scheme = null;
 	protected String userInfo = null;
 	protected String host = null;
-	protected int port = 80;
+	protected int port = 0;
 	protected String path = null;
 	protected Map<String, String> QueryMap = new HashMap<String, String>();
 	protected String fragment = null;
@@ -102,9 +102,12 @@ public class RestUtil {
 	public RestUtil() {
 		logger.info("new RestUtil()");
 		
-		scheme = ConfigProperties.getStringProperty("server.scheme", "http");
-		String p = ConfigProperties.getStringProperty("server.port", "80");
-		port = Integer.parseInt(p);
+		scheme = ConfigProperties.getStringProperty("server.scheme");
+		if (scheme.equals("https")) {
+			port = 443;
+		} else {
+			port = 80;
+		}		
 		path = "service/home/~/";
 	}
 	

--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
@@ -79,7 +79,7 @@ public class ZimbraAccount {
 	protected String MyAuthToken = null;
 	protected String MyClientAuthToken = null;
 	public final static String clientAccountName = "local@host.local";
-
+	
 	// Account Attributes
 	// These attributes are set per each test class
 	protected Map<String, String> startingAccountPreferences = new HashMap<String, String>();
@@ -143,85 +143,22 @@ public class ZimbraAccount {
 		this.MyClientAuthToken = null;
 	}
 
-	// Ajax client
-	public static synchronized ZimbraAccount AccountZWC() {
-		if (_AccountZWC == null) {
-			_AccountZWC = new ZimbraAccount();
-			_AccountZWC.provision();
-			_AccountZWC.authenticate();
+	// ZCS account
+	public static synchronized ZimbraAccount AccountZCS() {
+		if (_AccountZCS == null) {
+			_AccountZCS = new ZimbraAccount();
+			_AccountZCS.provision();
+			_AccountZCS.authenticate();
 		}
-		return (_AccountZWC);
+		return (_AccountZCS);
 	}
-	public static synchronized void ResetAccountZWC() {
-		logger.warn("AccountZWC is being reset");
-		_AccountZWC = null;
+	public static synchronized void ResetAccountZCS() {
+		logger.warn("AccountZCS is being reset");
+		_AccountZCS = null;
 	}
-	private static ZimbraAccount _AccountZWC = null;
+	private static ZimbraAccount _AccountZCS = null;
 
-	// HTML client
-	public static synchronized ZimbraAccount AccountHTML() {
-		if (_AccountHTML == null) {
-			_AccountHTML = new ZimbraAccount();
-			_AccountHTML.provision();
-			_AccountHTML.authenticate();
-		}
-		return (_AccountHTML);
-	}
-	public static synchronized void ResetAccountHTML() {
-		logger.warn("AccountHTML is being reset");
-		_AccountHTML = null;
-	}
-	private static ZimbraAccount _AccountHTML = null;
-
-	// Mobile client
-	public static synchronized ZimbraAccount AccountZMC() {
-		if (_AccountZMC == null) {
-			_AccountZMC = new ZimbraAccount();
-			_AccountZMC.provision();
-			_AccountZMC.authenticate();
-		}
-		return (_AccountZMC);
-	}
-	public static synchronized void ResetAccountZMC() {
-		_AccountZMC = null;
-	}
-	private static ZimbraAccount _AccountZMC = null;
-
-	// Touch client
-	public static synchronized ZimbraAccount AccountZTC() {
-		if (_AccountZTC == null) {
-			_AccountZTC = new ZimbraAccount();
-			_AccountZTC.provision();
-			_AccountZTC.authenticate();
-		}
-		return (_AccountZTC);
-	}
-	public static synchronized void ResetAccountZTC() {
-		logger.warn("AccountZTC is being reset");
-		_AccountZTC = null;
-	}
-	private static ZimbraAccount _AccountZTC = null;
-
-	// Universal client
-	public static synchronized ZimbraAccount AccountZUC() {
-		if (_AccountZUC == null) {
-			_AccountZUC = new ZimbraAccount();
-			_AccountZUC.provision();
-			_AccountZUC.authenticate();
-		}
-		return (_AccountZUC);
-	}
-	public static synchronized void ResetAccountZUC() {
-		logger.warn("AccountZUC is being reset");
-		_AccountZUC = null;
-	}
-	private static ZimbraAccount _AccountZUC = null;
-
-	/**
-	 * Get a general use account for interacting with the test account
-	 *
-	 * @return a general use ZimbraAccount
-	 */
+	// Test accounts
 	public static synchronized ZimbraAccount AccountA() {
 		if (_AccountA == null) {
 			_AccountA = new ZimbraAccount();
@@ -373,6 +310,7 @@ public class ZimbraAccount {
 	 * will have references to server1.
 	 */
 	public static void reset() {
+		ZimbraAccount._AccountZCS = null;
 		ZimbraAccount._AccountA = null;
 		ZimbraAccount._AccountB = null;
 		ZimbraAccount._AccountC = null;
@@ -386,11 +324,6 @@ public class ZimbraAccount {
 		ZimbraAccount._Account8 = null;
 		ZimbraAccount._Account9 = null;
 		ZimbraAccount._Account10 = null;
-		ZimbraAccount._AccountZWC = null;
-		ZimbraAccount._AccountHTML = null;
-		ZimbraAccount._AccountZMC = null;
-		ZimbraAccount._AccountZTC = null;
-		ZimbraAccount._AccountZUC = null;
 	}
 
 	// Set the default account settings
@@ -732,7 +665,6 @@ public class ZimbraAccount {
 				throw new HarnessException("Unable to modify preference " + soapLastResponse());
 
 		} catch (HarnessException e) {
-			// TODO: I would prefer to throw HarnessException here
 			logger.error("Unable to modify preference", e);
 		}
 
@@ -887,17 +819,12 @@ public class ZimbraAccount {
 			ExecuteHarnessMain.tracer.warn("Unable to parse " + request);
 		}
 
-		// TODO: need to watch for certain SOAP requests, such
-		// as ModifyPrefsRequest, which could trigger a client reload
-		//
-
 		return (soapClient.sendSOAP(request));
 	}
 
 	/**
 	 * Match an xpath or regex from the last SOAP response if xpath == null,
-	 * then use the root element - TODO: not yet supported if attr == null,
-	 * value is element text. if attr != null, value is attr value if regex ==
+	 * then use the root element value is element text. if attr != null, value is attr value if regex ==
 	 * null, return true if xpath matches. If regex != null, a regex to match
 	 * against the value
 	 *
@@ -907,8 +834,6 @@ public class ZimbraAccount {
 	 * @return
 	 */
 	public boolean soapMatch(String xpath, String attr, String regex) {
-
-		// TODO: support xpath == null
 
 		// Find all nodes that match the expath
 		Element[] elements = soapClient.selectNodes(xpath);
@@ -1372,49 +1297,37 @@ public class ZimbraAccount {
 
 		protected boolean setURI(Element request) throws HarnessException {
 
-			// TODO: need to get URI settings from config.properties
-
-			String scheme = ConfigProperties.getStringProperty("server.scheme", "http");
+			String scheme = ConfigProperties.getStringProperty("server.scheme");
 			String userInfo = null;
-			// String host = ConfigProperties.getStringProperty("server.host",
-			// "zqa-062.lab.zimbra.com");
-			String host = ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".server.host",
-					ConfigProperties.getStringProperty("server.host"));
-			String p = ConfigProperties.getStringProperty("server.port", "80");
-			int port = Integer.parseInt(p);
+			String host = ConfigProperties.getStringProperty("server.host");
 			String path = "/";
 			String query = null;
 			String fragment = null;
+			int port = ExecuteHarnessMain.serverPort;
 
 			String namespace = getNamespace(request);
 			logger.debug("namespace: " + namespace);
 
 			if (namespace.equals("urn:zimbraAdmin")) {
-
 				// https://server.com:7071/service/admin/soap/
 				scheme = "https";
 				path = "/service/admin/soap/";
-				port = Integer
-						.parseInt(ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".admin.port",
-								ConfigProperties.getStringProperty("admin.port")));
+				port = ExecuteHarnessMain.adminPort;
 
 			} else if (namespace.equals("urn:zimbraAccount")) {
-
 				// http://server.com:80/service/soap/
 				path = "/service/soap/";
 
 			} else if (namespace.equals("urn:zimbraMail")) {
-
 				// http://server.com:80/service/soap/
 				path = "/service/soap/";
 
 			} else if (namespace.equals("urn:zimbra")) {
-
 				// http://server.com:80/service/soap/
 				path = "/service/soap/";
 
 			} else {
-				throw new HarnessException("Unsupported qname: " + namespace + ".  Need to implement setURI for it.");
+				throw new HarnessException("Unsupported qname: " + namespace + ". Need to implement setURI for it.");
 			}
 
 			try {
@@ -1422,7 +1335,7 @@ public class ZimbraAccount {
 				logger.debug("scheme: " + scheme);
 				logger.debug("userInfo: " + userInfo);
 				logger.debug("Host: " + host);
-				logger.debug("Port: " + port);
+				logger.debug("Port: " + ExecuteHarnessMain.adminPort);
 				logger.debug("Path: " + path);
 				logger.debug("Query: " + query);
 				logger.debug("Fragment: " + fragment);
@@ -1683,7 +1596,7 @@ public class ZimbraAccount {
 						initialState.addCookie(authCookie);
 						mClient.setState(initialState);
 					} catch (URISyntaxException e) {
-						// TODO: how to handle this?
+						System.err.println("A exception occurred " + e.getMessage());
 					}
 
 				}
@@ -1750,7 +1663,6 @@ public class ZimbraAccount {
 		@Override
 		public Element invoke(Element arg0, boolean arg1, boolean arg2, String arg3, String arg4, String arg5,
 				NotificationFormat arg6, String arg7) throws IOException, HttpException, ServiceException {
-			// TODO Auto-generated method stub
 			return null;
 		}
 
@@ -1758,16 +1670,11 @@ public class ZimbraAccount {
 		public Future<HttpResponse> invokeAsync(Element arg0, boolean arg1, boolean arg2, String arg3, String arg4,
 				String arg5, NotificationFormat arg6, String arg7, FutureCallback<HttpResponse> arg8)
 				throws IOException {
-			// TODO Auto-generated method stub
 			return null;
 		}
 
 	}
 
-	/**
-	 * @param args
-	 * @throws HarnessException
-	 */
 	public static void main(String[] args) throws HarnessException {
 
 		// String domain =

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCommonTest.java
@@ -91,7 +91,7 @@ public class AjaxCommonTest {
 	public void commonTestBeforeSuite() throws HarnessException, IOException, InterruptedException, SAXException {
 
 		logger.info("BeforeSuite: start");
-		ZimbraAccount.ResetAccountZWC();
+		ZimbraAccount.ResetAccountZCS();
 
 		try {
 
@@ -169,17 +169,17 @@ public class AjaxCommonTest {
 
 			// If the current test accounts preferences match, then the account
 			// can be used
-			if (!ZimbraAccount.AccountZWC().compareAccountPreferences(startingAccountPreferences)) {
+			if (!ZimbraAccount.AccountZCS().compareAccountPreferences(startingAccountPreferences)) {
 
 				logger.info("BeforeMethod: startingAccountPreferences do not match active account");
 
 				// Reset the account
-				ZimbraAccount.ResetAccountZWC();
+				ZimbraAccount.ResetAccountZCS();
 
 				// Create a new account
 				// Set the preferences accordingly
-				ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
-				ZimbraAccount.AccountZWC().modifyUserZimletPreferences(startingUserZimletPreferences);
+				ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
+				ZimbraAccount.AccountZCS().modifyUserZimletPreferences(startingUserZimletPreferences);
 			}
 
 		}
@@ -191,20 +191,20 @@ public class AjaxCommonTest {
 
 			// If the current test accounts preferences match, then the account
 			// can be used
-			if (!ZimbraAccount.AccountZWC().compareUserZimletPreferences(startingUserZimletPreferences)) {
+			if (!ZimbraAccount.AccountZCS().compareUserZimletPreferences(startingUserZimletPreferences)) {
 
 				logger.info("BeforeMethod: startingAccountZimletPreferences do not match active account");
-				ZimbraAccount.ResetAccountZWC();
-				ZimbraAccount.AccountZWC().modifyAccountPreferences(startingAccountPreferences);
-				ZimbraAccount.AccountZWC().modifyUserZimletPreferences(startingUserZimletPreferences);
+				ZimbraAccount.ResetAccountZCS();
+				ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
+				ZimbraAccount.AccountZCS().modifyUserZimletPreferences(startingUserZimletPreferences);
 			}
 
-			ZimbraAccount.AccountZWC().modifyUserZimletPreferences(startingUserZimletPreferences);
+			ZimbraAccount.AccountZCS().modifyUserZimletPreferences(startingUserZimletPreferences);
 		}
 
-		// If AccountZWC is not currently logged in, then login now
-		if (!ZimbraAccount.AccountZWC().equals(app.zGetActiveAccount())) {
-			logger.info("BeforeMethod: AccountZWC is not currently logged in");
+		// If AccountZCS is not currently logged in, then login now
+		if (!ZimbraAccount.AccountZCS().equals(app.zGetActiveAccount())) {
+			logger.info("BeforeMethod: AccountZCS is not currently logged in");
 
 			if (app.zPageMain.zIsActive())
 				try {
@@ -285,8 +285,8 @@ public class AjaxCommonTest {
 		logger.info("AfterClass: start");
 
 		ZimbraAccount currentAccount = app.zGetActiveAccount();
-		if (currentAccount != null && currentAccount.accountIsDirty && currentAccount == ZimbraAccount.AccountZWC()) {
-			ZimbraAccount.ResetAccountZWC();
+		if (currentAccount != null && currentAccount.accountIsDirty && currentAccount == ZimbraAccount.AccountZCS()) {
+			ZimbraAccount.ResetAccountZCS();
 		}
 
 		logger.info("AfterClass: finish");
@@ -466,8 +466,8 @@ public class AjaxCommonTest {
 
 		if(testResult.getStatus() == ITestResult.FAILURE){
 			ZimbraAccount currentAccount = app.zGetActiveAccount();
-			if (currentAccount != null && currentAccount.accountIsDirty && currentAccount == ZimbraAccount.AccountZWC()) {
-				ZimbraAccount.ResetAccountZWC();
+			if (currentAccount != null && currentAccount.accountIsDirty && currentAccount == ZimbraAccount.AccountZCS()) {
+				ZimbraAccount.ResetAccountZCS();
 			}
 		}
 
@@ -476,7 +476,7 @@ public class AjaxCommonTest {
 
 	@AfterMethod(groups = { "performance" })
 	public void performanceTestAfterMethod() {
-		ZimbraAccount.ResetAccountZWC();
+		ZimbraAccount.ResetAccountZCS();
 	}
 
 	@DataProvider(name = "DataProviderSupportedCharsets")
@@ -640,7 +640,7 @@ public class AjaxCommonTest {
 
 	public void zFreshLogin() {
 
-		ZimbraAccount.ResetAccountZWC();
+		ZimbraAccount.ResetAccountZCS();
 
 		try {
 			if (ConfigProperties.getAppType() == AppType.AJAX) {
@@ -666,8 +666,8 @@ public class AjaxCommonTest {
 
 			((AppAjaxClient) app).zPageLogin.sOpen(ConfigProperties.getLogoutURL());
 			if (ConfigProperties.getAppType() == AppType.AJAX) {
-				if (ZimbraAccount.AccountZWC() != null) {
-					((AppAjaxClient) app).zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+				if (ZimbraAccount.AccountZCS() != null) {
+					((AppAjaxClient) app).zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 				} else {
 					((AppAjaxClient) app).zPageLogin.zLogin(ZimbraAccount.Account10());
 				}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/PageLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/PageLogin.java
@@ -122,8 +122,8 @@ public class PageLogin extends AbsTab {
 			// 1st login retry (sometime account creation remains fast and entire execution stuck due to non-existence of the account)
 			if (zIsVisiblePerPosition(Locators.zBtnLogin, 0, 0) == true || zIsVisiblePerPosition("css=div[id='ZLoginErrorPanel'] td:contains('The username or password is incorrect')", 0, 0) == true) {
 				logger.error("1st login failed or account not created successfully, retried using " + account.EmailAddress);
-				ZimbraAccount.ResetAccountZWC();
-				account = ZimbraAccount.AccountZWC();
+				ZimbraAccount.ResetAccountZCS();
+				account = ZimbraAccount.AccountZCS();
 				zSetLoginName(account.EmailAddress);
 				SleepUtil.sleepVerySmall();
 				zSetLoginPassword(account.Password);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/PageMain.java
@@ -145,7 +145,7 @@ public class PageMain extends AbsTab {
 			((AppAjaxClient) MyApplication).zPageLogin.zNavigateTo();
 		}
 		
-		((AppAjaxClient) MyApplication).zPageLogin.zLogin(ZimbraAccount.AccountZWC());
+		((AppAjaxClient) MyApplication).zPageLogin.zLogin(ZimbraAccount.AccountZCS());
 	}
 
 	public void zLogout() throws HarnessException {


### PR DESCRIPTION
ZCS-3368: Dynamically select ports for multi-node/single-code environment & remove static reference from configuration.

- Removed admin.port and server.port from config.properties

- According to server type, ports would be selected:

if (totalZimbraProxyServers >=1) {
    adminPort = 9071;
} else {
    adminPort = 7071;
}

if (ConfigProperties.getStringProperty("server.scheme").equals("https")) {
    serverPort = 443;
} else {
    serverPort = 80;
}

