### PR TITLE
ZCS-3111: Multinode: Remove mta.host and related references from selenium config to support dynamic mta host

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -29,7 +29,6 @@ browser=chrome
 # Zimbra server settings
 server.scheme=https
 server.host=zqa-206.eng.zimbra.com
-mta.host=zqa-206.eng.zimbra.com
 
 # For dev environment, globaladmin will send SOAP to https://adminHost:7071/service/admin/soap/
 #adminHost=host.local

--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
@@ -1677,10 +1677,8 @@ public class ZimbraAccount {
 
 	public static void main(String[] args) throws HarnessException {
 
-		// String domain =
 		// ConfigProperties.getStringProperty("server.host","zqa-062.eng.zimbra.com");
-		String domain = ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".server.host",
-				ConfigProperties.getStringProperty("server.host"));
+		String domain = ConfigProperties.getStringProperty("server.host");
 
 		// Configure log4j using the basic configuration
 		BasicConfigurator.configure();


### PR DESCRIPTION
Multinode: Remove mta.host and related references from selenium config to support dynamic mta host

- Removed mta.host from config
- Multi-node will dynamically pick up the mta.host
- Optimized code and speed-up the execution for single node
- Tested changes locally and through STAF for single node and multi node both

Please view entire file to see and review the changes properly.