### PR TITLE
ZCS-3331: Fixed firefox window resize issue and a small modification in displayMailContent testcase

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/core/ClientSession.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ClientSession.java
@@ -186,7 +186,6 @@ public class ClientSession {
 				System.setProperty("webdriver.gecko.driver", driverFilePath);
 				options.setCapability(CapabilityType.LOGGING_PREFS, logs);
 				webDriver = new FirefoxDriver(options);
-				webDriver.manage().window().maximize();
 
 			} else {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DisplayMailContent.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DisplayMailContent.java
@@ -80,7 +80,7 @@ public class DisplayMailContent extends PrefGroupMailByMessageTest {
 		
 		String multilineTextData = "";
 		if(ConfigProperties.getStringProperty("browser").contains("firefox")){
-			multilineTextData = "BoldString <br>ItalicString <br>Underline text <br>Red color text <br>Green background <br><br>Number list below : <br><br><br>    1. point one <br>    2. point two <br>    3. point three";
+			multilineTextData = "BoldString <br>ItalicString <br>Underline text <br>Red color text <br>Green background <br><br>Number list below : <br><br><br>&nbsp;&nbsp; &nbsp;1. point one <br>&nbsp;&nbsp; &nbsp;2. point two <br>&nbsp;&nbsp; &nbsp;3. point three";
 		}else{
 			multilineTextData = "BoldString <br />ItalicString <br />Underline text <br />Red color text <br />Green background <br /><br />Number list below : <br /><br /><br />    1. point one <br />    2. point two <br />    3. point three";
 		}


### PR DESCRIPTION
- Removed window.maximize() code because it actually resize firefox window to small.
- By default window always opens maximized...