### PR TITLE
ZCS-3415: Fixed Flag and UnFlag testcases and introduced new function for checking flag, tag & attachment

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/FlagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/FlagMail.java
@@ -67,24 +67,8 @@ public class FlagMail extends PrefGroupMailByMessageTest {
 		// Flag the item
 		app.zPageMail.zListItem(Action.A_MAIL_FLAG, mail.dSubject);
 
-		// Get the item from the list
-		List<MailItem> messages = app.zPageMail.zListGetMessages();
-		ZAssert.assertNotNull(messages, "Verify the message list exists");
-
-		MailItem listmail = null;
-		for (MailItem m : messages) {
-			logger.info("Subject: looking for "+ mail.dSubject +" found: "+ m.gSubject);
-			if ( mail.dSubject.equals(m.gSubject) ) {
-				listmail = m;
-				break;
-			}
-		}
-
-		
-
 		// Make sure the GUI shows "flagged"
-		ZAssert.assertNotNull(listmail, "Verify the message is in the list");
-		ZAssert.assertTrue(listmail.gIsFlagged, "Verify the message is flagged in the list");
+		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "true", "Verify the message is shown as flagged in the UI");
 		
 		// Make sure the server shows "flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
@@ -124,24 +108,8 @@ public class FlagMail extends PrefGroupMailByMessageTest {
 		// Flag the item
 		app.zPageMail.zKeyboardShortcut(Shortcut.S_MAIL_MARKFLAG);
 		
-		// Get the item from the list
-		List<MailItem> messages = app.zPageMail.zListGetMessages();
-		ZAssert.assertNotNull(messages, "Verify the message list exists");
-
-		MailItem listmail = null;
-		for (MailItem m : messages) {
-			logger.info("Subject: looking for "+ mail.dSubject +" found: "+ m.gSubject);
-			if ( mail.dSubject.equals(m.gSubject) ) {
-				listmail = m;
-				break;
-			}
-		}
-
-		
-		
 		// Make sure the GUI shows "flagged"
-		ZAssert.assertNotNull(listmail, "Verify the message is in the list");
-		ZAssert.assertTrue(listmail.gIsFlagged, "Verify the message is flagged in the list");
+		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "true", "Verify the message is shown as flagged in the UI");
 		
 		// Make sure the server shows "flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/FlagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/FlagMail.java
@@ -16,34 +16,27 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.util.*;
-
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.projects.ajax.core.PrefGroupMailByMessageTest;
 
-
 public class FlagMail extends PrefGroupMailByMessageTest {
 
 	public FlagMail() {
 		logger.info("New "+ FlagMail.class.getCanonicalName());
-		
-		
-		
-
-		
 	}
-	
+
+
 	@Test( description = "Flag a mail  clicking flagged icon",
 			groups = { "smoke", "L1" })
+
 	public void FlagMail_01() throws HarnessException {
-		
+
 		// Create the message data to be sent
 		String subject = "subject"+ ConfigProperties.getUniqueString();
-		
+
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -54,37 +47,36 @@ public class FlagMail extends PrefGroupMailByMessageTest {
 							"</mp>" +
 						"</m>" +
 					"</SendMsgRequest>");
-		
+
 		// Create a mail item to represent the message
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
-				
+
 		// Select the item
 		app.zPageMail.zListItem(Action.A_LEFTCLICK, mail.dSubject);
-		
+
 		// Flag the item
 		app.zPageMail.zListItem(Action.A_MAIL_FLAG, mail.dSubject);
 
 		// Make sure the GUI shows "flagged"
 		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "true", "Verify the message is shown as flagged in the UI");
-		
+
 		// Make sure the server shows "flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
 		ZAssert.assertStringContains(mail.getFlags(), "f", "Verify the message is flagged in the server");
-
-		
 	}
 
-	
+
 	@Test( description = "Flag a mail by using shortcut 'mf'",
 			groups = { "functional", "L2" })
+
 	public void FlagMail_02() throws HarnessException {
-		
+
 		// Create the message data to be sent
 		String subject = "subject"+ ConfigProperties.getUniqueString();
-		
+
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -95,28 +87,24 @@ public class FlagMail extends PrefGroupMailByMessageTest {
 							"</mp>" +
 						"</m>" +
 					"</SendMsgRequest>");
-		
+
 		// Create a mail item to represent the message
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
-				
+
 		// Select the item
 		app.zPageMail.zListItem(Action.A_LEFTCLICK, mail.dSubject);
-		
+
 		// Flag the item
 		app.zPageMail.zKeyboardShortcut(Shortcut.S_MAIL_MARKFLAG);
-		
+
 		// Make sure the GUI shows "flagged"
 		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "true", "Verify the message is shown as flagged in the UI");
-		
+
 		// Make sure the server shows "flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
 		ZAssert.assertStringContains(mail.getFlags(), "f", "Verify the message is flagged in the server");
-
-		
 	}
-
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/UnFlagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/UnFlagMail.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.util.*;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
@@ -30,7 +29,10 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		logger.info("New " + UnFlagMail.class.getCanonicalName());
 	}
 
-	@Test(description = "Un-Flag a mail by clicking flagged icon", groups = { "smoke", "L1" })
+
+	@Test(description = "Un-Flag a mail by clicking flagged icon",
+			groups = { "smoke", "L1" })
+
 	public void UnFlagMail_01() throws HarnessException {
 
 		// Create the message data to be sent
@@ -63,10 +65,12 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		// Make sure the server shows "un-flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject + ")");
 		ZAssert.assertStringDoesNotContain(mail.getFlags(), "f", "Verify the message is not flagged in the server");
-
 	}
 
-	@Test(description = "Un-Flag a mail by using shortcut 'mf'", groups = { "functional", "L2" })
+
+	@Test(description = "Un-Flag a mail by using shortcut 'mf'",
+			groups = { "functional", "L2" })
+
 	public void UnFlagMail_02() throws HarnessException {
 
 		// Create the message data to be sent
@@ -100,5 +104,4 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject + ")");
 		ZAssert.assertStringDoesNotContain(mail.getFlags(), "f", "Verify the message is not flagged in the server");
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/UnFlagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/UnFlagMail.java
@@ -57,24 +57,10 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		// Flag the item
 		app.zPageMail.zListItem(Action.A_MAIL_UNFLAG, mail.dSubject);
 
-		// Get the item from the list
-		List<MailItem> messages = app.zPageMail.zListGetMessages();
-		ZAssert.assertNotNull(messages, "Verify the message list exists");
+		// Make sure the GUI shows "un-flagged"
+		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "false", "Verify the message is shown as un-flagged in the UI");
 
-		MailItem listmail = null;
-		for (MailItem m : messages) {
-			logger.info("Subject: looking for " + mail.dSubject + " found: " + m.gSubject);
-			if (mail.dSubject.equals(m.gSubject)) {
-				listmail = m;
-				break;
-			}
-		}
-
-		// Make sure the GUI shows "flagged"
-		ZAssert.assertNotNull(listmail, "Verify the message is in the list");
-		ZAssert.assertFalse(listmail.gIsFlagged, "Verify the message is flagged in the list");
-
-		// Make sure the server shows "flagged"
+		// Make sure the server shows "un-flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject + ")");
 		ZAssert.assertStringDoesNotContain(mail.getFlags(), "f", "Verify the message is not flagged in the server");
 
@@ -107,24 +93,10 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		// Flag the item
 		app.zPageMail.zKeyboardShortcut(Shortcut.S_MAIL_MARKFLAG);
 
-		// Get the item from the list
-		List<MailItem> messages = app.zPageMail.zListGetMessages();
-		ZAssert.assertNotNull(messages, "Verify the message list exists");
+		// Make sure the GUI shows "un-flagged"
+		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "false", "Verify the message is shown as un-flagged in the UI");
 
-		MailItem listmail = null;
-		for (MailItem m : messages) {
-			logger.info("Subject: looking for " + mail.dSubject + " found: " + m.gSubject);
-			if (mail.dSubject.equals(m.gSubject)) {
-				listmail = m;
-				break;
-			}
-		}
-
-		// Make sure the GUI shows "flagged"
-		ZAssert.assertNotNull(listmail, "Verify the message is in the list");
-		ZAssert.assertFalse(listmail.gIsFlagged, "Verify the message is flagged in the list");
-
-		// Make sure the server shows "flagged"
+		// Make sure the server shows "un-flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject + ")");
 		ZAssert.assertStringDoesNotContain(mail.getFlags(), "f", "Verify the message is not flagged in the server");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/PageMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/PageMail.java
@@ -2348,5 +2348,50 @@ public class PageMail extends AbsTab {
 	public boolean zVerifyExternalImageInfoBarExists(String subject) throws HarnessException {
 		return sIsElementPresent("css=div[aria-label='"+subject+"'] span:contains('External images are not displayed.')");
 	}
+	
+	public String zGetMessageProperty (String subject, String property) throws HarnessException {
 
+		String viewLocator, listLocator, rowLocator, itemlocator;
+		
+		if (zGetPropMailView() == PageMailView.BY_MESSAGE) {
+			viewLocator = "__TV-main__";
+			listLocator = "css=ul[id='zl" + viewLocator + "rows']";
+			rowLocator = "li[id^='zli" + viewLocator + "']";
+		} else {
+			viewLocator = "__CLV-main__";
+			listLocator = "css=ul[id='zl" + viewLocator + "rows']";
+			rowLocator = "li[id^='zli" + viewLocator + "']";
+		}
+
+		int count = this.sGetCssCount(listLocator + " " + rowLocator);
+
+		for (int i = 1; i <= count; i++) {
+			itemlocator = listLocator + " li:nth-of-type(" + i + ") ";
+			String listSubject = this.sGetText(itemlocator + " [id$='__su']").trim();
+
+			if (listSubject.contains(subject)) {
+				String messageID = this.sGetAttribute(itemlocator + " span[id^='zlif" + viewLocator + "']@id");
+								
+				if (property.contains("flag")) {
+					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__fg");
+					Boolean isMessageFlagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgFlagRed']");
+					return isMessageFlagged.toString();
+					
+				} else if (property.contains("attachment")) {
+					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__at");
+					Boolean isMessageContainsAttachment = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgAttachment']");
+					return isMessageContainsAttachment.toString();
+					
+				} else if (property.contains("tag")) {
+					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__tg");
+					Boolean isMessageTagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] img[src^='data:image/png;base64']");
+					return isMessageTagged.toString();
+
+				} else {
+					break;
+				}
+			}
+		}
+		return null;
+	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/PageMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/PageMail.java
@@ -2348,11 +2348,11 @@ public class PageMail extends AbsTab {
 	public boolean zVerifyExternalImageInfoBarExists(String subject) throws HarnessException {
 		return sIsElementPresent("css=div[aria-label='"+subject+"'] span:contains('External images are not displayed.')");
 	}
-	
+
 	public String zGetMessageProperty (String subject, String property) throws HarnessException {
 
 		String viewLocator, listLocator, rowLocator, itemlocator;
-		
+
 		if (zGetPropMailView() == PageMailView.BY_MESSAGE) {
 			viewLocator = "__TV-main__";
 			listLocator = "css=ul[id='zl" + viewLocator + "rows']";
@@ -2371,17 +2371,17 @@ public class PageMail extends AbsTab {
 
 			if (listSubject.contains(subject)) {
 				String messageID = this.sGetAttribute(itemlocator + " span[id^='zlif" + viewLocator + "']@id");
-								
+
 				if (property.contains("flag")) {
 					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__fg");
 					Boolean isMessageFlagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgFlagRed']");
 					return isMessageFlagged.toString();
-					
+
 				} else if (property.contains("attachment")) {
 					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__at");
 					Boolean isMessageContainsAttachment = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgAttachment']");
 					return isMessageContainsAttachment.toString();
-					
+
 				} else if (property.contains("tag")) {
 					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__tg");
 					Boolean isMessageTagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] img[src^='data:image/png;base64']");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/FlagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/FlagMail.java
@@ -67,24 +67,8 @@ public class FlagMail extends PrefGroupMailByMessageTest {
 		// Flag the item
 		app.zPageMail.zListItem(Action.A_MAIL_FLAG, mail.dSubject);
 
-		// Get the item from the list
-		List<MailItem> messages = app.zPageMail.zListGetMessages();
-		ZAssert.assertNotNull(messages, "Verify the message list exists");
-
-		MailItem listmail = null;
-		for (MailItem m : messages) {
-			logger.info("Subject: looking for "+ mail.dSubject +" found: "+ m.gSubject);
-			if ( mail.dSubject.equals(m.gSubject) ) {
-				listmail = m;
-				break;
-			}
-		}
-
-		
-
 		// Make sure the GUI shows "flagged"
-		ZAssert.assertNotNull(listmail, "Verify the message is in the list");
-		ZAssert.assertTrue(listmail.gIsFlagged, "Verify the message is flagged in the list");
+		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "true", "Verify the message is shown as flagged in the UI");
 		
 		// Make sure the server shows "flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
@@ -124,24 +108,8 @@ public class FlagMail extends PrefGroupMailByMessageTest {
 		// Flag the item
 		app.zPageMail.zKeyboardShortcut(Shortcut.S_MAIL_MARKFLAG);
 		
-		// Get the item from the list
-		List<MailItem> messages = app.zPageMail.zListGetMessages();
-		ZAssert.assertNotNull(messages, "Verify the message list exists");
-
-		MailItem listmail = null;
-		for (MailItem m : messages) {
-			logger.info("Subject: looking for "+ mail.dSubject +" found: "+ m.gSubject);
-			if ( mail.dSubject.equals(m.gSubject) ) {
-				listmail = m;
-				break;
-			}
-		}
-
-		
-		
 		// Make sure the GUI shows "flagged"
-		ZAssert.assertNotNull(listmail, "Verify the message is in the list");
-		ZAssert.assertTrue(listmail.gIsFlagged, "Verify the message is flagged in the list");
+		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "true", "Verify the message is shown as flagged in the UI");
 		
 		// Make sure the server shows "flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/FlagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/FlagMail.java
@@ -16,34 +16,27 @@
  */
 package com.zimbra.qa.selenium.projects.universal.tests.mail.mail;
 
-import java.util.*;
-
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.projects.universal.core.PrefGroupMailByMessageTest;
 
-
 public class FlagMail extends PrefGroupMailByMessageTest {
 
 	public FlagMail() {
 		logger.info("New "+ FlagMail.class.getCanonicalName());
-		
-		
-		
-
-		
 	}
-	
+
+
 	@Test( description = "Flag a mail  clicking flagged icon",
 			groups = { "smoke", "L1" })
+
 	public void FlagMail_01() throws HarnessException {
-		
+
 		// Create the message data to be sent
 		String subject = "subject"+ ConfigProperties.getUniqueString();
-		
+
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -54,37 +47,36 @@ public class FlagMail extends PrefGroupMailByMessageTest {
 							"</mp>" +
 						"</m>" +
 					"</SendMsgRequest>");
-		
+
 		// Create a mail item to represent the message
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
-				
+
 		// Select the item
 		app.zPageMail.zListItem(Action.A_LEFTCLICK, mail.dSubject);
-		
+
 		// Flag the item
 		app.zPageMail.zListItem(Action.A_MAIL_FLAG, mail.dSubject);
 
 		// Make sure the GUI shows "flagged"
 		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "true", "Verify the message is shown as flagged in the UI");
-		
+
 		// Make sure the server shows "flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
 		ZAssert.assertStringContains(mail.getFlags(), "f", "Verify the message is flagged in the server");
-
-		
 	}
 
-	
+
 	@Test( description = "Flag a mail by using shortcut 'mf'",
 			groups = { "functional", "L2" })
+
 	public void FlagMail_02() throws HarnessException {
-		
+
 		// Create the message data to be sent
 		String subject = "subject"+ ConfigProperties.getUniqueString();
-		
+
 		ZimbraAccount.AccountA().soapSend(
 					"<SendMsgRequest xmlns='urn:zimbraMail'>" +
 						"<m>" +
@@ -95,28 +87,24 @@ public class FlagMail extends PrefGroupMailByMessageTest {
 							"</mp>" +
 						"</m>" +
 					"</SendMsgRequest>");
-		
+
 		// Create a mail item to represent the message
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
-				
+
 		// Select the item
 		app.zPageMail.zListItem(Action.A_LEFTCLICK, mail.dSubject);
-		
+
 		// Flag the item
 		app.zPageMail.zKeyboardShortcut(Shortcut.S_MAIL_MARKFLAG);
-		
+
 		// Make sure the GUI shows "flagged"
 		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "true", "Verify the message is shown as flagged in the UI");
-		
+
 		// Make sure the server shows "flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ subject +")");
 		ZAssert.assertStringContains(mail.getFlags(), "f", "Verify the message is flagged in the server");
-
-		
 	}
-
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/UnFlagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/UnFlagMail.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.universal.tests.mail.mail;
 
-import java.util.*;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
@@ -30,7 +29,10 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		logger.info("New " + UnFlagMail.class.getCanonicalName());
 	}
 
-	@Test(description = "Un-Flag a mail by clicking flagged icon", groups = { "smoke", "L1" })
+
+	@Test(description = "Un-Flag a mail by clicking flagged icon",
+			groups = { "smoke", "L1" })
+
 	public void UnFlagMail_01() throws HarnessException {
 
 		// Create the message data to be sent
@@ -63,10 +65,12 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		// Make sure the server shows "un-flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject + ")");
 		ZAssert.assertStringDoesNotContain(mail.getFlags(), "f", "Verify the message is not flagged in the server");
-
 	}
 
-	@Test(description = "Un-Flag a mail by using shortcut 'mf'", groups = { "functional", "L2" })
+
+	@Test(description = "Un-Flag a mail by using shortcut 'mf'",
+			groups = { "functional", "L2" })
+
 	public void UnFlagMail_02() throws HarnessException {
 
 		// Create the message data to be sent
@@ -100,5 +104,4 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject + ")");
 		ZAssert.assertStringDoesNotContain(mail.getFlags(), "f", "Verify the message is not flagged in the server");
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/UnFlagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/UnFlagMail.java
@@ -57,24 +57,10 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		// Flag the item
 		app.zPageMail.zListItem(Action.A_MAIL_UNFLAG, mail.dSubject);
 
-		// Get the item from the list
-		List<MailItem> messages = app.zPageMail.zListGetMessages();
-		ZAssert.assertNotNull(messages, "Verify the message list exists");
+		// Make sure the GUI shows "un-flagged"
+		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "false", "Verify the message is shown as un-flagged in the UI");
 
-		MailItem listmail = null;
-		for (MailItem m : messages) {
-			logger.info("Subject: looking for " + mail.dSubject + " found: " + m.gSubject);
-			if (mail.dSubject.equals(m.gSubject)) {
-				listmail = m;
-				break;
-			}
-		}
-
-		// Make sure the GUI shows "flagged"
-		ZAssert.assertNotNull(listmail, "Verify the message is in the list");
-		ZAssert.assertFalse(listmail.gIsFlagged, "Verify the message is flagged in the list");
-
-		// Make sure the server shows "flagged"
+		// Make sure the server shows "un-flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject + ")");
 		ZAssert.assertStringDoesNotContain(mail.getFlags(), "f", "Verify the message is not flagged in the server");
 
@@ -107,24 +93,10 @@ public class UnFlagMail extends PrefGroupMailByMessageTest {
 		// Flag the item
 		app.zPageMail.zKeyboardShortcut(Shortcut.S_MAIL_MARKFLAG);
 
-		// Get the item from the list
-		List<MailItem> messages = app.zPageMail.zListGetMessages();
-		ZAssert.assertNotNull(messages, "Verify the message list exists");
+		// Make sure the GUI shows "un-flagged"
+		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "false", "Verify the message is shown as un-flagged in the UI");
 
-		MailItem listmail = null;
-		for (MailItem m : messages) {
-			logger.info("Subject: looking for " + mail.dSubject + " found: " + m.gSubject);
-			if (mail.dSubject.equals(m.gSubject)) {
-				listmail = m;
-				break;
-			}
-		}
-
-		// Make sure the GUI shows "flagged"
-		ZAssert.assertNotNull(listmail, "Verify the message is in the list");
-		ZAssert.assertFalse(listmail.gIsFlagged, "Verify the message is flagged in the list");
-
-		// Make sure the server shows "flagged"
+		// Make sure the server shows "un-flagged"
 		mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject + ")");
 		ZAssert.assertStringDoesNotContain(mail.getFlags(), "f", "Verify the message is not flagged in the server");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/PageMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/PageMail.java
@@ -2295,6 +2295,7 @@ public class PageMail extends AbsTab {
 			throw new HarnessException("Action " + action.toString() + " is not applicable for Edition columns on Page mail");
 		}
 	}
+	
 	public boolean zVerifyColumnPresent(Column column) throws HarnessException {
 
 		logger.info(myPageName() + " zVerifyColumnPresent (" + column.name() + ") ");
@@ -2309,6 +2310,56 @@ public class PageMail extends AbsTab {
 		}
 		return sIsElementPresent(locatorPrefix + "[id$='" + column.value +"']");
 
+	}
+	
+	public boolean zVerifyExternalImageInfoBarExists(String subject) throws HarnessException {
+		return sIsElementPresent("css=div[aria-label='"+subject+"'] span:contains('External images are not displayed.')");
+	}
+	
+	public String zGetMessageProperty (String subject, String property) throws HarnessException {
+
+		String viewLocator, listLocator, rowLocator, itemlocator;
+		
+		if (zGetPropMailView() == PageMailView.BY_MESSAGE) {
+			viewLocator = "__TV-main__";
+			listLocator = "css=ul[id='zl" + viewLocator + "rows']";
+			rowLocator = "li[id^='zli" + viewLocator + "']";
+		} else {
+			viewLocator = "__CLV-main__";
+			listLocator = "css=ul[id='zl" + viewLocator + "rows']";
+			rowLocator = "li[id^='zli" + viewLocator + "']";
+		}
+
+		int count = this.sGetCssCount(listLocator + " " + rowLocator);
+
+		for (int i = 1; i <= count; i++) {
+			itemlocator = listLocator + " li:nth-of-type(" + i + ") ";
+			String listSubject = this.sGetText(itemlocator + " [id$='__su']").trim();
+
+			if (listSubject.contains(subject)) {
+				String messageID = this.sGetAttribute(itemlocator + " span[id^='zlif" + viewLocator + "']@id");
+								
+				if (property.contains("flag")) {
+					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__fg");
+					Boolean isMessageFlagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgFlagRed']");
+					return isMessageFlagged.toString();
+					
+				} else if (property.contains("attachment")) {
+					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__at");
+					Boolean isMessageContainsAttachment = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgAttachment']");
+					return isMessageContainsAttachment.toString();
+					
+				} else if (property.contains("tag")) {
+					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__tg");
+					Boolean isMessageTagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] img[src^='data:image/png;base64']");
+					return isMessageTagged.toString();
+
+				} else {
+					break;
+				}
+			}
+		}
+		return null;
 	}
 
 }

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/PageMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/mail/PageMail.java
@@ -2295,7 +2295,7 @@ public class PageMail extends AbsTab {
 			throw new HarnessException("Action " + action.toString() + " is not applicable for Edition columns on Page mail");
 		}
 	}
-	
+
 	public boolean zVerifyColumnPresent(Column column) throws HarnessException {
 
 		logger.info(myPageName() + " zVerifyColumnPresent (" + column.name() + ") ");
@@ -2311,15 +2311,15 @@ public class PageMail extends AbsTab {
 		return sIsElementPresent(locatorPrefix + "[id$='" + column.value +"']");
 
 	}
-	
+
 	public boolean zVerifyExternalImageInfoBarExists(String subject) throws HarnessException {
 		return sIsElementPresent("css=div[aria-label='"+subject+"'] span:contains('External images are not displayed.')");
 	}
-	
+
 	public String zGetMessageProperty (String subject, String property) throws HarnessException {
 
 		String viewLocator, listLocator, rowLocator, itemlocator;
-		
+
 		if (zGetPropMailView() == PageMailView.BY_MESSAGE) {
 			viewLocator = "__TV-main__";
 			listLocator = "css=ul[id='zl" + viewLocator + "rows']";
@@ -2338,17 +2338,17 @@ public class PageMail extends AbsTab {
 
 			if (listSubject.contains(subject)) {
 				String messageID = this.sGetAttribute(itemlocator + " span[id^='zlif" + viewLocator + "']@id");
-								
+
 				if (property.contains("flag")) {
 					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__fg");
 					Boolean isMessageFlagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgFlagRed']");
 					return isMessageFlagged.toString();
-					
+
 				} else if (property.contains("attachment")) {
 					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__at");
 					Boolean isMessageContainsAttachment = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgAttachment']");
 					return isMessageContainsAttachment.toString();
-					
+
 				} else if (property.contains("tag")) {
 					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__tg");
 					Boolean isMessageTagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] img[src^='data:image/png;base64']");


### PR DESCRIPTION
ZCS-3415: Fixed Flag and UnFlag testcases and introduced new function for checking flag, tag & attachment

# New function to check whether message tagged, flagged or contains attachment?

// USAGE: Make sure the GUI shows "flagged"
		ZAssert.assertStringContains(app.zPageMail.zGetMessageProperty(subject, "flag"), "true", "Verify the message is shown as flagged in the UI");

	public String zGetMessageProperty (String subject, String property) throws HarnessException {

		String viewLocator, listLocator, rowLocator, itemlocator;
		
		if (zGetPropMailView() == PageMailView.BY_MESSAGE) {
			viewLocator = "__TV-main__";
			listLocator = "css=ul[id='zl" + viewLocator + "rows']";
			rowLocator = "li[id^='zli" + viewLocator + "']";
		} else {
			viewLocator = "__CLV-main__";
			listLocator = "css=ul[id='zl" + viewLocator + "rows']";
			rowLocator = "li[id^='zli" + viewLocator + "']";
		}

		int count = this.sGetCssCount(listLocator + " " + rowLocator);

		for (int i = 1; i <= count; i++) {
			itemlocator = listLocator + " li:nth-of-type(" + i + ") ";
			String listSubject = this.sGetText(itemlocator + " [id$='__su']").trim();

			if (listSubject.contains(subject)) {
				String messageID = this.sGetAttribute(itemlocator + " span[id^='zlif" + viewLocator + "']@id");
								
				if (property.contains("flag")) {
					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__fg");
					Boolean isMessageFlagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgFlagRed']");
					return isMessageFlagged.toString();
					
				} else if (property.contains("attachment")) {
					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__at");
					Boolean isMessageContainsAttachment = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] div[class='ImgAttachment']");
					return isMessageContainsAttachment.toString();
					
				} else if (property.contains("tag")) {
					messageID = this.sGetAttribute(itemlocator + "span[id^='zlif" + viewLocator + "']@id").replace("__fr", "__tg");
					Boolean isMessageTagged = this.sIsVisible(itemlocator + "div[id='" + messageID + "'] img[src^='data:image/png;base64']");
					return isMessageTagged.toString();

				} else {
					break;
				}
			}
		}
		return null;
	}

![unflag mail - fixed](https://user-images.githubusercontent.com/21263826/32157509-f45342b0-bd69-11e7-85e2-f1ea5f318c4a.png)
