### PR TITLE
ZCS-2999: Fixed ViewAppointment_01 testcase for multi-node - failed because of wrong port

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/pub/ViewAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/pub/ViewAppointment.java
@@ -19,6 +19,7 @@ package com.zimbra.qa.selenium.projects.ajax.tests.calendar.mountpoints.pub;
 import java.util.Calendar;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
+import com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain;
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.projects.ajax.core.CalendarWorkWeekTest;
@@ -29,70 +30,80 @@ public class ViewAppointment extends CalendarWorkWeekTest {
 		logger.info("New "+ ViewAppointment.class.getCanonicalName());
 		super.startingPage = app.zPageCalendar;
 	}
-	
+
 	@Bugs(ids = "47629")
-	@Test( description = " HTML view of public shared calendar not showing appointments",
+	@Test( description = "HTML view of public shared calendar not showing appointments",
 			groups = { "sanity", "L0" })
-			
+
 	public void ViewAppointment_01() throws HarnessException {
-		
-		String apptSubject = ConfigProperties.getUniqueString();
-		String apptContent = ConfigProperties.getUniqueString();
-		String foldername = "folder" + ConfigProperties.getUniqueString();
-		
-		Calendar now = this.calendarWeekDayUTC;
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 02, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 03, 0, 0);
-		
-		FolderItem calendarFolder = FolderItem.importFromSOAP(ZimbraAccount.Account1(), FolderItem.SystemFolder.Calendar);
-		
-		// Create a folder to share
-		ZimbraAccount.Account1().soapSend(
-					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
-				+		"<folder name='" + foldername + "' l='" + calendarFolder.getId() + "' view='appointment'/>"
-				+	"</CreateFolderRequest>");
-		
-		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.Account1(), foldername);
-		
-		// Share it
-		ZimbraAccount.Account1().soapSend(
-					"<FolderActionRequest xmlns='urn:zimbraMail'>"
-				+		"<action id='"+ folder.getId() +"' op='grant'>"
-				+			"<grant inh='1' gt='pub' perm='r' view='appointment'/>"
-				+		"</action>"
-				+	"</FolderActionRequest>");
-				
-		// Create appointment
-		ZimbraAccount.Account1().soapSend(
-				"<CreateAppointmentRequest xmlns='urn:zimbraMail'>"
-				+		"<m l='"+ folder.getId() +"' >"
-				+			"<inv method='REQUEST' type='event' status='CONF' draft='0' class='PUB' fb='B' transp='O' allDay='0' name='"+ apptSubject +"'>"
-				+				"<s d='"+ startUTC.toTimeZone(ZTimeZone.TimeZoneEST.getID()).toYYYYMMDDTHHMMSS() +"' tz='"+ ZTimeZone.TimeZoneEST.getID() +"'/>"
-				+				"<e d='"+ endUTC.toTimeZone(ZTimeZone.TimeZoneEST.getID()).toYYYYMMDDTHHMMSS() +"' tz='"+ ZTimeZone.TimeZoneEST.getID() +"'/>"
-				+				"<or a='"+ ZimbraAccount.Account1().EmailAddress +"'/>"
-				+				"<at role='REQ' ptst='NE' rsvp='1' a='" + app.zGetActiveAccount().EmailAddress + "'/>"
-				+			"</inv>"
-				+			"<e a='"+ app.zGetActiveAccount().EmailAddress +"' t='t'/>"
-				+			"<su>"+ apptSubject +"</su>"
-				+			"<mp content-type='text/plain'>"
-				+				"<content>" + apptContent + "</content>"
-				+			"</mp>"
-				+		"</m>"
-				+	"</CreateAppointmentRequest>");
-		
-		// Verify appointment exists in current view
-        ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
 
-        if ( ConfigProperties.getStringProperty("server.host").equals(ConfigProperties.getStringProperty("mta.host")) ) {
-        	app.zPageCalendar.sOpen("https://" + ConfigProperties.getStringProperty("server.host") + ":8443/home/" + ZimbraAccount.Account1().EmailAddress + "/Calendar/" + foldername + ".html");
-		} else {
-			app.zPageCalendar.sOpen("https://" + ZimbraAccount.Account1().zGetAccountStoreHost() + "/home/" + ZimbraAccount.Account1().EmailAddress + "/Calendar/" + foldername + ".html");
+		try {
+			String apptSubject = ConfigProperties.getUniqueString();
+
+			String apptContent = ConfigProperties.getUniqueString();
+			String foldername = "folder" + ConfigProperties.getUniqueString();
+
+			Calendar now = this.calendarWeekDayUTC;
+			ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 02, 0, 0);
+			ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 03, 0, 0);
+
+			FolderItem calendarFolder = FolderItem.importFromSOAP(ZimbraAccount.Account1(), FolderItem.SystemFolder.Calendar);
+
+			// Create a folder to share
+			ZimbraAccount.Account1().soapSend(
+						"<CreateFolderRequest xmlns='urn:zimbraMail'>"
+					+		"<folder name='" + foldername + "' l='" + calendarFolder.getId() + "' view='appointment'/>"
+					+	"</CreateFolderRequest>");
+
+			FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.Account1(), foldername);
+
+			// Share it
+			ZimbraAccount.Account1().soapSend(
+						"<FolderActionRequest xmlns='urn:zimbraMail'>"
+					+		"<action id='"+ folder.getId() +"' op='grant'>"
+					+			"<grant inh='1' gt='pub' perm='r' view='appointment'/>"
+					+		"</action>"
+					+	"</FolderActionRequest>");
+
+			// Create appointment
+			ZimbraAccount.Account1().soapSend(
+					"<CreateAppointmentRequest xmlns='urn:zimbraMail'>"
+					+		"<m l='"+ folder.getId() +"' >"
+					+			"<inv method='REQUEST' type='event' status='CONF' draft='0' class='PUB' fb='B' transp='O' allDay='0' name='"+ apptSubject +"'>"
+					+				"<s d='"+ startUTC.toTimeZone(ZTimeZone.TimeZoneEST.getID()).toYYYYMMDDTHHMMSS() +"' tz='"+ ZTimeZone.TimeZoneEST.getID() +"'/>"
+					+				"<e d='"+ endUTC.toTimeZone(ZTimeZone.TimeZoneEST.getID()).toYYYYMMDDTHHMMSS() +"' tz='"+ ZTimeZone.TimeZoneEST.getID() +"'/>"
+					+				"<or a='"+ ZimbraAccount.Account1().EmailAddress +"'/>"
+					+				"<at role='REQ' ptst='NE' rsvp='1' a='" + app.zGetActiveAccount().EmailAddress + "'/>"
+					+			"</inv>"
+					+			"<e a='"+ app.zGetActiveAccount().EmailAddress +"' t='t'/>"
+					+			"<su>"+ apptSubject +"</su>"
+					+			"<mp content-type='text/plain'>"
+					+				"<content>" + apptContent + "</content>"
+					+			"</mp>"
+					+		"</m>"
+					+	"</CreateAppointmentRequest>");
+
+			// Verify appointment exists in current view
+			ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
+
+			int port;
+			if ( ConfigProperties.getStringProperty("server.host").equals(ZimbraAccount.Account1().zGetAccountStoreHost()) ) {
+				port = 8443;
+			} else {
+				port = ExecuteHarnessMain.serverPort;
+			}
+			
+			app.zPageCalendar.sOpen(ConfigProperties.getStringProperty("server.scheme") + "://"
+					+ ConfigProperties.getStringProperty("server.host") + ":" + port + "/home/"
+					+ ZimbraAccount.Account1().EmailAddress + "/Calendar/" + foldername + ".html");
+
+			ZAssert.assertTrue(
+					app.zPageCalendar.sIsElementPresent("css=div[class^='ZhCalMonthAppt']:contains('" + apptSubject + "')"),
+					"Appointment is visible");
+
+		} finally {
+			ZimbraURI uri = new ZimbraURI(ZimbraURI.getBaseURI());
+			app.zPageCalendar.sOpen(uri.toString());
 		}
-        
-        ZAssert.assertTrue(app.zPageCalendar.sIsElementPresent("css=div[class^='ZhCalMonthAppt']:contains('" + apptSubject + "')"), "Appointment is visible");
-        ZimbraURI uri = new ZimbraURI(ZimbraURI.getBaseURI());
-        app.zPageCalendar.sOpen(uri.toString());
-
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/mountpoints/pub/ViewAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/mountpoints/pub/ViewAppointment.java
@@ -19,9 +19,10 @@ package com.zimbra.qa.selenium.projects.universal.tests.calendar.mountpoints.pub
 import java.util.Calendar;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
+import com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain;
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.universal.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.ajax.core.CalendarWorkWeekTest;
 
 public class ViewAppointment extends CalendarWorkWeekTest {
 
@@ -29,70 +30,80 @@ public class ViewAppointment extends CalendarWorkWeekTest {
 		logger.info("New "+ ViewAppointment.class.getCanonicalName());
 		super.startingPage = app.zPageCalendar;
 	}
-	
+
 	@Bugs(ids = "47629")
-	@Test( description = " HTML view of public shared calendar not showing appointments",
+	@Test( description = "HTML view of public shared calendar not showing appointments",
 			groups = { "sanity", "L0" })
-			
+
 	public void ViewAppointment_01() throws HarnessException {
-		
-		String apptSubject = ConfigProperties.getUniqueString();
-		String apptContent = ConfigProperties.getUniqueString();
-		String foldername = "folder" + ConfigProperties.getUniqueString();
-		
-		Calendar now = this.calendarWeekDayUTC;
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 02, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 03, 0, 0);
-		
-		FolderItem calendarFolder = FolderItem.importFromSOAP(ZimbraAccount.Account1(), FolderItem.SystemFolder.Calendar);
-		
-		// Create a folder to share
-		ZimbraAccount.Account1().soapSend(
-					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
-				+		"<folder name='" + foldername + "' l='" + calendarFolder.getId() + "' view='appointment'/>"
-				+	"</CreateFolderRequest>");
-		
-		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.Account1(), foldername);
-		
-		// Share it
-		ZimbraAccount.Account1().soapSend(
-					"<FolderActionRequest xmlns='urn:zimbraMail'>"
-				+		"<action id='"+ folder.getId() +"' op='grant'>"
-				+			"<grant inh='1' gt='pub' perm='r' view='appointment'/>"
-				+		"</action>"
-				+	"</FolderActionRequest>");
-				
-		// Create appointment
-		ZimbraAccount.Account1().soapSend(
-				"<CreateAppointmentRequest xmlns='urn:zimbraMail'>"
-				+		"<m l='"+ folder.getId() +"' >"
-				+			"<inv method='REQUEST' type='event' status='CONF' draft='0' class='PUB' fb='B' transp='O' allDay='0' name='"+ apptSubject +"'>"
-				+				"<s d='"+ startUTC.toTimeZone(ZTimeZone.TimeZoneEST.getID()).toYYYYMMDDTHHMMSS() +"' tz='"+ ZTimeZone.TimeZoneEST.getID() +"'/>"
-				+				"<e d='"+ endUTC.toTimeZone(ZTimeZone.TimeZoneEST.getID()).toYYYYMMDDTHHMMSS() +"' tz='"+ ZTimeZone.TimeZoneEST.getID() +"'/>"
-				+				"<or a='"+ ZimbraAccount.Account1().EmailAddress +"'/>"
-				+				"<at role='REQ' ptst='NE' rsvp='1' a='" + app.zGetActiveAccount().EmailAddress + "'/>"
-				+			"</inv>"
-				+			"<e a='"+ app.zGetActiveAccount().EmailAddress +"' t='t'/>"
-				+			"<su>"+ apptSubject +"</su>"
-				+			"<mp content-type='text/plain'>"
-				+				"<content>" + apptContent + "</content>"
-				+			"</mp>"
-				+		"</m>"
-				+	"</CreateAppointmentRequest>");
-		
-		// Verify appointment exists in current view
-        ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
 
-        if ( ConfigProperties.getStringProperty("server.host").equals(ConfigProperties.getStringProperty("mta.host")) ) {
-        	app.zPageCalendar.sOpen("https://" + ConfigProperties.getStringProperty("server.host") + ":8443/home/" + ZimbraAccount.Account1().EmailAddress + "/Calendar/" + foldername + ".html");
-		} else {
-			app.zPageCalendar.sOpen("https://" + ZimbraAccount.Account1().zGetAccountStoreHost() + "/home/" + ZimbraAccount.Account1().EmailAddress + "/Calendar/" + foldername + ".html");
+		try {
+			String apptSubject = ConfigProperties.getUniqueString();
+
+			String apptContent = ConfigProperties.getUniqueString();
+			String foldername = "folder" + ConfigProperties.getUniqueString();
+
+			Calendar now = this.calendarWeekDayUTC;
+			ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 02, 0, 0);
+			ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 03, 0, 0);
+
+			FolderItem calendarFolder = FolderItem.importFromSOAP(ZimbraAccount.Account1(), FolderItem.SystemFolder.Calendar);
+
+			// Create a folder to share
+			ZimbraAccount.Account1().soapSend(
+						"<CreateFolderRequest xmlns='urn:zimbraMail'>"
+					+		"<folder name='" + foldername + "' l='" + calendarFolder.getId() + "' view='appointment'/>"
+					+	"</CreateFolderRequest>");
+
+			FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.Account1(), foldername);
+
+			// Share it
+			ZimbraAccount.Account1().soapSend(
+						"<FolderActionRequest xmlns='urn:zimbraMail'>"
+					+		"<action id='"+ folder.getId() +"' op='grant'>"
+					+			"<grant inh='1' gt='pub' perm='r' view='appointment'/>"
+					+		"</action>"
+					+	"</FolderActionRequest>");
+
+			// Create appointment
+			ZimbraAccount.Account1().soapSend(
+					"<CreateAppointmentRequest xmlns='urn:zimbraMail'>"
+					+		"<m l='"+ folder.getId() +"' >"
+					+			"<inv method='REQUEST' type='event' status='CONF' draft='0' class='PUB' fb='B' transp='O' allDay='0' name='"+ apptSubject +"'>"
+					+				"<s d='"+ startUTC.toTimeZone(ZTimeZone.TimeZoneEST.getID()).toYYYYMMDDTHHMMSS() +"' tz='"+ ZTimeZone.TimeZoneEST.getID() +"'/>"
+					+				"<e d='"+ endUTC.toTimeZone(ZTimeZone.TimeZoneEST.getID()).toYYYYMMDDTHHMMSS() +"' tz='"+ ZTimeZone.TimeZoneEST.getID() +"'/>"
+					+				"<or a='"+ ZimbraAccount.Account1().EmailAddress +"'/>"
+					+				"<at role='REQ' ptst='NE' rsvp='1' a='" + app.zGetActiveAccount().EmailAddress + "'/>"
+					+			"</inv>"
+					+			"<e a='"+ app.zGetActiveAccount().EmailAddress +"' t='t'/>"
+					+			"<su>"+ apptSubject +"</su>"
+					+			"<mp content-type='text/plain'>"
+					+				"<content>" + apptContent + "</content>"
+					+			"</mp>"
+					+		"</m>"
+					+	"</CreateAppointmentRequest>");
+
+			// Verify appointment exists in current view
+			ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
+
+			int port;
+			if ( ConfigProperties.getStringProperty("server.host").equals(ZimbraAccount.Account1().zGetAccountStoreHost()) ) {
+				port = 8443;
+			} else {
+				port = ExecuteHarnessMain.serverPort;
+			}
+			
+			app.zPageCalendar.sOpen(ConfigProperties.getStringProperty("server.scheme") + "://"
+					+ ConfigProperties.getStringProperty("server.host") + ":" + port + "/home/"
+					+ ZimbraAccount.Account1().EmailAddress + "/Calendar/" + foldername + ".html");
+
+			ZAssert.assertTrue(
+					app.zPageCalendar.sIsElementPresent("css=div[class^='ZhCalMonthAppt']:contains('" + apptSubject + "')"),
+					"Appointment is visible");
+
+		} finally {
+			ZimbraURI uri = new ZimbraURI(ZimbraURI.getBaseURI());
+			app.zPageCalendar.sOpen(uri.toString());
 		}
-        
-        ZAssert.assertTrue(app.zPageCalendar.sIsElementPresent("css=div[class^='ZhCalMonthAppt']:contains('" + apptSubject + "')"), "Appointment is visible");
-        ZimbraURI uri = new ZimbraURI(ZimbraURI.getBaseURI());
-        app.zPageCalendar.sOpen(uri.toString());
-
 	}
-
 }


### PR DESCRIPTION
ZCS-2999: Fixed ViewAppointment_01 testcase for multi-node - failed because of wrong port

Only change, must enclosed entire code with try and finally with port fix:

	if ( ConfigProperties.getStringProperty("server.host").equals(ZimbraAccount.Account1().zGetAccountStoreHost()) ) {
		port = 8443;
	} else {
		port = ExecuteHarnessMain.serverPort;
	}