### PR TITLE
ZCS-3414: Fix selenium testcases those are failed due to common pattern in full result

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -1523,7 +1523,6 @@ public class ExecuteHarnessMain {
 
 	public static void main(String[] args) throws HarnessException, IOException {
 
-		String project = args[3].split("\\.")[5];
 		String sumTestsResult = "No results";
 		String executeTestsResult = "No results";
 
@@ -1536,7 +1535,7 @@ public class ExecuteHarnessMain {
 			ConfigProperties.setConfigProperties("conf/config.properties");
 
 			for (AppType appType : AppType.values()) {
-	        	if (project.contains(appType.toString().toLowerCase()) ) {
+				if (args[3].contains(appType.toString().toLowerCase()) ) {
 	        		ConfigProperties.setAppType(appType);
 	            	break;
 	        	}

--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -745,19 +745,19 @@ public class ExecuteHarnessMain {
 				testEndTime = new Date();
 				testTotalSeconds = (int) ((testEndTime.getTime()-testStartTime.getTime())/1000);
 				testTotalMinutes = new DecimalFormat("##.##").format((float) Math.round(testTotalSeconds) / 60);
-				
+
 				sHarnessLogFileFolderPath = testoutputfoldername + "\\debug\\projects";
 				sHarnessLogFilePath = sHarnessLogFileFolderPath + "\\" + sHarnessLogFileName;
 				pHarnessLogFilePath = Paths.get(sHarnessLogFileFolderPath, sHarnessLogFileName);
 				fHarnessLogFile = new File(sHarnessLogFilePath);
 				fHarnessLogFileFolder = new File(sHarnessLogFileFolderPath);
 
-				try {					
+				try {
 					if (currentRunningTest == 1) {
 						Files.write(pHarnessLogFilePath,
 								Arrays.asList("\n\n# | Test | Start Time | End Time | Duration"), Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 					}
-					
+
 					byte[] bytes = Files.readAllBytes(Paths.get(sHarnessLogFilePath));
 					String harnessLogFile = new String(bytes);
 
@@ -1392,8 +1392,9 @@ public class ExecuteHarnessMain {
 
 			// Create harness log folder and file
 			fHarnessLogFileFolder.mkdirs();
-			fHarnessLogFile.delete();
-			fHarnessLogFile.createNewFile();
+			if (!fHarnessLogFile.exists()) {
+				fHarnessLogFile.createNewFile();
+			}
 
 			Files.write(pHarnessLogFilePath, Arrays.asList(logInfo), Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 
@@ -1569,14 +1570,14 @@ public class ExecuteHarnessMain {
 
 		logger.info(executeTestsResult);
 		System.out.println("*****\n" + executeTestsResult);
-		
+
 		try {
 			Files.write(pHarnessLogFilePath, Arrays.asList("\n\n" + executeTestsResult),
 					Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		System.exit(0);
 
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/freebusy/singleday/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/freebusy/singleday/GetAppointment.java
@@ -21,9 +21,9 @@ import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.ajax.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
 
-public class GetAppointment extends CalendarWorkWeekTest {
+public class GetAppointment extends AjaxCommonTest {
 	
 	public GetAppointment() {
 		logger.info("New "+ GetAppointment.class.getCanonicalName());
@@ -51,7 +51,7 @@ public class GetAppointment extends CalendarWorkWeekTest {
 		String apptSubject = ConfigProperties.getUniqueString();
 		
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/DeleteAppointment.java
@@ -36,10 +36,10 @@ import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZDate;
 import com.zimbra.qa.selenium.framework.util.ZTimeZone;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.projects.ajax.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
 import com.zimbra.qa.selenium.projects.ajax.ui.calendar.*;
 
-public class DeleteAppointment extends CalendarWorkWeekTest {
+public class DeleteAppointment extends AjaxCommonTest {
 
 	public DeleteAppointment() {
 		logger.info("New "+ DeleteAppointment.class.getCanonicalName());
@@ -73,7 +73,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 3, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 4, 0, 0);
 
@@ -163,7 +163,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 4, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 5, 0, 0);
 
@@ -255,7 +255,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 5, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 6, 0, 0);
 
@@ -338,7 +338,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 6, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
 
@@ -417,7 +417,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 		// Create three appointments on the server
 		String subject1 = ConfigProperties.getUniqueString();
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
 		String tz = ZTimeZone.getLocalTimeZone().getID();
@@ -584,7 +584,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
 
@@ -665,7 +665,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 
@@ -737,7 +737,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 		// Create three appointments on the server
 		String subject1 = ConfigProperties.getUniqueString();
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
 		String tz = ZTimeZone.getLocalTimeZone().getID();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/GetAppointment.java
@@ -24,9 +24,9 @@ import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.AppointmentItem;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.ajax.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
 
-public class GetAppointment extends CalendarWorkWeekTest {
+public class GetAppointment extends AjaxCommonTest {
 	
 	@SuppressWarnings("serial")
 	public GetAppointment() {
@@ -53,7 +53,7 @@ public class GetAppointment extends CalendarWorkWeekTest {
 		
 		
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		
@@ -108,7 +108,7 @@ public class GetAppointment extends CalendarWorkWeekTest {
 		
 		
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/conversation/AcceptProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/conversation/AcceptProposeNewTime.java
@@ -57,10 +57,10 @@ public class AcceptProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 5, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 6, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/conversation/DeclineProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/conversation/DeclineProposeNewTime.java
@@ -57,10 +57,10 @@ public class DeclineProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 17, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 19, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 6, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/message/AcceptProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/message/AcceptProposeNewTime.java
@@ -57,10 +57,10 @@ public class AcceptProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 15, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 15, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 16, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/message/DeclineProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/message/DeclineProposeNewTime.java
@@ -57,10 +57,10 @@ public class DeclineProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 17, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate ModifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate ModifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 19, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
+		ZDate ModifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
+		ZDate ModifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/conversation/AcceptProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/conversation/AcceptProposeNewTime.java
@@ -60,10 +60,10 @@ public class AcceptProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/conversation/DeclineProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/conversation/DeclineProposeNewTime.java
@@ -60,10 +60,10 @@ public class DeclineProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 17, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 19, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/listview/Accept.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/listview/Accept.java
@@ -26,7 +26,7 @@ import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.projects.ajax.core.*;
 
-public class Accept extends CalendarWorkWeekTest {
+public class Accept extends AjaxCommonTest {
 
 	@SuppressWarnings("serial")
 	public Accept() {
@@ -46,7 +46,7 @@ public class Accept extends CalendarWorkWeekTest {
 
 		String apptSubject = ConfigProperties.getUniqueString();
 
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 23, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 24, 0, 0);
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/listview/Decline.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/listview/Decline.java
@@ -27,7 +27,7 @@ import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.projects.ajax.core.*;
 import com.zimbra.qa.selenium.projects.ajax.ui.calendar.DialogConfirmationDeclineAppointment;
 
-public class Decline extends CalendarWorkWeekTest {
+public class Decline extends AjaxCommonTest {
 
 	@SuppressWarnings("serial")
 	public Decline() {
@@ -47,7 +47,7 @@ public class Decline extends CalendarWorkWeekTest {
 
 		String apptSubject = ConfigProperties.getUniqueString();
 
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 
@@ -156,7 +156,7 @@ public class Decline extends CalendarWorkWeekTest {
 
 		String apptSubject = ConfigProperties.getUniqueString();
 
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 16, 0, 0);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/listview/Tentative.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/listview/Tentative.java
@@ -26,7 +26,7 @@ import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.projects.ajax.core.*;
 
-public class Tentative extends CalendarWorkWeekTest {
+public class Tentative extends AjaxCommonTest {
 
 	@SuppressWarnings("serial")
 	public Tentative() {
@@ -46,7 +46,7 @@ public class Tentative extends CalendarWorkWeekTest {
 
 		String apptSubject = ConfigProperties.getUniqueString();
 
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/message/AcceptProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/message/AcceptProposeNewTime.java
@@ -65,8 +65,8 @@ public class AcceptProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
 		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/message/DeclineProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/message/DeclineProposeNewTime.java
@@ -65,10 +65,10 @@ public class DeclineProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 17, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 19, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 15, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/actions/Open.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/actions/Open.java
@@ -35,6 +35,8 @@ public class Open extends CalendarWorkWeekTest {
 	
 	public void Open_01() throws HarnessException {
 		
+		organizerTest = false;
+		
 		String apptSubject = ConfigProperties.getUniqueString();
 		String apptContent = ConfigProperties.getUniqueString();
 		String foldername = "folder" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/viewappt/Close.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/viewappt/Close.java
@@ -35,6 +35,8 @@ public class Close extends CalendarWorkWeekTest {
 			
 	public void Close_01() throws HarnessException {
 		
+		organizerTest = false;
+		
 		String apptSubject = ConfigProperties.getUniqueString();
 		String apptContent = ConfigProperties.getUniqueString();
 		String foldername = "folder" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/search/search/SearchAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/search/search/SearchAppointment.java
@@ -25,10 +25,10 @@ import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.ajax.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
 import com.zimbra.qa.selenium.projects.ajax.ui.calendar.PageCalendar.Locators;
 
-public class SearchAppointment extends CalendarWorkWeekTest {
+public class SearchAppointment extends AjaxCommonTest {
 
 	int pollIntervalSeconds = 60;
 	
@@ -41,7 +41,7 @@ public class SearchAppointment extends CalendarWorkWeekTest {
 			groups = { "functional","L2" })
 	
 	public void SearchAppointment_01() throws HarnessException {
-		ZDate startDate = new ZDate(this.calendarWeekDayUTC.get(Calendar.YEAR), this.calendarWeekDayUTC.get(Calendar.MONTH) + 1, this.calendarWeekDayUTC.get(Calendar.DAY_OF_MONTH), this.calendarWeekDayUTC.get(Calendar.HOUR_OF_DAY), 0, 0);
+		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 		
 		// Create a meeting
 		String subject = "appointment" + ConfigProperties.getUniqueString();
@@ -55,14 +55,15 @@ public class SearchAppointment extends CalendarWorkWeekTest {
 				"location" + ConfigProperties.getUniqueString(),
 				null);
 
-		// Refresh the calendar
-		app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
+		// Refresh the pane
+		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
 		
 		// Verify appointment exists on the server 
         AppointmentItem actual = AppointmentItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject + ")");
 		ZAssert.assertNotNull(actual, "Verify the new appointment is created");
 		
 		// Search for the appointment
+		app.zPageSearch.zToolbarPressPulldown(Button.B_SEARCHTYPE, Button.O_SEARCHTYPE_APPOINTMENTS);
 		app.zPageSearch.zAddSearchQuery("subject:("+ subject +")");
 		app.zPageSearch.zToolbarPressButton(Button.B_SEARCH);
 		
@@ -86,7 +87,7 @@ public class SearchAppointment extends CalendarWorkWeekTest {
 			groups = { "functional","L2" })
 	
 	public void SearchAppointment_02() throws HarnessException {
-		ZDate startDate = new ZDate(this.calendarWeekDayUTC.get(Calendar.YEAR), this.calendarWeekDayUTC.get(Calendar.MONTH) + 1, this.calendarWeekDayUTC.get(Calendar.DAY_OF_MONTH), this.calendarWeekDayUTC.get(Calendar.HOUR_OF_DAY), 0, 0);
+		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 		
 		// Create a meeting
 		String subject = "appointment" + ConfigProperties.getUniqueString();
@@ -98,10 +99,11 @@ public class SearchAppointment extends CalendarWorkWeekTest {
 				subject,
 				"content" + ConfigProperties.getUniqueString(),
 				"location" + ConfigProperties.getUniqueString(),
-				null);
+				null);		
 
-		// Refresh the calendar
-		app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
+		// Refresh the UI (work around due to active dialogs found when running as a second test and directly using app.zPageCalendar.zNavigateTo();)
+		app.zPageMain.sRefresh();
+		app.zPageCalendar.zNavigateTo();
 		
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_VIEW_MENU, Button.O_VIEW_LIST_SUB_MENU, "List");
         ZAssert.assertTrue(app.zPageCalendar.sIsElementPresent(Locators.CalendarViewListCSS), "Changed to list view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/DialogInformational.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/DialogInformational.java
@@ -97,9 +97,9 @@ public class DialogInformational extends AbsDialog {
 		}
 
 		// Click it
-		sClickAt(locator,"0,0");
-		SleepUtil.sleepSmall();
+		sClickAt(locator, "");
 		zWaitForBusyOverlay();
+		SleepUtil.sleepMedium();
 		
 		if (button == Button.B_OK) {
 			Stafpostqueue sp = new Stafpostqueue();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/DialogShare.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/DialogShare.java
@@ -37,8 +37,8 @@ public class DialogShare extends AbsDialog {
 	public static class Locators {
 		public static final String zDialogShareId = "ShareDialog";
 		public static final String zButtonsId = "ShareDialog_buttons";
-		public static final String note = "css=div[id='ZmShareReply'] textarea";
-		public static final String Message = "css=td[id='ZmShareReplySelect_select_container']";
+		public static final String zShareMessageNote = "css=div[id='ZmShareReply'] textarea";
+		public static final String zShareMessageDropDown = "css=td[id='ZmShareReplySelect_select_container']";
 		public static final String zAddNoteToStandardMessage = "//td[contains(@id,'_title') and contains(text(),'Add note to standard message')]";
 		public static final String zDoNotSendMailAboutThisShare = "//td[contains(@id,'_title') and contains(text(),'Do not send mail about this share')]";
 
@@ -184,20 +184,20 @@ public class DialogShare extends AbsDialog {
 
 		if (type == ShareMessageType.AddNoteToStandardMsg) {
 
-			zClickAt(Locators.Message, "");
+			zClickAt(Locators.zShareMessageDropDown, "");
 			zClick(Locators.zAddNoteToStandardMessage);
-			this.sFocus(Locators.note);
-			this.zClick(Locators.note);
+			this.sFocus(Locators.zShareMessageNote);
+			this.zClick(Locators.zShareMessageNote);
 			this.zWaitForBusyOverlay();
 
 			// this.zKeyboard.zTypeCharacters(message);
-			this.sType(Locators.note, message);
+			this.sType(Locators.zShareMessageNote, message);
 			SleepUtil.sleepSmall();
 
 		}
 
 		else if (type == ShareMessageType.DoNotSendMsg) {
-			zClickAt(Locators.Message, "");
+			zClickAt(Locators.zShareMessageDropDown, "");
 			zClick(Locators.zDoNotSendMailAboutThisShare);
 		}
 	}
@@ -220,7 +220,7 @@ public class DialogShare extends AbsDialog {
 			throw new HarnessException("Button " + button + " not implemented");
 		}
 
-		this.zClick(locator);
+		this.sClickAt(locator, "");
 		zWaitForBusyOverlay();
 
 		if (button == Button.B_OK) {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/PageCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/PageCalendar.java
@@ -1344,8 +1344,8 @@ public class PageCalendar extends AbsTab {
 
 				if ( optionLocator != null ) {
 					this.zClickAt(optionLocator, "");
-					SleepUtil.sleepSmall();
 					this.zWaitForBusyOverlay();
+					SleepUtil.sleepSmall();
 				}
 
 				if (com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.attendee.singleday.actions.CreateACopy.organizerTest == false ||
@@ -2834,7 +2834,7 @@ public class PageCalendar extends AbsTab {
 		if ( this.zIsVisiblePerPosition(Locators.CalendarViewListCSS, 0, 0) ) {
 			return (zListGetAppointmentsListView());											// LIST
 		} else if ( this.zIsVisiblePerPosition(Locators.CalendarViewSearchListCSS, 0, 0) ) {
-			return (zSearchListGetAppointmentsListView());
+			return (zSearchListGetAppointmentsListView());										// SEARCH
 		} else if ( this.zIsVisiblePerPosition(Locators.CalendarViewDayCSS, 0, 0) ) {
 			return (zListGetAppointmentsGeneral(Locators.CalendarViewDayItemCSS));				// DAY
 		} else if ( this.zIsVisiblePerPosition(Locators.CalendarViewWeekCSS, 0, 0) ) {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/DisplayMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/DisplayMail.java
@@ -134,7 +134,6 @@ public class DisplayMail extends AbsDisplay {
 
 		AbsPage page = this;
 		String locator = null;
-		boolean doPostfixCheck = false;
 
 		if (button == Button.B_REMOVE_ALL) {
 
@@ -194,127 +193,106 @@ public class DisplayMail extends AbsDisplay {
 
 			locator = Locators.AcceptButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_ACCEPT_NOTIFY_ORGANIZER) {
 
 			locator = Locators.AcceptNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_ACCEPT_EDIT_REPLY) {
 
 			locator = Locators.AcceptEditReplyMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_ACCEPT_DONT_NOTIFY_ORGANIZER) {
 
 			locator = Locators.AcceptDontNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_TENTATIVE) {
 
 			locator = Locators.TentativeButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_TENTATIVE_NOTIFY_ORGANIZER) {
 
 			locator = Locators.TentativeNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_TENTATIVE_EDIT_REPLY) {
 
 			locator = Locators.TentativeEditReplyMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_TENTATIVE_DONT_NOTIFY_ORGANIZER) {
 
 			locator = Locators.TentativeDontNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_DECLINE) {
 
 			locator = Locators.DeclineButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_DECLINE_NOTIFY_ORGANIZER) {
 
 			locator = Locators.DeclineNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_DECLINE_EDIT_REPLY) {
 
 			locator = Locators.DeclineEditReplyMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_DECLINE_DONT_NOTIFY_ORGANIZER) {
 
 			locator = Locators.DeclineDontNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_PROPOSE_NEW_TIME) {
 
 			locator = Locators.ProposeNewTimeButton;
 			page = new FormApptNew(this.MyApplication);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_ACCEPT_PROPOSE_NEW_TIME) {
 
 			locator = Locators.AcceptProposeNewTimeButton;
 			page = new FormApptNew(this.MyApplication);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_DECLINE_PROPOSE_NEW_TIME) {
 
 			locator = Locators.DeclineProposeNewTimeButton;
 			page = new FormMailNew(this.MyApplication);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_ACCEPT_SHARE) {
 
 			locator = this.ContainerLocator + " td[id$='__Shr__SHARE_ACCEPT_title']";
 			page = new DialogShareAccept(MyApplication, ((AppAjaxClient) MyApplication).zPageMail);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_DECLINE_SHARE) {
 
 			locator = this.ContainerLocator + " td[id$='__Shr__SHARE_DECLINE_title']";
 			page = new DialogShareDecline(MyApplication, ((AppAjaxClient) MyApplication).zPageMail);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_FORWARD) {
 
 			locator = Locators.zForwardButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_REPLY) {
 
 			locator = Locators.zReplyButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_REPLYALL) {
 
 			locator = Locators.zReplyAllButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_DELETE) {
 
 			locator = Locators.zDeleteButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else {
 			throw new HarnessException("no implementation for button: " + button);
@@ -327,12 +305,10 @@ public class DisplayMail extends AbsDisplay {
 			throw new HarnessException("locator is not present for button " + button + " : " + locator);
 
 		this.sClick(locator);
-		SleepUtil.sleepMedium();
+		SleepUtil.sleepLong();
 
-		if (doPostfixCheck) {
-			Stafpostqueue sp = new Stafpostqueue();
-			sp.waitForPostqueue();
-		}
+		Stafpostqueue sp = new Stafpostqueue();
+		sp.waitForPostqueue();
 
 		return (page);
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/freebusy/singleday/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/freebusy/singleday/GetAppointment.java
@@ -21,9 +21,9 @@ import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.universal.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.universal.core.UniversalCommonTest;
 
-public class GetAppointment extends CalendarWorkWeekTest {
+public class GetAppointment extends UniversalCommonTest {
 	
 	public GetAppointment() {
 		logger.info("New "+ GetAppointment.class.getCanonicalName());
@@ -51,7 +51,7 @@ public class GetAppointment extends CalendarWorkWeekTest {
 		String apptSubject = ConfigProperties.getUniqueString();
 		
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/list/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/list/DeleteAppointment.java
@@ -36,10 +36,10 @@ import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZDate;
 import com.zimbra.qa.selenium.framework.util.ZTimeZone;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
-import com.zimbra.qa.selenium.projects.universal.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.universal.core.UniversalCommonTest;
 import com.zimbra.qa.selenium.projects.universal.ui.calendar.*;
 
-public class DeleteAppointment extends CalendarWorkWeekTest {
+public class DeleteAppointment extends UniversalCommonTest {
 
 	public DeleteAppointment() {
 		logger.info("New "+ DeleteAppointment.class.getCanonicalName());
@@ -73,7 +73,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 3, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 4, 0, 0);
 
@@ -163,7 +163,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 4, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 5, 0, 0);
 
@@ -255,7 +255,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 5, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 6, 0, 0);
 
@@ -338,7 +338,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 6, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
 
@@ -417,7 +417,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 		// Create three appointments on the server
 		String subject1 = ConfigProperties.getUniqueString();
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
 		String tz = ZTimeZone.getLocalTimeZone().getID();
@@ -584,7 +584,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
 
@@ -665,7 +665,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 
@@ -737,7 +737,7 @@ public class DeleteAppointment extends CalendarWorkWeekTest {
 
 		// Create three appointments on the server
 		String subject1 = ConfigProperties.getUniqueString();
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
 		String tz = ZTimeZone.getLocalTimeZone().getID();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/list/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/list/GetAppointment.java
@@ -24,9 +24,9 @@ import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.AppointmentItem;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.universal.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.universal.core.UniversalCommonTest;
 
-public class GetAppointment extends CalendarWorkWeekTest {
+public class GetAppointment extends UniversalCommonTest {
 	
 	@SuppressWarnings("serial")
 	public GetAppointment() {
@@ -53,7 +53,7 @@ public class GetAppointment extends CalendarWorkWeekTest {
 		
 		
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		
@@ -108,7 +108,7 @@ public class GetAppointment extends CalendarWorkWeekTest {
 		
 		
 		// Absolute dates in UTC zone
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/conversation/AcceptProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/conversation/AcceptProposeNewTime.java
@@ -57,10 +57,10 @@ public class AcceptProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 5, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 6, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/conversation/DeclineProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/conversation/DeclineProposeNewTime.java
@@ -57,10 +57,10 @@ public class DeclineProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 17, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 19, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 6, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/message/AcceptProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/message/AcceptProposeNewTime.java
@@ -57,10 +57,10 @@ public class AcceptProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 15, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 15, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 16, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 7, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/message/DeclineProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/message/DeclineProposeNewTime.java
@@ -57,10 +57,10 @@ public class DeclineProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 17, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate ModifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate ModifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 19, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
+		ZDate ModifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
+		ZDate ModifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/conversation/AcceptProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/conversation/AcceptProposeNewTime.java
@@ -60,10 +60,10 @@ public class AcceptProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/conversation/DeclineProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/conversation/DeclineProposeNewTime.java
@@ -60,10 +60,10 @@ public class DeclineProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 17, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 19, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/listview/Accept.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/listview/Accept.java
@@ -26,7 +26,7 @@ import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.projects.universal.core.*;
 
-public class Accept extends CalendarWorkWeekTest {
+public class Accept extends UniversalCommonTest {
 
 	@SuppressWarnings("serial")
 	public Accept() {
@@ -46,7 +46,7 @@ public class Accept extends CalendarWorkWeekTest {
 
 		String apptSubject = ConfigProperties.getUniqueString();
 
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 23, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 24, 0, 0);
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/listview/Decline.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/listview/Decline.java
@@ -27,7 +27,7 @@ import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.projects.universal.core.*;
 import com.zimbra.qa.selenium.projects.universal.ui.calendar.DialogConfirmationDeclineAppointment;
 
-public class Decline extends CalendarWorkWeekTest {
+public class Decline extends UniversalCommonTest {
 
 	@SuppressWarnings("serial")
 	public Decline() {
@@ -47,7 +47,7 @@ public class Decline extends CalendarWorkWeekTest {
 
 		String apptSubject = ConfigProperties.getUniqueString();
 
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 
@@ -156,7 +156,7 @@ public class Decline extends CalendarWorkWeekTest {
 
 		String apptSubject = ConfigProperties.getUniqueString();
 
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 16, 0, 0);
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/listview/Tentative.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/listview/Tentative.java
@@ -26,7 +26,7 @@ import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.projects.universal.core.*;
 
-public class Tentative extends CalendarWorkWeekTest {
+public class Tentative extends UniversalCommonTest {
 
 	@SuppressWarnings("serial")
 	public Tentative() {
@@ -46,7 +46,7 @@ public class Tentative extends CalendarWorkWeekTest {
 
 		String apptSubject = ConfigProperties.getUniqueString();
 
-		Calendar now = this.calendarWeekDayUTC;
+		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/message/AcceptProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/message/AcceptProposeNewTime.java
@@ -65,8 +65,8 @@ public class AcceptProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
 		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/message/DeclineProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/invitations/message/DeclineProposeNewTime.java
@@ -65,10 +65,10 @@ public class DeclineProposeNewTime extends CalendarWorkWeekTest {
 
 		Calendar now = this.calendarWeekDayUTC;
 		AppointmentItem appt = new AppointmentItem();
-		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 17, 0, 0);
-		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 18, 0, 0);
-		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 19, 0, 0);
+		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
+		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
+		ZDate modifiedStartUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
+		ZDate modifiedEndUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 15, 0, 0);
 		
 		// --------------- Creating invitation (apptAttendee1) ----------------------------
 		organizer.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/mountpoints/viewer/actions/Open.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/mountpoints/viewer/actions/Open.java
@@ -35,6 +35,8 @@ public class Open extends CalendarWorkWeekTest {
 	
 	public void Open_01() throws HarnessException {
 		
+		organizerTest = false;
+		
 		String apptSubject = ConfigProperties.getUniqueString();
 		String apptContent = ConfigProperties.getUniqueString();
 		String foldername = "folder" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/mountpoints/viewer/viewappt/Close.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/mountpoints/viewer/viewappt/Close.java
@@ -35,6 +35,8 @@ public class Close extends CalendarWorkWeekTest {
 			
 	public void Close_01() throws HarnessException {
 		
+		organizerTest = false;
+		
 		String apptSubject = ConfigProperties.getUniqueString();
 		String apptContent = ConfigProperties.getUniqueString();
 		String foldername = "folder" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/search/search/SearchAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/search/search/SearchAppointment.java
@@ -25,10 +25,10 @@ import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
-import com.zimbra.qa.selenium.projects.universal.core.CalendarWorkWeekTest;
+import com.zimbra.qa.selenium.projects.universal.core.UniversalCommonTest;
 import com.zimbra.qa.selenium.projects.universal.ui.calendar.PageCalendar.Locators;
 
-public class SearchAppointment extends CalendarWorkWeekTest {
+public class SearchAppointment extends UniversalCommonTest {
 
 	int pollIntervalSeconds = 60;
 	
@@ -41,7 +41,7 @@ public class SearchAppointment extends CalendarWorkWeekTest {
 			groups = { "functional","L2" })
 	
 	public void SearchAppointment_01() throws HarnessException {
-		ZDate startDate = new ZDate(this.calendarWeekDayUTC.get(Calendar.YEAR), this.calendarWeekDayUTC.get(Calendar.MONTH) + 1, this.calendarWeekDayUTC.get(Calendar.DAY_OF_MONTH), this.calendarWeekDayUTC.get(Calendar.HOUR_OF_DAY), 0, 0);
+		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 		
 		// Create a meeting
 		String subject = "appointment" + ConfigProperties.getUniqueString();
@@ -55,14 +55,15 @@ public class SearchAppointment extends CalendarWorkWeekTest {
 				"location" + ConfigProperties.getUniqueString(),
 				null);
 
-		// Refresh the calendar
-		app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
+		// Refresh the pane
+		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
 		
 		// Verify appointment exists on the server 
         AppointmentItem actual = AppointmentItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject + ")");
 		ZAssert.assertNotNull(actual, "Verify the new appointment is created");
 		
 		// Search for the appointment
+		app.zPageSearch.zToolbarPressPulldown(Button.B_SEARCHTYPE, Button.O_SEARCHTYPE_APPOINTMENTS);
 		app.zPageSearch.zAddSearchQuery("subject:("+ subject +")");
 		app.zPageSearch.zToolbarPressButton(Button.B_SEARCH);
 		
@@ -86,7 +87,7 @@ public class SearchAppointment extends CalendarWorkWeekTest {
 			groups = { "functional","L2" })
 	
 	public void SearchAppointment_02() throws HarnessException {
-		ZDate startDate = new ZDate(this.calendarWeekDayUTC.get(Calendar.YEAR), this.calendarWeekDayUTC.get(Calendar.MONTH) + 1, this.calendarWeekDayUTC.get(Calendar.DAY_OF_MONTH), this.calendarWeekDayUTC.get(Calendar.HOUR_OF_DAY), 0, 0);
+		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 		
 		// Create a meeting
 		String subject = "appointment" + ConfigProperties.getUniqueString();
@@ -100,8 +101,9 @@ public class SearchAppointment extends CalendarWorkWeekTest {
 				"location" + ConfigProperties.getUniqueString(),
 				null);
 
-		// Refresh the calendar
-		app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
+		// Refresh the UI (work around due to active dialogs found when running as a second test and directly using app.zPageCalendar.zNavigateTo();)
+		app.zPageMain.sRefresh();
+		app.zPageCalendar.zNavigateTo();
 		
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_VIEW_MENU, Button.O_VIEW_LIST_SUB_MENU, "List");
         ZAssert.assertTrue(app.zPageCalendar.sIsElementPresent(Locators.CalendarViewListCSS), "Changed to list view");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/DialogInformational.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/DialogInformational.java
@@ -97,9 +97,9 @@ public class DialogInformational extends AbsDialog {
 		}
 
 		// Click it
-		sClickAt(locator,"0,0");
-		SleepUtil.sleepSmall();
+		sClickAt(locator, "");
 		zWaitForBusyOverlay();
+		SleepUtil.sleepMedium();
 		
 		if (button == Button.B_OK) {
 			Stafpostqueue sp = new Stafpostqueue();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/DialogShare.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/DialogShare.java
@@ -37,8 +37,8 @@ public class DialogShare extends AbsDialog {
 	public static class Locators {
 		public static final String zDialogShareId = "ShareDialog";
 		public static final String zButtonsId = "ShareDialog_buttons";
-		public static final String note = "css=div[id='ZmShareReply'] textarea";
-		public static final String Message = "css=td[id='ZmShareReplySelect_select_container']";
+		public static final String zShareMessageNote = "css=div[id='ZmShareReply'] textarea";
+		public static final String zShareMessageDropDown = "css=td[id='ZmShareReplySelect_select_container']";
 		public static final String zAddNoteToStandardMessage = "//td[contains(@id,'_title') and contains(text(),'Add note to standard message')]";
 		public static final String zDoNotSendMailAboutThisShare = "//td[contains(@id,'_title') and contains(text(),'Do not send mail about this share')]";
 
@@ -184,20 +184,20 @@ public class DialogShare extends AbsDialog {
 
 		if (type == ShareMessageType.AddNoteToStandardMsg) {
 
-			zClickAt(Locators.Message, "");
+			zClickAt(Locators.zShareMessageDropDown, "");
 			zClick(Locators.zAddNoteToStandardMessage);
-			this.sFocus(Locators.note);
-			this.zClick(Locators.note);
+			this.sFocus(Locators.zShareMessageNote);
+			this.zClick(Locators.zShareMessageNote);
 			this.zWaitForBusyOverlay();
 
 			// this.zKeyboard.zTypeCharacters(message);
-			this.sType(Locators.note, message);
+			this.sType(Locators.zShareMessageNote, message);
 			SleepUtil.sleepSmall();
 
 		}
 
 		else if (type == ShareMessageType.DoNotSendMsg) {
-			zClickAt(Locators.Message, "");
+			zClickAt(Locators.zShareMessageDropDown, "");
 			zClick(Locators.zDoNotSendMailAboutThisShare);
 		}
 	}
@@ -220,7 +220,7 @@ public class DialogShare extends AbsDialog {
 			throw new HarnessException("Button " + button + " not implemented");
 		}
 
-		this.zClick(locator);
+		this.sClickAt(locator, "");
 		zWaitForBusyOverlay();
 
 		if (button == Button.B_OK) {

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/calendar/PageCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/calendar/PageCalendar.java
@@ -1344,8 +1344,8 @@ public class PageCalendar extends AbsTab {
 
 				if ( optionLocator != null ) {
 					this.zClickAt(optionLocator, "");
-					SleepUtil.sleepSmall();
 					this.zWaitForBusyOverlay();
+					SleepUtil.sleepSmall();
 				}
 
 				if (com.zimbra.qa.selenium.projects.universal.tests.calendar.meetings.attendee.singleday.actions.CreateACopy.organizerTest == false ||
@@ -2829,7 +2829,7 @@ public class PageCalendar extends AbsTab {
 		if ( this.zIsVisiblePerPosition(Locators.CalendarViewListCSS, 0, 0) ) {
 			return (zListGetAppointmentsListView());											// LIST
 		} else if ( this.zIsVisiblePerPosition(Locators.CalendarViewSearchListCSS, 0, 0) ) {
-			return (zSearchListGetAppointmentsListView());
+			return (zSearchListGetAppointmentsListView());										// SEARCH
 		} else if ( this.zIsVisiblePerPosition(Locators.CalendarViewDayCSS, 0, 0) ) {
 			return (zListGetAppointmentsGeneral(Locators.CalendarViewDayItemCSS));				// DAY
 		} else if ( this.zIsVisiblePerPosition(Locators.CalendarViewWeekCSS, 0, 0) ) {

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/DisplayMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/DisplayMail.java
@@ -134,7 +134,6 @@ public class DisplayMail extends AbsDisplay {
 
 		AbsPage page = this;
 		String locator = null;
-		boolean doPostfixCheck = false;
 
 		if (button == Button.B_REMOVE_ALL) {
 
@@ -194,127 +193,106 @@ public class DisplayMail extends AbsDisplay {
 
 			locator = Locators.AcceptButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_ACCEPT_NOTIFY_ORGANIZER) {
 
 			locator = Locators.AcceptNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_ACCEPT_EDIT_REPLY) {
 
 			locator = Locators.AcceptEditReplyMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_ACCEPT_DONT_NOTIFY_ORGANIZER) {
 
 			locator = Locators.AcceptDontNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_TENTATIVE) {
 
 			locator = Locators.TentativeButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_TENTATIVE_NOTIFY_ORGANIZER) {
 
 			locator = Locators.TentativeNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_TENTATIVE_EDIT_REPLY) {
 
 			locator = Locators.TentativeEditReplyMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_TENTATIVE_DONT_NOTIFY_ORGANIZER) {
 
 			locator = Locators.TentativeDontNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_DECLINE) {
 
 			locator = Locators.DeclineButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_DECLINE_NOTIFY_ORGANIZER) {
 
 			locator = Locators.DeclineNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_DECLINE_EDIT_REPLY) {
 
 			locator = Locators.DeclineEditReplyMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.O_DECLINE_DONT_NOTIFY_ORGANIZER) {
 
 			locator = Locators.DeclineDontNotifyOrganizerMenu;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_PROPOSE_NEW_TIME) {
 
 			locator = Locators.ProposeNewTimeButton;
 			page = new FormApptNew(this.MyApplication);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_ACCEPT_PROPOSE_NEW_TIME) {
 
 			locator = Locators.AcceptProposeNewTimeButton;
 			page = new FormApptNew(this.MyApplication);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_DECLINE_PROPOSE_NEW_TIME) {
 
 			locator = Locators.DeclineProposeNewTimeButton;
 			page = new FormMailNew(this.MyApplication);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_ACCEPT_SHARE) {
 
 			locator = this.ContainerLocator + " td[id$='__Shr__SHARE_ACCEPT_title']";
 			page = new DialogShareAccept(MyApplication, ((AppUniversalClient) MyApplication).zPageMail);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_DECLINE_SHARE) {
 
 			locator = this.ContainerLocator + " td[id$='__Shr__SHARE_DECLINE_title']";
 			page = new DialogShareDecline(MyApplication, ((AppUniversalClient) MyApplication).zPageMail);
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_FORWARD) {
 
 			locator = Locators.zForwardButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_REPLY) {
 
 			locator = Locators.zReplyButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_REPLYALL) {
 
 			locator = Locators.zReplyAllButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else if (button == Button.B_DELETE) {
 
 			locator = Locators.zDeleteButton;
 			page = null;
-			doPostfixCheck = true;
 
 		} else {
 			throw new HarnessException("no implementation for button: " + button);
@@ -326,18 +304,11 @@ public class DisplayMail extends AbsDisplay {
 		if (!this.sIsElementPresent(locator))
 			throw new HarnessException("locator is not present for button " + button + " : " + locator);
 
-		this.zClickAt(locator, "");
-		this.zWaitForBusyOverlay();
-		SleepUtil.sleepMedium();
+		this.sClick(locator);
+		SleepUtil.sleepLong();
 
-		if (page != null) {
-			page.zWaitForActive();
-		}
-
-		if (doPostfixCheck) {
-			Stafpostqueue sp = new Stafpostqueue();
-			sp.waitForPostqueue();
-		}
+		Stafpostqueue sp = new Stafpostqueue();
+		sp.waitForPostqueue();
 
 		return (page);
 	}

--- a/src/java/com/zimbra/qa/selenium/staf/StafIntegration.java
+++ b/src/java/com/zimbra/qa/selenium/staf/StafIntegration.java
@@ -306,11 +306,8 @@ public class StafIntegration implements STAFServiceInterfaceLevel30 {
 			pHarnessLogFilePath = Paths.get(sHarnessLogFileFolderPath, sHarnessLogFileName);
 			fHarnessLogFile = new File(sHarnessLogFilePath);
 			fHarnessLogFileFolder = new File(sHarnessLogFileFolderPath);
-			if (!fHarnessLogFileFolder.exists()) {
-				fHarnessLogFileFolder.mkdirs();
-			}
+			fHarnessLogFileFolder.mkdirs();
 			try {
-				fHarnessLogFile.delete();
 				fHarnessLogFile.createNewFile();
 			} catch (IOException e1) {
 				e1.printStackTrace();


### PR DESCRIPTION
ZCS-3414: Fix selenium testcases those are failed due to common pattern in full result

Testcases are failed because of:
- Non work-week test must extends to AjaxCommentTest instead of CalendarWorkWeekTest otherwise list view will not show appointments created due to weekday logic. Calendar now = Calendar.getInstance(); should be used instead of Calendar now = this.calendarWeekDayUTC;
- Use CalendarWorkWeekTest only when work week view is used, 90% use-case though.
- Specified mid-day time for all propose new time testcases and testcase works fine, will see how changes goes. Time that has been used which overlaps with next day probably.
- CreateShare and CreateACopy mostly timing/click issue, Open and Close was not editing appointment so OrganizerTest should be false considering same function used to edit and view appointment. Fixed those testcases.
- Ideally SearchAppointment should have failed since it has been written due to multiple issues. It was using wrong view and again non work-week tests must extends to AjaxCommentTest instead of CalendarWorkWeekTest otherwise list view will not show appointments due to weekday logic. Calendar now = Calendar.getInstance(); should be used instead of Calendar now = this.calendarWeekDayUTC;

![acceptproposenewtime - fixed](https://user-images.githubusercontent.com/21263826/32141367-8f0c084e-bca4-11e7-8089-b52e218bf01b.png)
![deleteappointment - fixed](https://user-images.githubusercontent.com/21263826/32141368-8f3fc29c-bca4-11e7-87ab-2c742af870f2.png)
![getappointment - fixed](https://user-images.githubusercontent.com/21263826/32141369-8f7771ba-bca4-11e7-9e6f-7ba9ba6cad5b.png)
![mountpoints - fixed](https://user-images.githubusercontent.com/21263826/32141370-904c9250-bca4-11e7-8934-7b45d7038d5a.png)
![searchappointment - fixed](https://user-images.githubusercontent.com/21263826/32141371-90821d30-bca4-11e7-9777-b89dccd9b8ca.png)