### PR TITLE
ZCS-3117: Minor: Using app.zPageCalendar.zVerifyAppointmentExists instead of Refresh in case of slowness

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/MoveMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/MoveMeeting.java
@@ -78,8 +78,8 @@ public class MoveMeeting extends CalendarWorkWeekTest {
 				+		"</m>"
 				+	"</CreateAppointmentRequest>");        
 
-		// Refresh the view
-        app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
+		// Verify appointment exists in current view
+		ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
        
         // Select the appointment
         app.zPageCalendar.zListItem(Action.A_LEFTCLICK, apptSubject);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/MoveMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/MoveMeeting.java
@@ -78,8 +78,8 @@ public class MoveMeeting extends CalendarWorkWeekTest {
 				+		"</m>"
 				+	"</CreateAppointmentRequest>");        
 
-		// Refresh the view
-        app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
+		// Verify appointment exists in current view
+		ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
        
         // Select the appointment
         app.zPageCalendar.zListItem(Action.A_LEFTCLICK, apptSubject);


### PR DESCRIPTION
ZCS-3117: Minor: Using app.zPageCalendar.zVerifyAppointmentExists instead of Refresh in case of slowness