### PR TITLE
ZCS-3416: Formatting of all Calendar, Briefcase tests and renamed group L4 to deprecated, L5 to application-bug

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/DeleteCos.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/DeleteCos.java
@@ -141,7 +141,7 @@ public class DeleteCos extends AdminCommonTest {
 	 * @throws HarnessException
 	 */
 	@Test( description = "Verify delete cos operation -- Search list view",
-			groups = { "obsolete", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 			public void functional() throws HarnessException {
 
 		// Create a new cos in the Admin Console using SOAP
@@ -196,7 +196,7 @@ public class DeleteCos extends AdminCommonTest {
 	 * @throws HarnessException
 	 */
 	@Test( description = "Verify delete cos in -- Search list view/Right click menu",
-			groups = { "obsolete", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 			public void DeleteCos_04() throws HarnessException {
 
 		// Create a new cos in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/CreateDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/CreateDistributionList.java
@@ -44,7 +44,7 @@ public class CreateDistributionList extends AdminCommonTest {
 	 * @throws HarnessException
 	 */
 	@Test( description = "Create a basic DL",
-			groups = { "obsolete", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 			public void CreateDistributionList_01() throws HarnessException {
 
 		// Create a new dl in the Admin Console

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/navigation/HomePageLinks.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/navigation/HomePageLinks.java
@@ -46,7 +46,7 @@ public class HomePageLinks extends AdminCommonTest {
 	 * @throws HarnessException
 	 */
 	@Test( description = "Navigate to Install License",
-			groups = { "obsolete", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 			public void NavigateHomePageLinks_01() throws HarnessException {
 		
 		// click on Install license Link on Home page and check if it redirects to proper page

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/CreateResource.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/CreateResource.java
@@ -46,7 +46,7 @@ public class CreateResource extends AdminCommonTest {
 	 * @throws HarnessException
 	 */
 	@Test( description = "Create a basic resource",
-			groups = { "obsolete", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 			public void CreateResource_01() throws HarnessException {
 
 		// Create a new resource in the Admin Console
@@ -80,7 +80,7 @@ public class CreateResource extends AdminCommonTest {
 	 * @throws HarnessException
 	 */
 	@Test( description = "Create a basic resource using Manage Accounts --> Resources --> Gear box --> New",
-			groups = { "obsolete", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 			public void CreateResource_02() throws HarnessException {
 
 		// Create a new resource in the Admin Console

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/topmenu/logo/BasicLogo.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/topmenu/logo/BasicLogo.java
@@ -29,7 +29,7 @@ public class BasicLogo extends AdminCommonTest {
 	}
 	
 	@Test( description = "Verify the Top Menu displays the Logo image correctly",
-			groups = { "skip", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 	public void TopMenu_BasicLogo_01() throws HarnessException {
 		throw new HarnessException("Implement me!");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/topmenu/search/BasicSearch.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/topmenu/search/BasicSearch.java
@@ -29,7 +29,7 @@ public class BasicSearch extends AdminCommonTest {
 	}
 	
 	@Test( description = "Verify the Top Menu displays the Search bar correctly",
-			groups = { "skip", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 	public void TopMenu_BasicSearch_01() throws HarnessException {
 		throw new HarnessException("Implement me!");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/AppBriefcase.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/AppBriefcase.java
@@ -35,20 +35,19 @@ public class AppBriefcase extends FeatureBriefcaseTest {
 
 	public AppBriefcase() {
 		logger.info("New " + AppBriefcase.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-		
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 	}
 
-	@Test( description = "?app=briefcase in url", 
+
+	@Test( description = "?app=briefcase in url",
 			groups = { "smoke", "L1" })
+
 	public void AppBriefcase_01() throws HarnessException {
-		
-		//Go to AB tab
-				app.zPageContacts.zNavigateTo();				
-				SleepUtil.sleepMedium();
+
+		// Go to briefcase app
+		app.zPageContacts.zNavigateTo();
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
@@ -74,24 +73,18 @@ public class AppBriefcase extends FeatureBriefcaseTest {
 						+ "</content>"
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
-		
-		
+
 		// Reload the application, with app=tasks query parameter
 		ZimbraURI uri = new ZimbraURI(ZimbraURI.getBaseURI());
 		uri.addQuery("app", "briefcase");
 		app.zPageMail.sOpen(uri.toString());
-		SleepUtil.sleepMedium();	
+		SleepUtil.sleepMedium();
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
-		// String name = app.zPageBriefcase.getText(docName);
-		// ZAssert.assertEquals(name, docName,
-		// "Verify document name through GUI");
 		boolean present = app.zPageBriefcase.waitForPresentInListView(docName);
 		ZAssert.assertTrue(present, "Verify document name through GUI");
-
 	}
 }
-

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/OpenLinkToMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/OpenLinkToMessage.java
@@ -18,10 +18,8 @@ package com.zimbra.qa.selenium.projects.ajax.tests.briefcase;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Button;
@@ -39,25 +37,22 @@ public class OpenLinkToMessage extends FeatureBriefcaseTest {
 
 	public OpenLinkToMessage() {
 		logger.info("New " + OpenLinkToMessage.class.getCanonicalName());
-
-		// test starts in the Briefcase tab
 		super.startingPage = app.zPageBriefcase;
-
-		// use an account with message view
 		super.startingAccountPreferences.put("zimbraPrefGroupMailBy", "message");
 		super.startingAccountPreferences.put("zimbraPrefMessageViewHtmlPreferred", "TRUE");
 	}
 
+
 	@Bugs(ids = "56802,64833,65939,67059")
-	@Test( description = "Open link to the message - Verify List View Rows are displayed after message closed", 
+	@Test( description = "Open link to the message - Verify List View Rows are displayed after message closed",
 			groups = { "functional", "L2" })
-	
+
 	public void OpenLinkToMessage_01() throws HarnessException {
+
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();
 
-		ZimbraAccount.AccountA()
-				.soapSend(
+		ZimbraAccount.AccountA().soapSend(
 						"<SendMsgRequest xmlns='urn:zimbraMail'>" + "<m>"
 								+ "<e t='t' a='"
 								+ app.zGetActiveAccount().EmailAddress + "'/>"
@@ -67,25 +62,14 @@ public class OpenLinkToMessage extends FeatureBriefcaseTest {
 								+ "</content>" + "</mp>" + "</m>"
 								+ "</SendMsgRequest>");
 
-		// The starting page intentionally defined as Briefcase and not Mail
-		// From Briefcase open Mail page by clicking on Mail tab 
-		app.zPageMain.zClickAt("id=zb__App__Mail_title", "0,0");
-		
-		SleepUtil.sleepSmall();
-		
+		app.zPageMail.zNavigateTo();
+
 		// Click Get Mail button to view message in the list
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
 
-		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(),
-				"subject:(" + subject + ")");
-
-		// Store opened url
-		// url = ConfigProperties.getBaseURL();
+		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject + ")");
 
 		url = app.zPageBriefcase.getLocation();
-
-		// Open link through RestUtil
-		// Map<String, String> map = CodeCoverage.getInstance().getQueryMap();
 
 		Map<String, String> map = new HashMap<String, String>();
 
@@ -94,7 +78,7 @@ public class OpenLinkToMessage extends FeatureBriefcaseTest {
 
 			for (String p : query.split("&")) {
 				if (p.contains("=")) {
-					map.put(p.split("=")[0], p.split("=")[1].substring(0,1));
+					map.put(p.split("=")[0], p.split("=")[1].substring(0, 1));
 				}
 			}
 		}
@@ -102,22 +86,16 @@ public class OpenLinkToMessage extends FeatureBriefcaseTest {
 		map.put("id", mail.getId());
 
 		app.zPageBriefcase.openUrl("", map);
-		
+
 		String locator = PageBriefcase.Locators.zCloseIconBtn.locator;
 
-		app.zPageBriefcase
-				.zWaitForElementPresent(locator);
-		
+		app.zPageBriefcase.zWaitForElementPresent(locator);
+
+		app.zPageBriefcase.sClickAt(locator, "");
 		SleepUtil.sleepSmall();
 
-		app.zPageBriefcase.sClickAt(locator,"");
-				
-		SleepUtil.sleepVerySmall();
-		
-		ZAssert
-				.assertTrue(app.zPageBriefcase
-						.zWaitForElementPresent("css=[id=zl__TV-main__rows]","5000"),
-						"Verify List View Rows are displayed after message pane is closed");
+		ZAssert.assertTrue(app.zPageBriefcase.zWaitForElementPresent("css=[id=zl__TV-main__rows]", "5000"),
+				"Verify List View Rows are displayed after message pane is closed");
 	}
 
 	@AfterMethod(groups = { "always" })

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/CreateDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/CreateDocument.java
@@ -33,7 +33,6 @@ import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.ui.Shortcut;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.projects.ajax.core.FeatureBriefcaseTest;
@@ -45,17 +44,18 @@ public class CreateDocument extends FeatureBriefcaseTest {
 
 	public CreateDocument() {
 		logger.info("New " + CreateDocument.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox", "TRUE");
 	}
 
+
 	@Bugs(ids = "97124")
-	@Test( description = "Create document through GUI - verify through GUI", 
+	@Test( description = "Create document through GUI - verify through GUI",
 		groups = { "sanity", "L0" })
-	
+
 	public void CreateDocument_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -78,12 +78,13 @@ public class CreateDocument extends FeatureBriefcaseTest {
 			documentBriefcaseNew.zFillField(DocumentBriefcaseNew.Field.Body, docText);
 
 			documentBriefcaseNew.zSubmit();
+
 		} finally {
 			app.zPageBriefcase.sSelectWindow(null);
 			app.zPageBriefcase.sWindowFocus();
 		}
 
-		// Refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Click on created document
@@ -118,11 +119,13 @@ public class CreateDocument extends FeatureBriefcaseTest {
 		ZAssert.assertStringContains(name, docName,	"Verify document name through GUI");
 		ZAssert.assertStringContains(text, docText,	"Verify document text through GUI");
 	}
-	
-	@Test( description = "Create document using keyboard shortcut - verify through SOAP & RestUtil", 
+
+
+	@Test( description = "Create document using keyboard shortcut - verify through SOAP & RestUtil",
 			groups = { "functional", "L3" })
-	
+
 	public void CreateDocument_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -156,7 +159,7 @@ public class CreateDocument extends FeatureBriefcaseTest {
 
 		app.zPageBriefcase.zWaitForWindowClosed(DocumentBriefcaseNew.pageTitle);
 
-		// Refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Display file through RestUtil
@@ -173,7 +176,6 @@ public class CreateDocument extends FeatureBriefcaseTest {
 		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>" + "<query>" + docName + "</query>" + "</SearchRequest>");
 
 		String name = account.soapSelectValue("//mail:SearchResponse//mail:doc", "name");
-
 		ZAssert.assertNotNull(name, "Verify the search response returns the document name");
 		ZAssert.assertStringContains(name, docName, "Verify document name through SOAP");
 
@@ -182,19 +184,20 @@ public class CreateDocument extends FeatureBriefcaseTest {
 
 		ZAssert.assertStringContains(response.get(PageBriefcase.Response.ResponsePart.BODY), docText, "Verify document content through GUI");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docName);
 	}
-	
+
+
 	@Bugs(ids="81299")
-	@Test( description = "Create document using New menu pulldown menu - verify through SOAP & RestUtil", 
+	@Test( description = "Create document using New menu pulldown menu - verify through SOAP & RestUtil",
 			groups = { "smoke", "L1" })
-	
+
 	public void CreateDocument_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem document = new DocumentItem();
@@ -202,11 +205,8 @@ public class CreateDocument extends FeatureBriefcaseTest {
 		String docName = document.getName();
 		String docText = document.getDocText();
 
-		// Refresh briefcase page before creating a new document
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
-
-		SleepUtil.sleepVerySmall();
+		// Select briefcase folder before creating a new document
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Create a new document using New pull down menu
 		DocumentBriefcaseNew documentBriefcaseNew = (DocumentBriefcaseNew) app.zPageBriefcase.zToolbarPressPulldown(Button.B_NEW, Button.O_NEW_DOCUMENT, document);
@@ -227,7 +227,7 @@ public class CreateDocument extends FeatureBriefcaseTest {
 
 		app.zPageBriefcase.zWaitForWindowClosed(DocumentBriefcaseNew.pageTitle);
 
-		// Refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Search for created document
@@ -242,9 +242,10 @@ public class CreateDocument extends FeatureBriefcaseTest {
 		ZAssert.assertStringContains(docName, name, "Verify document name through SOAP");
 		ZAssert.assertEquals(dateFormat.format(modDate), dateFormat.format(date), "modified date is displayed correctly");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docName);
 	}
+
 
 	@AfterMethod(groups = { "always" })
 	public void afterMethod() throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/DeleteDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/DeleteDocument.java
@@ -25,7 +25,6 @@ import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.ui.Shortcut;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.XmlStringUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
@@ -37,23 +36,22 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 
 	public DeleteDocument() {
 		logger.info("New " + DeleteDocument.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-		
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 	}
 
-	@Test( description = "Create document through SOAP - delete & check trash", 
+
+	@Test( description = "Create document through SOAP - delete & check trash",
 			groups = { "smoke", "L0" })
+
 	public void DeleteDocument_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
-		FolderItem trashFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Trash);
+		FolderItem trashFolder = FolderItem.importFromSOAP(account, SystemFolder.Trash);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -62,11 +60,9 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 		String docText = docItem.getDocText();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -81,75 +77,60 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 		String docId = account.soapSelectValue(
 				"//mail:SaveDocumentResponse//mail:doc", "id");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-
 		// Click on created document
-		
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Click on Delete document icon in toolbar
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zToolbarPressButton(Button.B_DELETE, docItem);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zToolbarPressButton(Button.B_DELETE, docItem);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was deleted from the list
-		boolean isDeleted = app.zPageBriefcase
-				.waitForDeletedFromListView(docName);
+		boolean isDeleted = app.zPageBriefcase.waitForDeletedFromListView(docName);
 
-		ZAssert
-				.assertTrue(isDeleted,
-						"Verify document was deleted through GUI");
+		ZAssert.assertTrue(isDeleted, "Verify document was deleted through GUI");
 
 		// Verify document moved to Trash
-		account
-				.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
+		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
 						+ "<query>in:"
 						+ trashFolder.getName()
 						+ " "
 						+ docName
 						+ "</query>" + "</SearchRequest>");
 
-		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc",
-				"id");
-
-		ZAssert.assertNotNull(id,
-				"Verify the search response returns the document id");
-
-		ZAssert.assertEquals(id, docId,
-				"Verify the document was moved to the trash folder");
+		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "id");
+		ZAssert.assertNotNull(id, "Verify the search response returns the document id");
+		ZAssert.assertEquals(id, docId, "Verify the document was moved to the trash folder");
 	}
 
-	@Test( description = "Create document through SOAP - delete using Delete Key & verify through GUI", 
+
+	@Test( description = "Create document through SOAP - delete using Delete Key & verify through GUI",
 			groups = { "functional", "L2" })
+
 	public void DeleteDocument_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
 
 		String docName = docItem.getName();
 		String docText = docItem.getDocText();
-
 		Shortcut shortcut = Shortcut.S_DELETE;
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -161,43 +142,35 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-
 		// Click on created document
-		
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Click the Delete keyboard shortcut
-		// app.zPageBriefcase.zSelectWindow("Zimbra: Briefcase");
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zKeyboardShortcut(shortcut);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zKeyboardShortcut(shortcut);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was deleted
-		boolean isDeleted = app.zPageBriefcase
-				.waitForDeletedFromListView(docName);
-
-		ZAssert
-				.assertTrue(isDeleted,
-						"Verify document was deleted through GUI");
+		boolean isDeleted = app.zPageBriefcase.waitForDeletedFromListView(docName);
+		ZAssert.assertTrue(isDeleted, "Verify document was deleted through GUI");
 	}
+
 
 	@Test( description = "Create document through SOAP - delete using Backspace Key & verify through GUI",
 			groups = { "functional","L3" })
+
 	public void DeleteDocument_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -208,11 +181,9 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 		Shortcut shortcut = Shortcut.S_BACKSPACE;
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -224,43 +195,35 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-
 		// Click on created document
-		
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Delete Document using Backspace keyboard shortcut
-		// app.zPageBriefcase.zSelectWindow("Zimbra: Briefcase");
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zKeyboardShortcut(shortcut);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zKeyboardShortcut(shortcut);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was deleted
-		boolean isDeleted = app.zPageBriefcase
-				.waitForDeletedFromListView(docName);
-
-		ZAssert
-				.assertTrue(isDeleted,
-						"Verify document was deleted through GUI");
+		boolean isDeleted = app.zPageBriefcase.waitForDeletedFromListView(docName);
+		ZAssert.assertTrue(isDeleted, "Verify document was deleted through GUI");
 	}
 
-	@Test( description = "Create document through SOAP - delete using Right Click context menu & verify through GUI", 
+
+	@Test( description = "Create document through SOAP - delete using Right Click context menu & verify through GUI",
 			groups = { "smoke", "L1" })
+
 	public void DeleteDocument_04() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -269,11 +232,9 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 		String docText = docItem.getDocText();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -285,60 +246,47 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Click on created document
-		
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Delete Document using Right Click Context Menu
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zListItem(Action.A_RIGHTCLICK, Button.O_DELETE, docItem);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.O_DELETE, docItem);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was deleted
-		boolean isDeleted = app.zPageBriefcase
-				.waitForDeletedFromListView(docName);
-
-		ZAssert
-				.assertTrue(isDeleted,
-						"Verify document was deleted through GUI");
+		boolean isDeleted = app.zPageBriefcase.waitForDeletedFromListView(docName);
+		ZAssert.assertTrue(isDeleted, "Verify document was deleted through GUI");
 	}
 
-	@Test( description = "Delete multiple documents(3) by selecting check box and delete using toolbar", 
+
+	@Test( description = "Delete multiple documents(3) by selecting check box and delete using toolbar",
 			groups = { "functional", "L2" })
+
 	public void DeleteDocument_05() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
-
-		FolderItem trashFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Trash);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
+		FolderItem trashFolder = FolderItem.importFromSOAP(account, SystemFolder.Trash);
 
 		// Create documents using SOAP
-		DocumentItem[] docItems = {
-				new DocumentItem("docName1"
-						+ ConfigProperties.getUniqueString()),
-				new DocumentItem("docName2"
-						+ ConfigProperties.getUniqueString()),
-				new DocumentItem("docName3"
-						+ ConfigProperties.getUniqueString()) };
+		DocumentItem[] docItems = { new DocumentItem("docName1" + ConfigProperties.getUniqueString()),
+				new DocumentItem("docName2" + ConfigProperties.getUniqueString()),
+				new DocumentItem("docName3" + ConfigProperties.getUniqueString()) };
 
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ ConfigProperties.getUniqueString() + "</body>"
-				+ "</html>");
+		String contentHTML = XmlStringUtil
+				.escapeXml("<html>" + "<body>" + ConfigProperties.getUniqueString() + "</body>" + "</html>");
 
 		for (int i = 0; i < docItems.length; i++) {
-			account
-					.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+			account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 							+ "<doc name='"
 							+ docItems[i].getName()
 							+ "' l='"
@@ -350,32 +298,25 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 							+ "</doc>"
 							+ "</SaveDocumentRequest>");
 
-			docItems[i].setDocId(account.soapSelectValue(
-					"//mail:SaveDocumentResponse//mail:doc", "id"));
-
+			docItems[i].setDocId(account.soapSelectValue("//mail:SaveDocumentResponse//mail:doc", "id"));
 		}
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Select all three items
 		for (DocumentItem item : docItems) {
 			app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, item);
-			SleepUtil.sleepVerySmall();
 		}
 
 		// Click toolbar delete button
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zToolbarPressButton(Button.B_DELETE, docItems[0]);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zToolbarPressButton(Button.B_DELETE, docItems[0]);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
-
-		SleepUtil.sleepVerySmall();
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify items are deleted);
 		for (DocumentItem item : docItems) {
@@ -383,36 +324,30 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 			String docId = item.getId();
 
 			// Verify document was deleted from the list
-			ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(name),
-					"Verify the document " + name
-							+ " is no longer in the list view");
+			ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(name), "Verify the document " + name + " is no longer in the list view");
 
 			// Verify document moved to Trash
-			account
-					.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
+			account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
 							+ "<query>in:"
 							+ trashFolder.getName()
 							+ " "
 							+ name
 							+ "</query>" + "</SearchRequest>");
 
-			String id = account.soapSelectValue(
-					"//mail:SearchResponse//mail:doc", "id");
-
-			ZAssert.assertNotNull(id,
-					"Verify the search response returns the document id");
-
-			ZAssert
-					.assertEquals(docId, id, "Verify the deleted document: "
-							+ name + " id: " + docId
-							+ " was moved to the trash folder");
+			String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "id");
+			ZAssert.assertNotNull(id, "Verify the search response returns the document id");
+			ZAssert.assertEquals(docId, id,
+					"Verify the deleted document: " + name + " id: " + docId + " was moved to the trash folder");
 		}
 	}
 
+
 	@Bugs(ids = "43836")
-	@Test( description = "can not delete documents in briefcase with the same file name",
-	groups = { "functional", "L3" })
+	@Test(description = "can not delete documents in briefcase with the same file name",
+			groups = { "functional", "L3" })
+
 	public void DeleteDocument_06() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
@@ -440,10 +375,8 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 
 		String docId = account.soapSelectValue("//mail:SaveDocumentResponse//mail:doc", "id");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
@@ -454,7 +387,7 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was deleted from the list
@@ -473,7 +406,7 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "id");
 		ZAssert.assertNotNull(id, "Verify the search response returns the document id");
 		ZAssert.assertEquals(id, docId,	"Verify the document was moved to the trash folder");
-		
+
 		// Create document using SOAP
 		String contentHTML1 = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
@@ -491,10 +424,8 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 
 		String docId1 = account.soapSelectValue("//mail:SaveDocumentResponse//mail:doc", "id");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
@@ -505,7 +436,7 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was deleted from the list
@@ -526,14 +457,16 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 		ZAssert.assertEquals(id, docId1,	"Verify the document was moved to the trash folder");
 	}
 
+
 	@Bugs(ids = "103343")
-	@Test( description = "Create document with 3 versions through SOAP - delete using Right Click context menu & verify through GUI",
-	groups = { "functional", "L3" })
+	@Test(description = "Create document with 3 versions through SOAP - delete using Right Click context menu & verify through GUI", 
+			groups = { "functional", "L3" })
+
 	public void DeleteDocument_07() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -549,59 +482,49 @@ public class DeleteDocument extends FeatureBriefcaseTest {
 		String nodeExpanded = "css=div[id^=zlif__BDLV-main__] div[class='ImgNodeExpanded']";
 		String locator = "css=tr[id^='zlif__BDLV-main__'] div[id^='zlif__BDLV-main__']:contains('#2:')";
 		String dialogText = "css=div[id='CONFIRM_DIALOG_content'] div[class='DwtConfirmDialogQuestion']:contains('Are you sure you want to permanently delete \"" + docName + "\"?')";
+
 		// Create document using SOAP
-		String contentHTML1 = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docTextV1 + "</body>" + "</html>");
-		
-		String contentHTML2 = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docTextV2 + "</body>" + "</html>");
-		
-		String contentHTML3 = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docTextV3 + "</body>" + "</html>");
-		
+		String contentHTML1 = XmlStringUtil.escapeXml("<html>" + "<body>" + docTextV1 + "</body>" + "</html>");
+		String contentHTML2 = XmlStringUtil.escapeXml("<html>" + "<body>" + docTextV2 + "</body>" + "</html>");
+		String contentHTML3 = XmlStringUtil.escapeXml("<html>" + "<body>" + docTextV3 + "</body>" + "</html>");
+
 		account.soapSend(
 				"<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>" +
-				"<doc ct='application/x-zimbra-doc' name='"+ docName +"' descEnabled='true' l='"+ briefcaseFolder.getId() +"' desc='" + notesV1 +"'>" +
-				"<content>" + contentHTML1 + "</content>" +
-				"</doc>" +
+					"<doc ct='application/x-zimbra-doc' name='"+ docName +"' descEnabled='true' l='"+ briefcaseFolder.getId() +"' desc='" + notesV1 +"'>" +
+					"<content>" + contentHTML1 + "</content></doc>" +
 				"</SaveDocumentRequest>");
 		String documentId = account.soapSelectValue("//mail:doc", "id");
-		
+
 		account.soapSend(
 				"<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>" +
-				"<doc ct='application/x-zimbra-doc' name='"+ docName +"' descEnabled='true' ver='1' id='" + documentId + "' l='"+ briefcaseFolder.getId() +"' desc='" + notesV2 +"'>" +
-				"<content>" + contentHTML2 + "</content>" +
-				"</doc>" +
+					"<doc ct='application/x-zimbra-doc' name='"+ docName +"' descEnabled='true' ver='1' id='" + documentId + "' l='"+ briefcaseFolder.getId() +"' desc='" + notesV2 +"'>" +
+					"<content>" + contentHTML2 + "</content></doc>" +
 				"</SaveDocumentRequest>");
 
 		account.soapSend(
 				"<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>" +
-				"<doc ct='application/x-zimbra-doc' name='"+ docName +"' descEnabled='true' ver='2' id='" + documentId + "' l='"+ briefcaseFolder.getId() +"' desc='" + notesV3 +"'>" +
-				"<content>" + contentHTML3 + "</content>" +
-				"</doc>" +
+					"<doc ct='application/x-zimbra-doc' name='"+ docName +"' descEnabled='true' ver='2' id='" + documentId + "' l='"+ briefcaseFolder.getId() +"' desc='" + notesV3 +"'>" +
+					"<content>" + contentHTML3 + "</content></doc>" +
 				"</SaveDocumentRequest>");
-		
-		// refresh briefcase page
-		// refresh briefcase page
+
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-		
 		if (!app.zPageBriefcase.sIsElementPresent(nodeExpanded)) {
 			app.zPageBriefcase.zClickAt(nodeCollapsed, "");
 		}
-		
+
 		// Delete Document using Right Click Context Menu
 		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.O_DELETE, locator);
 		ZAssert.assertTrue(app.zPageBriefcase.sIsElementPresent(dialogText), "Verify that text is correct");
+
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was deleted
 		boolean isDeleted = app.zPageBriefcase.waitForDeletedFromListView(docName);
-
 		ZAssert.assertTrue(isDeleted, "Verify document was deleted through GUI");
 	}
-	
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/DisplayDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/DisplayDocument.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.document;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.DocumentItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
@@ -28,7 +27,6 @@ import com.zimbra.qa.selenium.framework.util.HarnessException;
 import com.zimbra.qa.selenium.framework.util.XmlStringUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
-import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.FeatureBriefcaseTest;
 import com.zimbra.qa.selenium.projects.ajax.ui.briefcase.DocumentBriefcaseOpen;
 
@@ -36,15 +34,17 @@ public class DisplayDocument extends FeatureBriefcaseTest {
 
 	public DisplayDocument() {
 		logger.info("New " + DisplayDocument.class.getCanonicalName());
-
-		super.startingPage = app.zPageBriefcase;		
+		super.startingPage = app.zPageBriefcase;
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 	}
 
-	@Test( description = "Create document through SOAP - verify through GUI", 
+
+	@Test( description = "Create document through SOAP - verify through GUI",
 			groups = { "smoke", "L0" })
+
 	public void DisplayDocument_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
@@ -71,32 +71,20 @@ public class DisplayDocument extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		// Verify document is created
-		// String name = app.zPageBriefcase.getText(docName);
-		// ZAssert.assertEquals(name, docName,
-		// "Verify document name through GUI");
 		boolean present = app.zPageBriefcase.waitForPresentInListView(docName);
-
 		ZAssert.assertTrue(present, "Verify document name through GUI");
-
-		/*
-		 * //name =ClientSessionFactory.session().selenium().getText(
-		 * "css=div[id='zl__BDLV__rows'][class='DwtListView-Rows'] td[width*='auto'] div[id^=zlif__BDLV__]"
-		 * );//ClientSessionFactory.session().selenium().isElementPresent(
-		 * "css=div[id='zl__BDLV__rows'][class='DwtListView-Rows'] td[width*='auto']>div:contains[id*='zlif__BDLV__']"
-		 * );//ClientSessionFactory.session().selenium().isElementPresent(
-		 * "css=div[id='zl__BDLV__rows'][class='DwtListView-Rows'] div:contains('name')"
-		 * );
-		 */
 	}
 
+
 	@Bugs(ids = "79994")
-	@Test( description = " german umlauts breaks briefcase ", 
-	groups = { "functional", "L3" })
+	@Test( description = " german umlauts breaks briefcase ",
+			groups = { "functional", "L3" })
+
 	public void DisplayDocument_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
@@ -122,23 +110,17 @@ public class DisplayDocument extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 		boolean present = app.zPageBriefcase.waitForPresentInListView(docName);
 
 		ZAssert.assertTrue(present, "Verify document name through GUI");
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, document);
+
 		// Click on open in a separate window icon in toolbar
 		DocumentBriefcaseOpen documentBriefcaseOpen;
-		if (ConfigProperties.zimbraGetVersionString().contains("7.1."))
-			documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase
-					.zToolbarPressButton(Button.B_OPEN_IN_SEPARATE_WINDOW,
-							document);
-		else
-			documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase
-					.zToolbarPressPulldown(Button.B_ACTIONS,
-							Button.B_LAUNCH_IN_SEPARATE_WINDOW, document);
-		
+		documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS,
+					Button.B_LAUNCH_IN_SEPARATE_WINDOW, document);
 		app.zPageBriefcase.isOpenDocLoaded(document);
 
 		String text = "";
@@ -157,13 +139,9 @@ public class DisplayDocument extends FeatureBriefcaseTest {
 			app.zPageBriefcase.zSelectWindow("Zimbra: Briefcase");
 		}
 
-		ZAssert.assertStringContains(text, docText,
-				"Verify document text through GUI");
+		ZAssert.assertStringContains(text, docText,	"Verify document text through GUI");
 
-		//delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docName);
-		
-
 	}
-	
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/EditDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/EditDocument.java
@@ -17,10 +17,8 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.document;
 
 import java.util.List;
-
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.DocumentItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
@@ -28,7 +26,6 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.XmlStringUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
@@ -47,7 +44,8 @@ public class EditDocument extends FeatureBriefcaseTest {
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test(description = "Create document through SOAP - edit name & verify through GUI", 
+
+	@Test(description = "Create document through SOAP - edit name & verify through GUI",
 			groups = { "smoke", "L2" })
 
 	public void EditDocument_01() throws HarnessException {
@@ -68,12 +66,10 @@ public class EditDocument extends FeatureBriefcaseTest {
 				+ docItem1.getName() + "' l='" + briefcaseFolder.getId() + "' ct='application/x-zimbra-doc'>"
 				+ "<content>" + contentHTML + "</content>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-		SleepUtil.sleepSmall();
 
 		// Click on created document
-
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem1);
 
 		// Click on Edit document icon in toolbar
@@ -98,22 +94,24 @@ public class EditDocument extends FeatureBriefcaseTest {
 			app.zPageBriefcase.zSelectWindow(PageBriefcase.pageTitle);
 		}
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// "Verify document name through GUI");
 		ZAssert.assertTrue(app.zPageBriefcase.waitForPresentInListView(docItem2.getName()),
 				"Verify document name through GUI");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docItem2.getName());
 	}
 
+
 	@Bugs(ids = "97124")
 	@Test(description = "Create document through SOAP - edit text & name & verify through GUI",
-	groups = { "smoke", "L2" })
+			groups = { "smoke", "L2" })
 
 	public void EditDocument_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -130,15 +128,11 @@ public class EditDocument extends FeatureBriefcaseTest {
 				+ docItem1.getName() + "' l='" + briefcaseFolder.getId() + "' ct='application/x-zimbra-doc'>"
 				+ "<content>" + contentHTML + "</content>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem1);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on Edit document icon in toolbar
 		DocumentBriefcaseEdit documentBriefcaseEdit = (DocumentBriefcaseEdit) app.zPageBriefcase
@@ -162,24 +156,16 @@ public class EditDocument extends FeatureBriefcaseTest {
 			app.zPageBriefcase.sSelectWindow(PageBriefcase.pageTitle);
 		}
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-
 		// Click on modified document
-
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem2);
 
 		// Click on open in a separate window icon in toolbar
 		DocumentBriefcaseOpen documentBriefcaseOpen;
-		if (ConfigProperties.zimbraGetVersionString().contains("7.1."))
-			documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase
-					.zToolbarPressButton(Button.B_OPEN_IN_SEPARATE_WINDOW, docItem2);
-		else
-			documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS,
+		documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS,
 					Button.B_LAUNCH_IN_SEPARATE_WINDOW, docItem2);
-
 		app.zPageBriefcase.isOpenDocLoaded(docItem2);
 
 		String name = "";
@@ -202,15 +188,17 @@ public class EditDocument extends FeatureBriefcaseTest {
 
 		ZAssert.assertStringContains(text, docItem2.getDocText(), "Verify document text through GUI");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docItem2.getName());
 	}
 
+
 	@Bugs(ids = "97124")
-	@Test(description = "Create document & edit text through SOAP & verify through GUI", 
-	groups = { "smoke", "L3" })
+	@Test(description = "Create document & edit text through SOAP & verify through GUI",
+			groups = { "smoke", "L3" })
 
 	public void EditDocument_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -231,13 +219,10 @@ public class EditDocument extends FeatureBriefcaseTest {
 				+ "</query>" + "</SearchRequest>");
 
 		String docId = account.soapSelectValue("//mail:doc", "id");
-
-		ZAssert.assertNotNull(docId, "Verify the search response returns the document id");
-
 		String version = account.soapSelectValue("//mail:doc", "ver");
 
+		ZAssert.assertNotNull(docId, "Verify the search response returns the document id");
 		ZAssert.assertNotNull(docId, "Verify the search response returns the document version");
-
 		docItem.setDocText("editText" + ConfigProperties.getUniqueString());
 
 		// Edit document through SOAP
@@ -246,7 +231,7 @@ public class EditDocument extends FeatureBriefcaseTest {
 				+ "' ct='application/x-zimbra-doc'>" + "<content>&lt;html>&lt;body>" + docItem.getDocText()
 				+ "&lt;/body>&lt;/html></content>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Click on modified document
@@ -255,13 +240,8 @@ public class EditDocument extends FeatureBriefcaseTest {
 
 		// Click on open in a separate window icon in toolbar
 		DocumentBriefcaseOpen documentBriefcaseOpen;
-		if (ConfigProperties.zimbraGetVersionString().contains("7.1."))
-			documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase
-					.zToolbarPressButton(Button.B_OPEN_IN_SEPARATE_WINDOW, docItem);
-		else
-			documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS,
+		documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS,
 					Button.B_LAUNCH_IN_SEPARATE_WINDOW, docItem);
-
 		app.zPageBriefcase.isOpenDocLoaded(docItem);
 
 		String text = "";
@@ -280,14 +260,16 @@ public class EditDocument extends FeatureBriefcaseTest {
 
 		ZAssert.assertStringContains(text, docItem.getDocText(), "Verify document text through GUI");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docItem.getName());
 	}
 
-	@Test(description = "Create document through SOAP - Edit Document using Right Click Context Menu & verify through GUI", 
+
+	@Test(description = "Create document through SOAP - Edit Document using Right Click Context Menu & verify through GUI",
 			groups = {"functional", "L2" })
 
 	public void EditDocument_04() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -303,11 +285,10 @@ public class EditDocument extends FeatureBriefcaseTest {
 				+ docItem.getName() + "' l='" + briefcaseFolder.getId() + "' ct='application/x-zimbra-doc'>"
 				+ "<content>" + contentHTML + "</content>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Click on created document
-
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Edit Document using Right Click Context Menu
@@ -338,7 +319,7 @@ public class EditDocument extends FeatureBriefcaseTest {
 
 		docItem.setDocName(editDocName);
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// "Verify document name through GUI");
@@ -346,7 +327,7 @@ public class EditDocument extends FeatureBriefcaseTest {
 
 		ZAssert.assertTrue(present, "Verify document name through GUI");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docItem.getName());
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/MoveDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/MoveDocument.java
@@ -21,9 +21,7 @@ import com.zimbra.qa.selenium.framework.items.DocumentItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.ui.Shortcut;
-
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.XmlStringUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
@@ -42,9 +40,12 @@ public class MoveDocument extends FeatureBriefcaseTest {
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test(description = "Create document through SOAP - move & verify through GUI", 
+
+	@Test(description = "Create document through SOAP - move & verify through GUI",
 			groups = { "smoke", "L0" })
+
 	public void MoveDocument_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -59,10 +60,10 @@ public class MoveDocument extends FeatureBriefcaseTest {
 
 		FolderItem subFolderItem = FolderItem.importFromSOAP(account, name);
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		// double click on created subfolder
+		// Double Click on created subfolder
 		app.zPageBriefcase.zListItem(Action.A_DOUBLECLICK, subFolderItem);
 
 		// Create document item
@@ -78,40 +79,23 @@ public class MoveDocument extends FeatureBriefcaseTest {
 
 		// document.importFromSOAP(account, document.getDocName());
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
-		// Click on 'Move selected item' icon in toolbar
-		if (ConfigProperties.zimbraGetVersionString().contains("7.2.")) {
-			DialogMove chooseFolder = (DialogMove) app.zPageBriefcase.zToolbarPressButton(Button.B_MOVE, docItem);
+		// Click move -> subfolder
+		app.zPageBriefcase.zToolbarPressPulldown(Button.B_MOVE, subFolderItem);
 
-			// Choose folder on Confirmation dialog
-			chooseFolder.zClickTreeFolder(subFolderItem);
-
-			// Click OK on Confirmation dialog
-			app.zPageBriefcase.zClick(
-					"//div[@id='ChooseFolderDialog_buttons']//td[contains(@id,'OK_')]//td[contains(@id,'_title')]");
-		} else {
-			// Click move -> subfolder
-			app.zPageBriefcase.zToolbarPressPulldown(Button.B_MOVE, subFolderItem);
-
-		}
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was moved from the folder
 		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(docItem.getName()),
 				"Verify document was moved from the folder");
 
-		SleepUtil.sleepVerySmall();
-
-		// click on subfolder in tree view
+		// Click on subfolder in tree view
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolderItem, true);
 
 		// Verify document was moved to the selected folder
@@ -119,9 +103,12 @@ public class MoveDocument extends FeatureBriefcaseTest {
 				"Verify document was moved to the selected folder");
 	}
 
-	@Test(description = "Move Document using 'm' keyboard shortcut", 
+
+	@Test(description = "Move Document using 'm' keyboard shortcut",
 			groups = { "functional", "L3" })
+
 	public void MoveDocument_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -143,7 +130,7 @@ public class MoveDocument extends FeatureBriefcaseTest {
 			subFolders[i] = FolderItem.importFromSOAP(account, subFolderNames[i]);
 		}
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, true);
 
 		// Create document item
@@ -157,17 +144,11 @@ public class MoveDocument extends FeatureBriefcaseTest {
 				+ docItem.getName() + "' l='" + subFolders[0].getId() + "' ct='application/x-zimbra-doc'>" + "<content>"
 				+ contentHTML + "</content>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, true);
 
-		// double-click on sub-folder1 in list view
+		// Double click on sub-folder1 in list view
 		app.zPageBriefcase.zListItem(Action.A_DOUBLECLICK, subFolders[0]);
-
-		// click on sub-folder1 in tree view to refresh view
-		// app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolders[0],
-		// true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document in list view
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
@@ -184,21 +165,17 @@ public class MoveDocument extends FeatureBriefcaseTest {
 
 		// app.zPageBriefcase.zClickAt("css=div[id=ChooseFolderDialog_button2]","0,0");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, true);
 
-		SleepUtil.sleepVerySmall();
-
-		// click on sub-folder1 in tree view
+		// Click on sub-folder1 in tree view
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolders[0], false);
 
 		// Verify document is no longer in the sub-folder1
 		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(docItem.getName()),
 				"Verify document is no longer in the folder: " + subFolders[0].getName());
 
-		SleepUtil.sleepVerySmall();
-
-		// click on sub-folder2 in tree view
+		// Click on sub-folder2 in tree view
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolders[1], true);
 
 		// Verify document was moved to sub-folder2
@@ -206,10 +183,12 @@ public class MoveDocument extends FeatureBriefcaseTest {
 				"Verify document was moved to the folder: " + subFolders[1].getName());
 	}
 
-	@Test(description = "Create document through SOAP - move using Right Click Context Menu & verify through GUI", 
+
+	@Test(description = "Create document through SOAP - move using Right Click Context Menu & verify through GUI",
 			groups = {"functional", "L3" })
 
 	public void MoveDocument_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -224,10 +203,10 @@ public class MoveDocument extends FeatureBriefcaseTest {
 
 		FolderItem subFolderItem = FolderItem.importFromSOAP(account, name);
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		// double click on created subfolder
+		// Double Click on created subfolder
 		app.zPageBriefcase.zListItem(Action.A_DOUBLECLICK, subFolderItem);
 
 		// Create document item
@@ -241,12 +220,8 @@ public class MoveDocument extends FeatureBriefcaseTest {
 				+ docItem.getName() + "' l='" + briefcaseFolderId + "' ct='application/x-zimbra-doc'>" + "<content>"
 				+ contentHTML + "</content>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// document.importFromSOAP(account, document.getDocName());
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
@@ -262,16 +237,14 @@ public class MoveDocument extends FeatureBriefcaseTest {
 		app.zPageBriefcase
 				.zClick("//div[@id='ChooseFolderDialog_buttons']//td[contains(@id,'OK_')]//td[contains(@id,'_title')]");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was moved from the folder
 		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(docItem.getName()),
 				"Verify document was moved from the folder");
 
-		SleepUtil.sleepVerySmall();
-
-		// click on subfolder in tree view
+		// Click on subfolder in tree view
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolderItem, true);
 
 		// Verify document was moved to the selected folder

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/OpenDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/OpenDocument.java
@@ -17,10 +17,8 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.document;
 
 import java.util.List;
-
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.DocumentItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
@@ -28,11 +26,9 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.XmlStringUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
-import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.FeatureBriefcaseTest;
 import com.zimbra.qa.selenium.projects.ajax.ui.briefcase.DocumentBriefcaseOpen;
 import com.zimbra.qa.selenium.projects.ajax.ui.briefcase.PageBriefcase;
@@ -41,20 +37,20 @@ public class OpenDocument extends FeatureBriefcaseTest {
 
 	public OpenDocument() {
 		logger.info("New " + OpenDocument.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
-		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");				
+		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
+
 	@Bugs(ids = "97124")
-	@Test( description = "Create document through SOAP - open & verify through GUI", 
+	@Test( description = "Create document through SOAP - open & verify through GUI",
 			groups = { "smoke", "L0" })
+
 	public void OpenDocument_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -63,11 +59,9 @@ public class OpenDocument extends FeatureBriefcaseTest {
 		String docText = docItem.getDocText();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -79,26 +73,16 @@ public class OpenDocument extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-		
 		// Click on created document
-		
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Click on open in a separate window icon in toolbar
 		DocumentBriefcaseOpen documentBriefcaseOpen;
-		if (ConfigProperties.zimbraGetVersionString().contains("7.1."))
-			documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase
-					.zToolbarPressButton(Button.B_OPEN_IN_SEPARATE_WINDOW,
-							docItem);
-		else
-			documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase
-					.zToolbarPressPulldown(Button.B_ACTIONS,
-							Button.B_LAUNCH_IN_SEPARATE_WINDOW, docItem);
-		
+		documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS,
+					Button.B_LAUNCH_IN_SEPARATE_WINDOW, docItem);
 		app.zPageBriefcase.isOpenDocLoaded(docItem);
 
 		String text = "";
@@ -117,29 +101,21 @@ public class OpenDocument extends FeatureBriefcaseTest {
 			app.zPageBriefcase.zSelectWindow("Zimbra: Briefcase");
 		}
 
-		ZAssert.assertStringContains(text, docText,
-				"Verify document text through GUI");
+		ZAssert.assertStringContains(text, docText, "Verify document text through GUI");
 
-		//delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docName);
-		
-		/*
-		 * //name =ClientSessionFactory.session().selenium().getText(
-		 * "css=div[id='zl__BDLV__rows'][class='DwtListView-Rows'] td[width*='auto'] div[id^=zlif__BDLV__]"
-		 * );//ClientSessionFactory.session().selenium().isElementPresent(
-		 * "css=div[id='zl__BDLV__rows'][class='DwtListView-Rows'] td[width*='auto']>div:contains[id*='zlif__BDLV__']"
-		 * );//ClientSessionFactory.session().selenium().isElementPresent(
-		 * "css=div[id='zl__BDLV__rows'][class='DwtListView-Rows'] div:contains('name')"
-		 * );
-		 */
 	}
 
-	@Test( description = "Create document through SOAP - Double click to open in new window & verify through GUI", groups = { "functional","L1" })
+
+	@Test( description = "Create document through SOAP - Double click to open in new window & verify through GUI",
+			groups = { "functional","L1" })
+
 	public void OpenDocument_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -148,11 +124,9 @@ public class OpenDocument extends FeatureBriefcaseTest {
 		String docText = docItem.getDocText();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -164,19 +138,17 @@ public class OpenDocument extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Click on created document
-		
+
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Double Click on item in the list view
 		DocumentBriefcaseOpen documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase
 				.zListItem(Action.A_DOUBLECLICK, docItem);
 
-		//app.zPageBriefcase.isOpenDocLoaded(docName, docText);
-
 		String text = "";
 
 		// Select document opened in a separate window
@@ -189,23 +161,26 @@ public class OpenDocument extends FeatureBriefcaseTest {
 			app.zPageBriefcase.zSelectWindow(docName);
 
 			app.zPageBriefcase.closeWindow();
+
 		} finally {
 			app.zPageBriefcase.zSelectWindow("Zimbra: Briefcase");
 		}
 
-		ZAssert.assertStringContains(text, docText,
-				"Verify document text through GUI");
-		
-		//delete file upon test completion
+		ZAssert.assertStringContains(text, docText, "Verify document text through GUI");
+
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docName);
 	}
-	
-	@Test( description = "Create document through SOAP - open using Right Click Context Menu & verify through GUI", groups = { "functional", "L2" })
+
+
+	@Test(description = "Create document through SOAP - open using Right Click Context Menu & verify through GUI",
+			groups = { "functional", "L2" })
+
 	public void OpenDocument_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -214,11 +189,9 @@ public class OpenDocument extends FeatureBriefcaseTest {
 		String docText = docItem.getDocText();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -230,18 +203,15 @@ public class OpenDocument extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Click on created document
-		
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Open Document using Right Click Context Menu
 		DocumentBriefcaseOpen documentBriefcaseOpen = (DocumentBriefcaseOpen) app.zPageBriefcase.
 		zListItem(Action.A_RIGHTCLICK, Button.O_OPEN, docItem);
-		
-		//app.zPageBriefcase.isOpenDocLoaded(docName, docText);
 
 		String text = "";
 
@@ -255,24 +225,24 @@ public class OpenDocument extends FeatureBriefcaseTest {
 			app.zPageBriefcase.zSelectWindow(docName);
 
 			app.zPageBriefcase.closeWindow();
+
 		} finally {
 			app.zPageBriefcase.zSelectWindow("Zimbra: Briefcase");
 		}
 
-		ZAssert.assertStringContains(text, docText,
-				"Verify document text through GUI");
-		
-		//delete file upon test completion
+		ZAssert.assertStringContains(text, docText, "Verify document text through GUI");
+
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(docName);
 	}
-	
+
 	@AfterMethod(groups = { "always" })
 	public void afterMethod() throws HarnessException {
 		logger.info("Checking for the opened window ...");
 
 		// Check if the window is still open
 		List<String> windows = app.zPageBriefcase.sGetAllWindowNames();
-				
+
 		for (String window : windows) {
 			if (!window.isEmpty() && !window.contains("null") && !window.contains(PageBriefcase.pageTitle)
 					&& !window.contains("main_app_window")

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/SendDocAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/SendDocAttachment.java
@@ -23,11 +23,9 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.XmlStringUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
-import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.FeatureBriefcaseTest;
 import com.zimbra.qa.selenium.projects.ajax.ui.DialogWarning;
 import com.zimbra.qa.selenium.projects.ajax.ui.briefcase.PageBriefcase;
@@ -37,19 +35,19 @@ public class SendDocAttachment extends FeatureBriefcaseTest {
 
 	public SendDocAttachment() {
 		logger.info("New " + SendDocAttachment.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test( description = "Create document through SOAP - click Send as attachment, Cancel & verify through GUI", 
+
+	@Test( description = "Create document through SOAP - click Send as attachment, Cancel & verify through GUI",
 			groups = { "functional", "L2" })
+
 	public void SendDocAttachment_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -58,11 +56,9 @@ public class SendDocAttachment extends FeatureBriefcaseTest {
 		String docText = docItem.getDocText();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -74,21 +70,15 @@ public class SendDocAttachment extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Click on Send as attachment
 		FormMailNew mailform;
-		if (ConfigProperties.zimbraGetVersionString().contains("7.1."))
-			mailform = (FormMailNew) app.zPageBriefcase.zToolbarPressPulldown(
-					Button.B_SEND, Button.O_SEND_AS_ATTACHMENT, docItem);
-		else
-			mailform = (FormMailNew) app.zPageBriefcase.zToolbarPressPulldown(
+		mailform = (FormMailNew) app.zPageBriefcase.zToolbarPressPulldown(
 					Button.B_ACTIONS, Button.O_SEND_AS_ATTACHMENT, docItem);
 
 		// Verify the new mail form has attachment
@@ -104,7 +94,7 @@ public class SendDocAttachment extends FeatureBriefcaseTest {
 		ZAssert.assertNotNull(warningDlg, "Verify the dialog is returned");
 
 		// Dismiss the dialog
-		//warningDlg.zClickButton(Button.B_NO);		
+		//warningDlg.zClickButton(Button.B_NO);
 		// Click No on warning dialog
 		app.zPageBriefcase.zClick("//div[@id='YesNoCancel']//td[contains(@id,'No_')]//td[contains(@id,'_title')]");
 
@@ -112,17 +102,19 @@ public class SendDocAttachment extends FeatureBriefcaseTest {
 		// Make sure the dialog is dismissed
 		warningDlg.zWaitForClose();
 
-		// delete document upon test completion
+		// Delete document upon test completion
 		app.zPageBriefcase.deleteFileByName(docItem.getName());
 	}
 
-	@Test( description = "Send document as attachment using Right Click Context Menu & verify through GUI", 
+
+	@Test( description = "Send document as attachment using Right Click Context Menu & verify through GUI",
 			groups = { "functional", "L2" })
+
 	public void SendDocAttachment_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -131,11 +123,9 @@ public class SendDocAttachment extends FeatureBriefcaseTest {
 		String docText = docItem.getDocText();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -147,12 +137,8 @@ public class SendDocAttachment extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		// SleepUtil.sleepVerySmall();
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
@@ -168,20 +154,18 @@ public class SendDocAttachment extends FeatureBriefcaseTest {
 
 		// Cancel the message
 		// A warning dialog should appear regarding losing changes
-		DialogWarning warningDlg = (DialogWarning) mailform
-				.zToolbarPressButton(Button.B_CANCEL);
+		DialogWarning warningDlg = (DialogWarning) mailform.zToolbarPressButton(Button.B_CANCEL);
 
 		ZAssert.assertNotNull(warningDlg, "Verify the dialog is returned");
 
 		// Dismiss the dialog
-		//warningDlg.zClickButton(Button.B_NO);		
+		//warningDlg.zClickButton(Button.B_NO);
 		// Click No on warning dialog
 		app.zPageBriefcase.zClick("//div[@id='YesNoCancel']//td[contains(@id,'No_')]//td[contains(@id,'_title')]");
 
-
 		warningDlg.zWaitForClose(); // Make sure the dialog is dismissed
 
-		// delete document upon test completion
+		// Delete document upon test completion
 		app.zPageBriefcase.deleteFileByName(docItem.getName());
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/SendDocLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/SendDocLink.java
@@ -22,13 +22,10 @@ import com.zimbra.qa.selenium.framework.items.FolderItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
-
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.XmlStringUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
-import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.FeatureBriefcaseTest;
 import com.zimbra.qa.selenium.projects.ajax.ui.DialogWarning;
 import com.zimbra.qa.selenium.projects.ajax.ui.briefcase.DialogConfirm;
@@ -38,20 +35,20 @@ public class SendDocLink extends FeatureBriefcaseTest {
 
 	public SendDocLink() {
 		logger.info("New " + SendDocLink.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
-		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");				
+		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test( description = "Create document through SOAP - click Send Link, Cancel & verify through GUI", 
+
+	@Test( description = "Create document through SOAP - click Send Link, Cancel & verify through GUI",
 			groups = { "functional", "L2" })
+
 	public void SendDocLink_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -60,11 +57,9 @@ public class SendDocLink extends FeatureBriefcaseTest {
 		String docText = docItem.getDocText();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -76,25 +71,16 @@ public class SendDocLink extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Click on Send Link
 		DialogConfirm confDlg;
-		if (ConfigProperties.zimbraGetVersionString().contains("7.1."))
-			confDlg = (DialogConfirm) app.zPageBriefcase
-			.zToolbarPressPulldown(Button.B_SEND, Button.O_SEND_LINK, docItem);
-		else
-			confDlg = (DialogConfirm) app.zPageBriefcase.zToolbarPressPulldown(
-					Button.B_ACTIONS, Button.O_SEND_LINK, docItem);
-	
+		confDlg = (DialogConfirm) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS, Button.O_SEND_LINK, docItem);
+
 		// Click Yes on confirmation dialog
 		FormMailNew mailform = (FormMailNew) confDlg.zClickButton(Button.B_YES);
 
@@ -102,16 +88,14 @@ public class SendDocLink extends FeatureBriefcaseTest {
 		ZAssert.assertTrue(mailform.zIsActive(), "Verify the new form opened");
 
 		// Verify link
-		boolean visible = mailform.zWaitForIframeText(
-				"css=iframe[id*=_body_ifr]", docName);
+		boolean visible = mailform.zWaitForIframeText("css=iframe[id*=_body_ifr]", docName);
 		ZAssert.assertTrue(visible,"Verify the link text");
 
 		// Cancel the message
 		// A warning dialog should appear regarding losing changes
-		DialogWarning warningDlg = (DialogWarning) mailform
-				.zToolbarPressButton(Button.B_CANCEL);
+		DialogWarning warningDlg = (DialogWarning) mailform.zToolbarPressButton(Button.B_CANCEL);
 
-		// temporary: check if dialog exists since it was implemented recently on send link 
+		// temporary: check if dialog exists since it was implemented recently on send link
 		if (warningDlg.zIsActive()) {
 			// Dismiss the dialog
 			warningDlg.zClickButton(Button.B_NO);
@@ -120,17 +104,19 @@ public class SendDocLink extends FeatureBriefcaseTest {
 			warningDlg.zWaitForClose();
 		}
 
-		// delete document upon test completion
+		// Delete document upon test completion
 		app.zPageBriefcase.deleteFileByName(docItem.getName());
 	}
 
-	@Test( description = "Send document link using Right Click Context Menu & verify through GUI", 
+
+	@Test( description = "Send document link using Right Click Context Menu & verify through GUI",
 			groups = { "functional", "L2" })
+
 	public void SendDocLink_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
@@ -139,11 +125,9 @@ public class SendDocLink extends FeatureBriefcaseTest {
 		String docText = docItem.getDocText();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docText + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docText + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docName
 						+ "' l='"
@@ -155,19 +139,14 @@ public class SendDocLink extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		//SleepUtil.sleepVerySmall();
-		
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Click on Send Link using Right Click Context Menu
-		DialogConfirm confDlg = (DialogConfirm) app.zPageBriefcase.zListItem(
-				Action.A_RIGHTCLICK, Button.O_SEND_LINK, docItem);
+		DialogConfirm confDlg = (DialogConfirm) app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.O_SEND_LINK, docItem);
 
 		// Click Yes on confirmation dialog
 		FormMailNew mailform = (FormMailNew) confDlg.zClickButton(Button.B_YES);
@@ -176,16 +155,13 @@ public class SendDocLink extends FeatureBriefcaseTest {
 		ZAssert.assertTrue(mailform.zIsActive(), "Verify the new form opened");
 
 		// Verify link
-		ZAssert.assertTrue(mailform.zWaitForIframeText(
-				"css=iframe[id*=_body_ifr]", docName),
-				"Verify the link text");
+		ZAssert.assertTrue(mailform.zWaitForIframeText("css=iframe[id*=_body_ifr]", docName), "Verify the link text");
 
 		// Cancel the message
 		// A warning dialog should appear regarding losing changes
-		DialogWarning warningDlg = (DialogWarning) mailform
-				.zToolbarPressButton(Button.B_CANCEL);
+		DialogWarning warningDlg = (DialogWarning) mailform.zToolbarPressButton(Button.B_CANCEL);
 
-		// temporary: check if dialog exists since it was implemented recently on send link 
+		// temporary: check if dialog exists since it was implemented recently on send link
 		if (warningDlg.zIsActive()) {
 			// Dismiss the dialog
 			warningDlg.zClickButton(Button.B_NO);
@@ -194,8 +170,7 @@ public class SendDocLink extends FeatureBriefcaseTest {
 			warningDlg.zWaitForClose();
 		}
 
-		// delete document upon test completion
+		// Delete document upon test completion
 		app.zPageBriefcase.deleteFileByName(docItem.getName());
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/TagDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/TagDocument.java
@@ -28,17 +28,16 @@ public class TagDocument extends FeatureBriefcaseTest {
 
 	public TagDocument() {
 		logger.info("New " + TagDocument.class.getCanonicalName());
-
-		// All tests start at the Briefcase page
 		super.startingPage = app.zPageBriefcase;
-
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
-	
-	@Test(description = "Tag a Document using Toolbar -> Tag -> New Tag", 
+
+
+	@Test(description = "Tag a Document using Toolbar -> Tag -> New Tag",
 			groups = { "smoke", "L1" })
 
 	public void TagDocument_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -56,13 +55,10 @@ public class TagDocument extends FeatureBriefcaseTest {
 				+ "' l='" + briefcaseFolder.getId() + "' ct='application/x-zimbra-doc'>" + "<content>" + contentHTML
 				+ "</content>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-
 		// Click on created document
-
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Create a tag using GUI
@@ -72,7 +68,6 @@ public class TagDocument extends FeatureBriefcaseTest {
 		DialogTag dialogTag = (DialogTag) app.zPageBriefcase.zToolbarPressPulldown(Button.B_TAG, Button.O_TAG_NEWTAG,
 				null);
 
-		SleepUtil.sleepSmall();
 		dialogTag.zSetTagName(tagName);
 		dialogTag.zClickButton(Button.B_OK);
 
@@ -86,34 +81,24 @@ public class TagDocument extends FeatureBriefcaseTest {
 				+ "</query>" + "</SearchRequest>");
 
 		String name = account.soapSelectValue("//mail:SearchResponse//mail:doc", "name");
-
 		ZAssert.assertEquals(name, docName, "Verify tagged document name");
-
-		// Make sure the tag was applied to the document
-		// account.soapSend("<SearchRequest xmlns='urn:zimbraMail'
-		// types='document'>"
-		// + "<query>in:briefcase</query></SearchRequest>");
-
-		// String id = account.soapSelectValue(
-		// "//mail:SearchResponse//mail:doc[@name='" + docName + "']", "t");
-
 		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>" + "<query>" + docName + "</query>"
 				+ "</SearchRequest>");
 
 		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "t");
-
 		ZAssert.assertNotNull(id, "Verify the search response returns the document tag id");
-
 		ZAssert.assertEquals(id, tagId, "Verify the tag was attached to the document");
 
-		// delete Document upon test completion
+		// Delete Document upon test completion
 		app.zPageBriefcase.deleteFileByName(docName);
 	}
-	
-	@Test(description = "Tag a Document using pre-existing Tag", 
+
+
+	@Test(description = "Tag a Document using pre-existing Tag",
 			groups = { "functional", "L2" })
 
 	public void TagDocument_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -141,13 +126,10 @@ public class TagDocument extends FeatureBriefcaseTest {
 		TagItem tag = TagItem.importFromSOAP(app.zGetActiveAccount(), tagName);
 		ZAssert.assertNotNull(tag, "Verify the new tag was created");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-
 		// Click on created document
-
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
 
 		// Tag document selecting pre-existing tag from Toolbar drop down list
@@ -158,19 +140,19 @@ public class TagDocument extends FeatureBriefcaseTest {
 				+ "</SearchRequest>");
 
 		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "t");
-
 		ZAssert.assertNotNull(id, "Verify the search response returns the document tag id");
-
 		ZAssert.assertEquals(id, tag.getId(), "Verify the tag was attached to the document");
 
-		// delete Document upon test completion
+		// Delete Document upon test completion
 		app.zPageBriefcase.deleteFileByName(docName);
 	}
 
-	@Test(description = "Tag a Document using Right Click context menu", 
+
+	@Test(description = "Tag a Document using Right Click context menu",
 			groups = { "functional", "L2" })
 
 	public void TagDocument_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -198,10 +180,8 @@ public class TagDocument extends FeatureBriefcaseTest {
 		TagItem tagItem = TagItem.importFromSOAP(app.zGetActiveAccount(), tagName);
 		ZAssert.assertNotNull(tagItem, "Verify the new tag was created");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
@@ -214,12 +194,10 @@ public class TagDocument extends FeatureBriefcaseTest {
 				+ "</SearchRequest>");
 
 		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "t");
-
 		ZAssert.assertNotNull(id, "Verify the search response returns the document tag id");
-
 		ZAssert.assertEquals(id, tagItem.getId(), "Verify the tag was attached to the document");
 
-		// delete Document upon test completion
+		// Delete Document upon test completion
 		app.zPageBriefcase.deleteFileByName(docName);
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/UnTagDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/UnTagDocument.java
@@ -27,30 +27,27 @@ public class UnTagDocument extends FeatureBriefcaseTest {
 
 	public UnTagDocument() {
 		logger.info("New " + UnTagDocument.class.getCanonicalName());
-
-		// All tests start at the Briefcase page
 		super.startingPage = app.zPageBriefcase;
-
-		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");				
+		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test( description = "Remove a tag from a Document using Toolbar -> Tag -> Remove Tag", 
+
+	@Test( description = "Remove a tag from a Document using Toolbar -> Tag -> Remove Tag",
 			groups = { "smoke", "L1" })
+
 	public void UnTagDocument_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create document item
 		DocumentItem docItem = new DocumentItem();
 
 		// Create document using SOAP
-		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>"
-				+ docItem.getDocText() + "</body>" + "</html>");
+		String contentHTML = XmlStringUtil.escapeXml("<html>" + "<body>" + docItem.getDocText() + "</body>" + "</html>");
 
-		account
-				.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
+		account.soapSend("<SaveDocumentRequest requestId='0' xmlns='urn:zimbraMail'>"
 						+ "<doc name='"
 						+ docItem.getName()
 						+ "' l='"
@@ -62,86 +59,20 @@ public class UnTagDocument extends FeatureBriefcaseTest {
 						+ "</doc>"
 						+ "</SaveDocumentRequest>");
 
-		/*
-		 * String docId =
-		 * account.soapSelectValue("//mail:SaveDocumentResponse//mail:doc"
-		 * ,"id");
-		 * 
-		 * // Search for created documentaccount.soapSend(
-		 * "<SearchRequest xmlns='urn:zimbraMail' types='document'>" +
-		 * "<query>in:" + briefcaseFolder.getName() +
-		 * "</query></SearchRequest>");
-		 * 
-		 * String docId = account.soapSelectValue(
-		 * "//mail:SearchResponse//mail:doc[@name='" + docName + "']", "id");
-		 * String version = account.soapSelectValue(
-		 * "//mail:SearchResponse//mail:doc[@name='" + docName + "']", "ver");
-		 * 
-		 * account.soapSend(
-		 * "<SearchRequest xmlns='urn:zimbraMail' types='document'>" + "<query>"
-		 * + docName + "</query>" + "</SearchRequest>");
-		 * 
-		 * docId = account.soapSelectValue("//mail:doc", "id"); version =
-		 * account.soapSelectValue("//mail:doc", "ver");
-		 */
-
 		// Create a tag
 		String tagName = "tag" + ConfigProperties.getUniqueString();
 
-		/*
-		 * //this flow needs page reload account.soapSend(
-		 * "<CreateTagRequest xmlns='urn:zimbraMail'>" + "<tag name='"+ tagName
-		 * +"' color='1' />" + "</CreateTagRequest>");
-		 * 
-		 * String tagId =
-		 * account.soapSelectValue("//mail:CreateTagResponse/mail:tag", "id");
-		 * 
-		 * account.soapSend( "<ItemActionRequest xmlns='urn:zimbraMail'>" +
-		 * "<action id='"+ docId +"' op='tag' tag='" + tagId + "'/>" +
-		 * "</ItemActionRequest>");
-		 * 
-		 * //ClientSessionFactory.session().selenium().refresh();
-		 */
-
-		/*
-		 * // this flow is using tag pull down menu // refresh briefcase page
-		 * app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder,
-		 * true);
-		 * 
-		 * SleepUtil.sleepVerySmall();
-		 * 
-		 * // Click on created document
-		 * 
-		 * app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
-		 * 
-		 * // Click on New Tag DialogTag dialogTag = (DialogTag)
-		 * app.zPageBriefcase .zToolbarPressPulldown(Button.B_TAG,
-		 * Button.O_TAG_NEWTAG, null);
-		 * 
-		 * dialogTag.zSetTagName(tagName); dialogTag.zClickButton(Button.B_OK);
-		 */
-
-		account.soapSend("<CreateTagRequest xmlns='urn:zimbraMail'>"
-				+ "<tag name='" + tagName + "' color='1' />"
+		account.soapSend("<CreateTagRequest xmlns='urn:zimbraMail'>" + "<tag name='" + tagName + "' color='1' />"
 				+ "</CreateTagRequest>");
 
-		// Make sure the tag was created on the server
-		// account.soapSend("<GetTagRequest xmlns='urn:zimbraMail'/>");
-		// String tagId = account.soapSelectValue(
-		//		"//mail:GetTagResponse//mail:tag[@name='" + tagName + "']",
-		//		"id");
+		TagItem tagItem = TagItem.importFromSOAP(app.zGetActiveAccount(), tagName);
 
-		TagItem tagItem = TagItem.importFromSOAP(app.zGetActiveAccount(),
-				tagName);
-		
 		ZAssert.assertNotNull(tagItem, "Verify the new tag was created");
 
 		String tagId = tagItem.getId();
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
@@ -151,26 +82,18 @@ public class UnTagDocument extends FeatureBriefcaseTest {
 				tagItem.getName(), docItem);
 
 		// Make sure the tag was applied to the document
-		account
-				.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
+		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
 						+ "<query>"
 						+ docItem.getName()
 						+ "</query>"
 						+ "</SearchRequest>");
 
-		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc",
-				"t");
+		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "t");
+		ZAssert.assertNotNull(id, "Verify the search response returns the document tag id");
+		ZAssert.assertEquals(id, tagId, "Verify the tag was attached to the document");
 
-		ZAssert.assertNotNull(id,
-				"Verify the search response returns the document tag id");
-
-		ZAssert.assertEquals(id, tagId,
-				"Verify the tag was attached to the document");
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepVerySmall();
 
 		// Click on tagged document
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
@@ -179,16 +102,13 @@ public class UnTagDocument extends FeatureBriefcaseTest {
 		app.zPageBriefcase.zToolbarPressPulldown(Button.B_TAG,
 				Button.O_TAG_REMOVETAG, docItem);
 
-		account
-				.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
+		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
 						+ "<query>"
 						+ docItem.getName()
 						+ "</query>"
 						+ "</SearchRequest>");
 
 		id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "t");
-
-		ZAssert.assertStringDoesNotContain(id, tagId,
-				"Verify that the tag is removed from the message");
+		ZAssert.assertStringDoesNotContain(id, tagId, "Verify that the tag is removed from the message");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/CheckInFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/CheckInFile.java
@@ -23,7 +23,6 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -34,23 +33,22 @@ public class CheckInFile extends FeatureBriefcaseTest {
 
 	public CheckInFile() {
 		logger.info("New " + CheckInFile.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test( description = "Check Out File through SOAP - right click 'Check In' - click 'Cancel'", 
+
+	@Test( description = "Check Out File through SOAP - right click 'Check In' - click 'Cancel'",
 			groups = { "functional", "L2" })
+
 	public void CheckInFile_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		FileItem file = new FileItem(filePath);
 
@@ -64,71 +62,59 @@ public class CheckInFile extends FeatureBriefcaseTest {
 				+ "<doc l='" + briefcaseFolder.getId() + "'>" + "<upload id='"
 				+ attachmentId + "'/>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// account.soapSelectNode("//mail:SaveDocumentResponse", 1);
-
-		// search the uploaded file
-		account
-				.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
-						+ "<query>"
-						+ fileName
-						+ "</query>"
-						+ "</SearchRequest>");
+		// Search the uploaded file
+		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>" + "<query>" + fileName + "</query>"
+				+ "</SearchRequest>");
 
 		// Verify file name through SOAP
 		String name = account.soapSelectValue("//mail:doc", "name");
 		ZAssert.assertEquals(name, fileName, "Verify file name through SOAP");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-		
-		//Verify Lock icon is not present for the uploaded file
+		// Verify Lock icon is not present for the uploaded file
 		ZAssert.assertFalse(app.zPageBriefcase.isLockIconPresent(file),"Verify Lock icon is not present for the uploaded file");
-		
+
 		// Check Out file through SOAP
 		String id = account.soapSelectValue("//mail:doc", "id");
 		account.soapSend("<ItemActionRequest xmlns='urn:zimbraMail'>"
 				+ "<action id='" + id + "' op='lock'/>"
 				+ "</ItemActionRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-
-		//Verify Lock icon is present for the checked out file
+		// Verify Lock icon is present for the checked out file
 		ZAssert.assertTrue(app.zPageBriefcase.isLockIconPresent(file),"Verify Lock icon is present for the checked out file");
 
 		// Right click on the locked file and select Check In File context menu
-		DialogCheckInFile dlg = (DialogCheckInFile) app.zPageBriefcase
-				.zListItem(Action.A_RIGHTCLICK, Button.O_CHECK_IN_FILE, file);
+		DialogCheckInFile dlg = (DialogCheckInFile) app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK,
+				Button.O_CHECK_IN_FILE, file);
 
 		// Verify the 'Check In File to Briefcase' dialog is displayed
-		ZAssert.assertTrue(dlg.zIsActive(),
-				"Verify the 'Check In File to Briefcase' dialog is displayed");
+		ZAssert.assertTrue(dlg.zIsActive(), "Verify the 'Check In File to Briefcase' dialog is displayed");
 
 		// Dismiss dialog by clicking on Cancel button
 		dlg.zClickButton(Button.B_CANCEL);
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileById(id);
 	}
-	
-	@Test( description = "Check Out File through SOAP - right click 'Discard Check Out'", 
+
+
+	@Test( description = "Check Out File through SOAP - right click 'Discard Check Out'",
 			groups = { "functional", "L2" })
+
 	public void CheckInFile_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
-
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 		FileItem file = new FileItem(filePath);
-
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
@@ -139,53 +125,43 @@ public class CheckInFile extends FeatureBriefcaseTest {
 				+ "<doc l='" + briefcaseFolder.getId() + "'>" + "<upload id='"
 				+ attachmentId + "'/>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// search the uploaded file
-		account
-				.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
-						+ "<query>"
-						+ fileName
-						+ "</query>"
-						+ "</SearchRequest>");
+		// Search the uploaded file
+		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>" + "<query>" + fileName + "</query>"
+				+ "</SearchRequest>");
 
 		// Verify file name through SOAP
 		String name = account.soapSelectValue("//mail:doc", "name");
 		ZAssert.assertEquals(name, fileName, "Verify file name through SOAP");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-		
-		//Verify Lock icon is not present for the uploaded file
+		// Verify Lock icon is not present for the uploaded file
 		ZAssert.assertFalse(app.zPageBriefcase.isLockIconPresent(file),"Verify Lock icon is not present for the uploaded file");
-		
+
 		// Check Out file through SOAP
 		String id = account.soapSelectValue("//mail:doc", "id");
 		account.soapSend("<ItemActionRequest xmlns='urn:zimbraMail'>"
 				+ "<action id='" + id + "' op='lock'/>"
 				+ "</ItemActionRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-
-		//Verify Lock icon is present for the checked out file
+		// Verify Lock icon is present for the checked out file
 		ZAssert.assertTrue(app.zPageBriefcase.isLockIconPresent(file),"Verify Lock icon is present for the checked out file");
 
 		// Right click on the locked file and select Discard Check Out context menu
 		app.zPageBriefcase
 				.zListItem(Action.A_RIGHTCLICK, Button.O_DISCARD_CHECK_OUT, file);
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepVerySmall();
-		
-		//Verify Lock icon is removed for the corresponding file
+		// Verify Lock icon is removed for the corresponding file
 		ZAssert.assertFalse(app.zPageBriefcase.isLockIconPresent(file),"Verify Lock icon is not present for the uploaded file");
-				
-		// delete file upon test completion
+
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileById(id);
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DeleteFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DeleteFile.java
@@ -25,7 +25,6 @@ import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.ui.Shortcut;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -36,27 +35,23 @@ public class DeleteFile extends FeatureBriefcaseTest {
 
 	public DeleteFile() throws HarnessException {
 		logger.info("New " + DeleteFile.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-		
-		//if (ConfigProperties.zimbraGetVersionString().contains("FOSS")) {
-		    super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
-		//}
-			    
-		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");	
-	}		
+		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
+		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
+	}
 
-	@Test( description = "Upload file through RestUtil - delete & verify through GUI", 
+
+	@Test( description = "Upload file through RestUtil - delete & verify through GUI",
 			groups = { "smoke", "L1" })
+
 	public void DeleteFile_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		FileItem fileItem = new FileItem(filePath);
 
@@ -66,76 +61,48 @@ public class DeleteFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend(
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"
+				+ "<upload id='" + attachmentId + "'/>" + "</doc>" + "</SaveDocumentRequest>");
 
-		"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-
-		"<doc l='" + briefcaseFolder.getId() + "'>" +
-
-		"<upload id='" + attachmentId + "'/>" +
-
-		"</doc>" +
-
-		"</SaveDocumentRequest>");
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepSmall();
-		
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-	    		"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Click on Delete document icon in toolbar
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zToolbarPressButton(Button.B_DELETE, fileItem);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zToolbarPressButton(Button.B_DELETE, fileItem);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
-
-		// This step is necessary because next test may be uploading the same
-		// file
-		// if ZD is not synced to ZCS, ZCS will be confused, and the next
-		// uploaded file
-		// will be deleted per previous command.
-		
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify document was deleted
 		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileName),
 				"Verify document was deleted through GUI");
 	}
 
-	@Test( description = "Upload file through RestUtil - delete using Delete Key & check trash", 
+
+	@Test( description = "Upload file through RestUtil - delete using Delete Key & check trash",
 			groups = { "functional", "L2" })
+
 	public void DeleteFile_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
-		FolderItem trashFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Trash);
+		FolderItem trashFolder = FolderItem.importFromSOAP(account, SystemFolder.Trash);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		FileItem fileItem = new FileItem(filePath);
 
 		String fileName = fileItem.getName();
-		
+
 		Shortcut shortcut = Shortcut.S_DELETE;
 
 		// Upload file to server through RestUtil
@@ -146,76 +113,53 @@ public class DeleteFile extends FeatureBriefcaseTest {
 				+ briefcaseFolder.getId() + "'>" + "<upload id='"
 				+ attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		String docId = account.soapSelectValue(
-				"//mail:SaveDocumentResponse//mail:doc", "id");
+		String docId = account.soapSelectValue("//mail:SaveDocumentResponse//mail:doc", "id");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepSmall();
-		
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Click the Delete keyboard shortcut
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zKeyboardShortcut(shortcut);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zKeyboardShortcut(shortcut);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify file was deleted from the list
-		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileName),
-				"Verify file was deleted through GUI");
-		
-		// Verify document moved to Trash
-		account
-				.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
-						+ "<query>in:"
-						+ trashFolder.getName()
-						+ " "
-						+ fileName
-						+ "</query>" + "</SearchRequest>");
+		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileName), "Verify file was deleted through GUI");
 
-		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc",
-				"id");
-		
-		ZAssert.assertEquals(id, docId,
-				"Verify the file was moved to the trash folder: "
-				+ fileName + " id: " + id);		
+		// Verify document moved to Trash
+		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>" + "<query>in:"
+				+ trashFolder.getName() + " " + fileName + "</query>" + "</SearchRequest>");
+
+		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "id");
+		ZAssert.assertEquals(id, docId, "Verify the file was moved to the trash folder: " + fileName + " id: " + id);
 	}
-	
-	@Test( description = "Upload file through RestUtil - delete using <Backspace> Key & check trash", 
+
+
+	@Test( description = "Upload file through RestUtil - delete using <Backspace> Key & check trash",
 			groups = { "functional", "L2" })
+
 	public void DeleteFile_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
-		FolderItem trashFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Trash);
+		FolderItem trashFolder = FolderItem.importFromSOAP(account, SystemFolder.Trash);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		FileItem fileItem = new FileItem(filePath);
 
 		String fileName = fileItem.getName();
-		
+
 		Shortcut shortcut = Shortcut.S_BACKSPACE;
 
 		// Upload file to server through RestUtil
@@ -226,73 +170,51 @@ public class DeleteFile extends FeatureBriefcaseTest {
 				+ briefcaseFolder.getId() + "'>" + "<upload id='"
 				+ attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		String docId = account.soapSelectValue(
-				"//mail:SaveDocumentResponse//mail:doc", "id");
+		String docId = account.soapSelectValue("//mail:SaveDocumentResponse//mail:doc", "id");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepSmall();
-		
 		// Click on created document
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Click the Backspace keyboard shortcut
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zKeyboardShortcut(shortcut);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zKeyboardShortcut(shortcut);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify file was deleted from the list
-		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileName),
-				"Verify file was deleted through GUI");
-		
-		// Verify document moved to Trash
-		account
-				.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
-						+ "<query>in:"
-						+ trashFolder.getName()
-						+ " "
-						+ fileName
-						+ "</query>" + "</SearchRequest>");
+		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileName), "Verify file was deleted through GUI");
 
-		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc",
-				"id");
-		
-		ZAssert.assertEquals(id, docId,
-				"Verify the file was moved to the trash folder: "
-				+ fileName + " id: " + id);		
+		// Verify document moved to Trash
+		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>" + "<query>in:"
+				+ trashFolder.getName() + " " + fileName + "</query>" + "</SearchRequest>");
+
+		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "id");
+		ZAssert.assertEquals(id, docId, "Verify the file was moved to the trash folder: " + fileName + " id: " + id);
 	}
-	
-	@Test( description = "Upload file through RestUtil - delete using Right Click context menu", 
+
+
+	@Test( description = "Upload file through RestUtil - delete using Right Click context menu",
 			groups = { "functional", "L2" })
+
 	public void DeleteFile_04() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		FileItem fileItem = new FileItem(filePath);
 
 		String fileName = fileItem.getName();
-		
+
 		// Upload file to server through RestUtil
 		String attachmentId = account.uploadFile(filePath);
 
@@ -301,72 +223,52 @@ public class DeleteFile extends FeatureBriefcaseTest {
 				+ briefcaseFolder.getId() + "'>" + "<upload id='"
 				+ attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// String docId = account.soapSelectValue("//mail:SaveDocumentResponse//mail:doc", "id");
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepSmall();
-		
 		// Click on created file
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Delete File using Right Click Context Menu
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zListItem(Action.A_RIGHTCLICK, Button.O_DELETE, fileItem);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.O_DELETE,
+				fileItem);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify file was deleted from the list
-		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileName),
-				"Verify file was deleted through GUI");		
+		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileName), "Verify file was deleted through GUI");
 	}
 
+
 	@Bugs(ids = "46889")
-	@Test( description = "Cannot delete uploaded file if it was already deleted once before", 
-	groups = { "functional", "L2" })
+	@Test( description = "Cannot delete uploaded file if it was already deleted once before",
+			groups = { "functional", "L2" })
+
 	public void DeleteFile_05() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
-
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 		FileItem fileItem = new FileItem(filePath);
-
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend(
-		"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-		"<doc l='" + briefcaseFolder.getId() + "'>" +
-		"<upload id='" + attachmentId + "'/>" +
-		"</doc>" +
-		"</SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"
+				+ "<upload id='" + attachmentId + "'/>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-		SleepUtil.sleepSmall();
-		
+
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
 		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
@@ -379,34 +281,27 @@ public class DeleteFile extends FeatureBriefcaseTest {
 
 		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileName),
 				"Verify document was deleted through GUI");
-		
+
 		// Re-Upload file to server through RestUtil
 		String attachId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend(
-		"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-		"<doc l='" + briefcaseFolder.getId() + "'>" +
-		"<upload id='" + attachId + "'/>" +
-		"</doc>" +
-		"</SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"
+				+ "<upload id='" + attachId + "'/>" + "</doc>" + "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-		SleepUtil.sleepSmall();
-		
+
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		DialogConfirm deleteConfirm2 = (DialogConfirm) app.zPageBriefcase
-				.zToolbarPressButton(Button.B_DELETE, fileItem);
+		DialogConfirm deleteConfirm2 = (DialogConfirm) app.zPageBriefcase.zToolbarPressButton(Button.B_DELETE,
+				fileItem);
 
 		deleteConfirm2.zClickButton(Button.B_YES);
 
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileName),
-				"Verify document was deleted through GUI");		
+				"Verify document was deleted through GUI");
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DisplayFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DisplayFile.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.file;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.FileItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
@@ -33,23 +32,23 @@ public class DisplayFile extends FeatureBriefcaseTest {
 
 	public DisplayFile() {
 		logger.info("New " + DisplayFile.class.getCanonicalName());
-
-		super.startingPage = app.zPageBriefcase;		
+		super.startingPage = app.zPageBriefcase;
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 	}
 
-	@Test( description = "Upload file through RestUtil - verify through GUI", 
+
+	@Test( description = "Upload file through RestUtil - verify through GUI",
 			groups = { "smoke", "L0" })
+
 	public void DisplayFile_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		FileItem file = new FileItem(filePath);
 
@@ -63,51 +62,42 @@ public class DisplayFile extends FeatureBriefcaseTest {
 				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
 				+ attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
 		String name = app.zPageBriefcase.getItemNameFromListView(fileName);
 		ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
-
-		// boolean present = app.zPageBriefcase.isPresent(docName);
-		// ZAssert.assertTrue(present, "Verify document name through GUI");
-
 	}
 
+
 	@Bugs(ids = "79994")
-	@Test( description = " german umlauts breaks briefcase", 
-	groups = { "deprecate", "L4" })
+	@Test( description = " german umlauts breaks briefcase",
+			groups = { "functional-skip", "L3-skip" })
+
 	public void DisplayFile_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testäöütest.txt";
-
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testäöütest.txt";
 		String subject = "test???test.txt";
 
 		// Upload file to server through RestUtil
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
-				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
-				+ attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
 		String name = app.zPageBriefcase.getItemNameFromListView(subject);
 		ZAssert.assertStringContains(name, subject, "Verify file name through GUI");
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, subject);
-		
-		
-
 	}
-	
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/EditFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/EditFile.java
@@ -29,7 +29,6 @@ import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
 import com.zimbra.qa.selenium.framework.util.HtmlElement;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -45,19 +44,18 @@ public class EditFile extends FeatureBriefcaseTest {
 		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 	}
 
-	@Test( description = "Upload file, edit name - verify the content remains the same", 
+
+	@Test( description = "Upload file, edit name - verify the content remains the same",
 			groups = { "smoke", "L1" })
-	
+
 	public void EditFile_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
-
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
@@ -68,7 +66,7 @@ public class EditFile extends FeatureBriefcaseTest {
 				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
 				+ attachmentId + "'/>" + "</doc></SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Retrieve file text through RestUtil
@@ -79,45 +77,40 @@ public class EditFile extends FeatureBriefcaseTest {
 				.get(PageBriefcase.Response.ResponsePart.BODY);
 
 		// Right click on File, select Rename
-		app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.B_RENAME,
-				fileItem);
+		app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.B_RENAME, fileItem);
 
-		String fileName2 = "renameFile"
-				+ ConfigProperties.getUniqueString();
+		String fileName2 = "renameFile" + ConfigProperties.getUniqueString();
 
 		app.zPageBriefcase.rename(fileName2);
-		app.zPageBriefcase.zClick("css=div[id='zl__BDLV-main__rows']");	
+		app.zPageBriefcase.zClick("css=div[id='zl__BDLV-main__rows']");
+
 		// Verify document name through GUI
 		ZAssert.assertTrue(app.zPageBriefcase
 				.waitForPresentInListView(fileName2),
 				"Verify new file name through GUI");
 
 		// Display file through RestUtil
-		EnumMap<PageBriefcase.Response.ResponsePart, String> response = app.zPageBriefcase
-				.displayFile(fileName2, hm);
+		EnumMap<PageBriefcase.Response.ResponsePart, String> response = app.zPageBriefcase.displayFile(fileName2, hm);
 
-		HtmlElement element = HtmlElement.clean(response
-				.get(PageBriefcase.Response.ResponsePart.BODY));
-		HtmlElement.evaluate(element, "//body", null, Pattern.compile(".*"
-				+ text + ".*"), 1);
+		HtmlElement element = HtmlElement.clean(response.get(PageBriefcase.Response.ResponsePart.BODY));
+		HtmlElement.evaluate(element, "//body", null, Pattern.compile(".*" + text + ".*"), 1);
 
-		ZAssert.assertEquals(response
-				.get(PageBriefcase.Response.ResponsePart.BODY), text,
+		ZAssert.assertEquals(response.get(PageBriefcase.Response.ResponsePart.BODY), text,
 				"Verify document content through GUI");
 	}
-	
+
+
 	@Test( description = "Upload file through RestUtil - Verify 'Edit' toolbar button is disabled",
 			groups = { "functional", "L2" })
-	
+
 	public void EditFile_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		IItem fileItem = new FileItem(filePath);
 
@@ -125,56 +118,34 @@ public class EditFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend(
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"
+				+ "<upload id='" + attachmentId + "'/>" + "</doc>" + "</SaveDocumentRequest>");
 
-		"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-
-		"<doc l='" + briefcaseFolder.getId() + "'>" +
-
-		"<upload id='" + attachmentId + "'/>" +
-
-		"</doc>" +
-
-		"</SaveDocumentRequest>");
-
-		
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepSmall();
-		
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Verify 'Edit' tool-bar button is disabled
-		ZAssert.assertTrue(app.zPageBriefcase
-				.isToolbarButtonDisabled(PageBriefcase.Locators.zEditFileBtn),
+		ZAssert.assertTrue(app.zPageBriefcase.isToolbarButtonDisabled(PageBriefcase.Locators.zEditFileBtn),
 				"Verify 'Edit' toolbar button is disabled");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
-	
-	@Test( description = "Upload file through RestUtil - Verify 'Edit' context menu is disabled", 
+
+
+	@Test( description = "Upload file through RestUtil - Verify 'Edit' context menu is disabled",
 			groups = { "functional", "L2" })
-	
+
 	public void EditFile_04() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		IItem fileItem = new FileItem(filePath);
 
@@ -182,50 +153,36 @@ public class EditFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend(
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"
+				+ "<upload id='" + attachmentId + "'/>" + "</doc>" + "</SaveDocumentRequest>");
 
-		"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-
-		"<doc l='" + briefcaseFolder.getId() + "'>" +
-
-		"<upload id='" + attachmentId + "'/>" +
-
-		"</doc>" +
-
-		"</SaveDocumentRequest>");
-
-		
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-		
-		SleepUtil.sleepVerySmall();
 
 		// Right Click on created File
 		app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, fileItem);
 
 		// Verify 'Edit' context menu is disabled
-		ZAssert.assertTrue(app.zPageBriefcase
-				.isOptionDisabled(PageBriefcase.Locators.zEditMenuDisabled),
+		ZAssert.assertTrue(app.zPageBriefcase.isOptionDisabled(PageBriefcase.Locators.zEditMenuDisabled),
 				"Verify 'Edit' context menu is disabled");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
-	
+
+
 	@Bugs(ids = "54706")
-	@Test( description = "'Restore As Current Version' does not restore notes", 
+	@Test( description = "'Restore As Current Version' does not restore notes",
 		groups = { "functional", "L3" })
-	
+
 	public void EditFile_05() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String file1Path = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/restoreversion.txt";
+		String file1Path = ConfigProperties.getBaseDirectory() + "/data/public/other/restoreversion.txt";
 		IItem fileItem = new FileItem(file1Path);
 
 		String notesV1 = "notesVersion1" + ConfigProperties.getUniqueString();
@@ -233,65 +190,64 @@ public class EditFile extends FeatureBriefcaseTest {
 		String nodeCollapsed = "css=div[id^=zlif__BDLV-main__] div[class='ImgNodeCollapsed']";
 		String nodeExpanded = "css=div[id^=zlif__BDLV-main__] div[class='ImgNodeExpanded']";
 		String locator = "css=tr[id^='zlif__BDLV-main__'] div[id^='zlif__BDLV-main__']:contains('#1:')";
+
 		// Upload file to server through RestUtil
 		String attachment1Id = account.uploadFile(file1Path);
 		String attachment2Id = account.uploadFile(file1Path);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend(
-				"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-				"<doc desc='" + notesV1 + "' l='" + briefcaseFolder.getId() + "'>" +
-				"<upload id='" + attachment1Id + "'/>" + 
-				"</doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc desc='" + notesV1 + "' l='"
+				+ briefcaseFolder.getId() + "'>" + "<upload id='" + attachment1Id + "'/></doc>"
+				+ "</SaveDocumentRequest>");
 		String file1Id = account.soapSelectValue("//mail:doc", "id");
 
-		account.soapSend(
-				"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-				"<doc desc='" + notesV2 + "' ver='1' l='" + briefcaseFolder.getId() + "' id='" + file1Id + "'>" +
-				"<upload id='" + attachment2Id + "'/>" +
-				"</doc>" +
-				"</SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc desc='" + notesV2 + "' ver='1' l='"
+				+ briefcaseFolder.getId() + "' id='" + file1Id + "'>" + "<upload id='" + attachment2Id + "'/>"
+				+ "</doc>" + "</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-		
+
 		if (!app.zPageBriefcase.sIsElementPresent(nodeExpanded)) {
 			app.zPageBriefcase.zClickAt(nodeCollapsed, "");
 		}
-		
+
 		app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.O_RESTORE_AS_CURRENT_VERSION, locator);
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-		
+
 		if (!app.zPageBriefcase.sIsElementPresent(nodeExpanded)) {
 			app.zPageBriefcase.zClickAt(nodeCollapsed, "");
 		}
 
-        ZAssert.assertTrue(app.zPageCalendar.sIsElementPresent("css=tr[id^='zlif__BDLV-main__'] div[id^='zlif__BDLV-main__']:contains('#3: " + notesV1 + "')"), "'Notes' is restored");
-        
-        // delete file upon test completion
-        app.zPageBriefcase.deleteFileByName(fileItem.getName());
+		ZAssert.assertTrue(
+				app.zPageCalendar.sIsElementPresent(
+						"css=tr[id^='zlif__BDLV-main__'] div[id^='zlif__BDLV-main__']:contains('#3: " + notesV1 + "')"),
+				"'Notes' is restored");
 
+		// Delete file upon test completion
+		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
-	
+
+
 	@Bugs(ids = "74644")
-	@Test( description = "Cannot rename the file's latest version", 
+	@Test( description = "Cannot rename the file's latest version",
 		groups = { "functional", "L3" })
-	
+
 	public void EditFile_06() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String file1Path = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/filerename.txt";
+		String file1Path = ConfigProperties.getBaseDirectory() + "/data/public/other/filerename.txt";
 
 		String notesV1 = "notesVersion1" + ConfigProperties.getUniqueString();
 		String notesV2 = "notesVersion2" + ConfigProperties.getUniqueString();
 		String nodeCollapsed = "css=div[id^=zlif__BDLV-main__] div[class='ImgNodeCollapsed']";
 		String nodeExpanded = "css=div[id^=zlif__BDLV-main__] div[class='ImgNodeExpanded']";
 		String locator = "css=tr[id^='zlif__BDLV-main__'] div[id^='zlif__BDLV-main__']:contains('#2:')";
+
 		// Upload file to server through RestUtil
 		String attachment1Id = account.uploadFile(file1Path);
 		String attachment2Id = account.uploadFile(file1Path);
@@ -299,39 +255,34 @@ public class EditFile extends FeatureBriefcaseTest {
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend(
 				"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-				"<doc desc='" + notesV1 + "' l='" + briefcaseFolder.getId() + "'>" +
-				"<upload id='" + attachment1Id + "'/>" + 
-				"</doc></SaveDocumentRequest>");
+					"<doc desc='" + notesV1 + "' l='" + briefcaseFolder.getId() + "'>" +
+					"<upload id='" + attachment1Id + "'/></doc>" +
+				"</SaveDocumentRequest>");
 		String file1Id = account.soapSelectValue("//mail:doc", "id");
 
 		account.soapSend(
 				"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-				"<doc desc='" + notesV2 + "' ver='1' l='" + briefcaseFolder.getId() + "' id='" + file1Id + "'>" +
-				"<upload id='" + attachment2Id + "'/>" +
-				"</doc>" +
+					"<doc desc='" + notesV2 + "' ver='1' l='" + briefcaseFolder.getId() + "' id='" + file1Id + "'>" +
+					"<upload id='" + attachment2Id + "'/>" +
+					"</doc>" +
 				"</SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-		
+
 		if (!app.zPageBriefcase.sIsElementPresent(nodeExpanded)) {
 			app.zPageBriefcase.zClickAt(nodeCollapsed, "");
 		}
-		
+
 		// Right click on File, select Rename
 		app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.B_RENAME, locator);
 
-		String fileName2 = "renameFile"
-				+ ConfigProperties.getUniqueString();
+		String fileName2 = "renameFile" + ConfigProperties.getUniqueString();
 
 		app.zPageBriefcase.rename(fileName2);
-		app.zPageBriefcase.sClick("css=div[id='zl__BDLV-main__rows']");	
+		app.zPageBriefcase.sClick("css=div[id='zl__BDLV-main__rows']");
 
 		// Verify document name through GUI
-		ZAssert.assertTrue(app.zPageBriefcase.waitForPresentInListView(fileName2),
-				"Verify new file name through GUI");
-
-
+		ZAssert.assertTrue(app.zPageBriefcase.waitForPresentInListView(fileName2), "Verify new file name through GUI");
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/MoveFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/MoveFile.java
@@ -22,7 +22,6 @@ import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.ui.Shortcut;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -36,252 +35,39 @@ public class MoveFile extends FeatureBriefcaseTest {
 
 	public MoveFile() throws HarnessException {
 		logger.info("New " + MoveFile.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
-		//if (ConfigProperties.zimbraGetVersionString().contains("FOSS")) {
-		    super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
-		//}
-	
-		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");				
-			
-		// Make sure we are using an account with message view
-		// super.startingAccountPreferences.put("zimbraPrefGroupMailBy", "message");
+		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
+		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test( description = "Upload file through RestUtil - move & verify through GUI", 
+
+	@Test( description = "Upload file through RestUtil - move & verify through GUI",
 			groups = { "smoke", "L1" })
+
 	public void MoveFile_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem folderItem = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem folderItem = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		String briefcaseFolderId = folderItem.getId();
 
 		String name = "subFolder" + ConfigProperties.getUniqueString();
 
 		// Create a subfolder to move the file into i.e. Briefcase/subfolder
-		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>"
-				+ "<folder name='" + name + "' l='" + briefcaseFolderId + "'/>"
-				+ "</CreateFolderRequest>");
+		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>" + "<folder name='" + name + "' l='"
+				+ briefcaseFolderId + "'/>" + "</CreateFolderRequest>");
 
 		FolderItem subFolderItem = FolderItem.importFromSOAP(account, name);
 
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, folderItem, true);
-
-		// Click on created subfolder		
-		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, subFolderItem);
-
-		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
-
-		FileItem fileItem = new FileItem(filePath);
-
-		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
-
-		// Save uploaded file to briefcase through SOAP
-		account.soapSend(
-
-		"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-
-		"<doc l='" + folderItem.getId() + "'>" +
-
-		"<upload id='" + attachmentId + "'/>" +
-
-		"</doc>" +
-
-		"</SaveDocumentRequest>");
-
-		// account.soapSelectNode("//mail:SaveDocumentResponse", 1);
-
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, folderItem, true);
-
-		SleepUtil.sleepSmall();
-		
-		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
-		// Click on 'Move selected item' icon in toolbar
-		if (ConfigProperties.zimbraGetVersionString().contains("7.2.")) {
-		    DialogMove chooseFolder = (DialogMove) app.zPageBriefcase
-			    .zToolbarPressButton(Button.B_MOVE, fileItem);
-
-		    // Choose folder on Confirmation dialog
-		    chooseFolder.zClickTreeFolder(subFolderItem);
-		    
-		    // Click OK on Confirmation dialog
-		    chooseFolder.zClickButton(Button.B_OK);
-		} else {
-		    // Click move -> subfolder
-		    app.zPageBriefcase.zToolbarPressPulldown(Button.B_MOVE, subFolderItem);
-
-		}
-		
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, folderItem, false);
-
-		// Verify document was moved from the folder
-		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileItem
-				.getName()), "Verify document was moved from the folder");
-
-		// click on subfolder in tree view
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolderItem, true);
-
-		// Verify document was moved to the selected folder
-		boolean present = app.zPageBriefcase.isPresentInListView(fileItem
-				.getName());
-
-		ZAssert.assertTrue(present,
-				"Verify document was moved to the selected folder");
-	}
-
-	@Test( description = "Move File using 'm' keyboard shortcut", 
-			groups = { "functional", "L3" })
-	public void MoveFile_02() throws HarnessException {
-		ZimbraAccount account = app.zGetActiveAccount();
-
-		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
-
-		String briefcaseRootFolderId = briefcaseRootFolder.getId();
-
-		Shortcut shortcut = Shortcut.S_MOVE;
-
-		String[] subFolderNames = {
-				"subFolderName1" + ConfigProperties.getUniqueString(),
-				"subFolderName2" + ConfigProperties.getUniqueString() };
-
-		FolderItem[] subFolders = new FolderItem[subFolderNames.length];
-
-		// Create sub-folders to move the message from/to: Briefcase/sub-folder
-		for (int i = 0; i < subFolderNames.length; i++) {
-			account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>"
-					+ "<folder name='" + subFolderNames[i] + "' l='"
-					+ briefcaseRootFolderId + "'/>" + "</CreateFolderRequest>");
-
-			subFolders[i] = FolderItem.importFromSOAP(account,
-					subFolderNames[i]);
-		}
-
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
-				true);
-
-		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
-
-		FileItem fileItem = new FileItem(filePath);
-
-		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
-
-		// Save uploaded file to briefcase through SOAP
-		account.soapSend(
-
-		"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-
-		"<doc l='" + subFolders[0].getId() + "'>" +
-
-		"<upload id='" + attachmentId + "'/>" +
-
-		"</doc>" +
-
-		"</SaveDocumentRequest>");
-
-		// account.soapSelectNode("//mail:SaveDocumentResponse", 1);
-
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
-				true);
-
-		// double-click on sub-folder1 in list view
-		app.zPageBriefcase.zListItem(Action.A_DOUBLECLICK, subFolders[0]);
-
-		// click on sub-folder1 in tree view to refresh view
-		// app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolders[0],
-		// true);
-
-		SleepUtil.sleepSmall();
-
-		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
-		// Click the Move keyboard shortcut
-		DialogMove chooseFolder = (DialogMove) app.zPageBriefcase
-				.zKeyboardShortcut(shortcut);
-
-		// Choose destination folder and Click OK on Confirmation dialog
-		chooseFolder.zClickTreeFolder(subFolders[1]);
-
-		//chooseFolder.zClickButton(Button.B_OK);
-		app.zPageBriefcase.zClickAt("css=div[id=ChooseFolderDialog_button2]","0,0");
-
-		// click on sub-folder1 in tree view
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolders[0], false);
-
-		// Verify document is no longer in the sub-folder1
-		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileItem
-				.getName()), "Verify document is no longer in the folder: "
-				+ subFolders[0].getName());
-
-		SleepUtil.sleepVerySmall();
-		// click on sub-folder2 in tree view
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolders[1], true);
-
-		// Verify document was moved to sub-folder2
-		ZAssert.assertTrue(app.zPageBriefcase.isPresentInListView(fileItem
-				.getName()), "Verify document was moved to the folder: "
-				+ subFolders[1].getName());
-	}
-
-	@Test( description = "Upload file through RestUtil - move using Right Click Context Menu & verify through GUI", 
-			groups = { "functional", "L2" })
-	public void MoveFile_03() throws HarnessException {
-		ZimbraAccount account = app.zGetActiveAccount();
-
-		FolderItem folderItem = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
-
-		String briefcaseFolderId = folderItem.getId();
-
-		String name = "subFolder" + ConfigProperties.getUniqueString();
-
-		// Create a subfolder to move the message into i.e. Briefcase/subfolder
-		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>"
-				+ "<folder name='" + name + "' l='" + briefcaseFolderId + "'/>"
-				+ "</CreateFolderRequest>");
-
-		FolderItem subFolderItem = FolderItem.importFromSOAP(account, name);
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, folderItem, true);
 
 		// Click on created subfolder
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, subFolderItem);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		FileItem fileItem = new FileItem(filePath);
 
@@ -289,72 +75,183 @@ public class MoveFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend(
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + folderItem.getId() + "'>"
+				+ "<upload id='" + attachmentId + "'/>" + "</doc>" + "</SaveDocumentRequest>");
 
-		"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-
-		"<doc l='" + folderItem.getId() + "'>" +
-
-		"<upload id='" + attachmentId + "'/>" +
-
-		"</doc>" +
-
-		"</SaveDocumentRequest>");
-
-		// account.soapSelectNode("//mail:SaveDocumentResponse", 1);
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, folderItem, true);
 
-		SleepUtil.sleepSmall();
-		
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
+		// Click move -> subfolder
+		app.zPageBriefcase.zToolbarPressPulldown(Button.B_MOVE, subFolderItem);
+
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, folderItem, false);
+
+		// Verify document was moved from the folder
+		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileItem.getName()),
+				"Verify document was moved from the folder");
+
+		// Click on subfolder in tree view
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolderItem, true);
+
+		// Verify document was moved to the selected folder
+		boolean present = app.zPageBriefcase.isPresentInListView(fileItem.getName());
+
+		ZAssert.assertTrue(present, "Verify document was moved to the selected folder");
+	}
+
+
+	@Test( description = "Move File using 'm' keyboard shortcut",
+			groups = { "functional", "L3" })
+
+	public void MoveFile_02() throws HarnessException {
+		ZimbraAccount account = app.zGetActiveAccount();
+
+		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
+
+		String briefcaseRootFolderId = briefcaseRootFolder.getId();
+
+		Shortcut shortcut = Shortcut.S_MOVE;
+
+		String[] subFolderNames = { "subFolderName1" + ConfigProperties.getUniqueString(),
+				"subFolderName2" + ConfigProperties.getUniqueString() };
+
+		FolderItem[] subFolders = new FolderItem[subFolderNames.length];
+
+		// Create sub-folders to move the message from/to: Briefcase/sub-folder
+		for (int i = 0; i < subFolderNames.length; i++) {
+			account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>" + "<folder name='" + subFolderNames[i]
+					+ "' l='" + briefcaseRootFolderId + "'/>" + "</CreateFolderRequest>");
+
+			subFolders[i] = FolderItem.importFromSOAP(account, subFolderNames[i]);
 		}
-		*/
-		// Move using Right Click Context Menu 
-		DialogMove chooseFolder = (DialogMove) app.zPageBriefcase
-		.zListItem(Action.A_RIGHTCLICK, Button.O_MOVE, fileItem);
+
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, true);
+
+		// Create file item
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
+
+		FileItem fileItem = new FileItem(filePath);
+
+		// Upload file to server through RestUtil
+		String attachmentId = account.uploadFile(filePath);
+
+		// Save uploaded file to briefcase through SOAP
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + subFolders[0].getId() + "'>"
+				+ "<upload id='" + attachmentId + "'/>" + "</doc>" + "</SaveDocumentRequest>");
+
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
+				true);
+
+		// Double click on sub-folder1 in list view
+		app.zPageBriefcase.zListItem(Action.A_DOUBLECLICK, subFolders[0]);
+
+		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
+
+		// Click the Move keyboard shortcut
+		DialogMove chooseFolder = (DialogMove) app.zPageBriefcase.zKeyboardShortcut(shortcut);
+
+		// Choose destination folder and Click OK on Confirmation dialog
+		chooseFolder.zClickTreeFolder(subFolders[1]);
+		app.zPageBriefcase.zClickAt("css=div[id=ChooseFolderDialog_button2]", "0,0");
+
+		// Click on sub-folder1 in tree view
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolders[0], false);
+
+		// Verify document is no longer in the sub-folder1
+		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileItem.getName()),
+				"Verify document is no longer in the folder: " + subFolders[0].getName());
+
+		// Click on sub-folder2 in tree view
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolders[1], true);
+
+		// Verify document was moved to sub-folder2
+		ZAssert.assertTrue(app.zPageBriefcase.isPresentInListView(fileItem.getName()),
+				"Verify document was moved to the folder: " + subFolders[1].getName());
+	}
+
+
+	@Test( description = "Upload file through RestUtil - move using Right Click Context Menu & verify through GUI",
+			groups = { "functional", "L2" })
+
+	public void MoveFile_03() throws HarnessException {
+
+		ZimbraAccount account = app.zGetActiveAccount();
+
+		FolderItem folderItem = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
+
+		String briefcaseFolderId = folderItem.getId();
+
+		String name = "subFolder" + ConfigProperties.getUniqueString();
+
+		// Create a subfolder to move the message into i.e. Briefcase/subfolder
+		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>" + "<folder name='" + name + "' l='"
+				+ briefcaseFolderId + "'/>" + "</CreateFolderRequest>");
+
+		FolderItem subFolderItem = FolderItem.importFromSOAP(account, name);
+
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, folderItem, true);
+
+		// Click on created subfolder
+		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, subFolderItem);
+
+		// Create file item
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
+		FileItem fileItem = new FileItem(filePath);
+
+		// Upload file to server through RestUtil
+		String attachmentId = account.uploadFile(filePath);
+
+		// Save uploaded file to briefcase through SOAP
+		account.soapSend(
+			"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
+				"<doc l='" + folderItem.getId() + "'>" +
+				"<upload id='" + attachmentId + "'/></doc>" +
+			"</SaveDocumentRequest>");
+
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, folderItem, true);
+
+		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
+
+		// Move using Right Click Context Menu
+		DialogMove chooseFolder = (DialogMove) app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.O_MOVE,
+				fileItem);
 
 		// Click OK on Confirmation dialog
 		chooseFolder.zClickTreeFolder(subFolderItem);
 		chooseFolder.zClickButton(Button.B_OK);
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, folderItem, false);
 
 		// Verify document was moved from the folder
-		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileItem
-				.getName()), "Verify document was moved from the folder");
+		ZAssert.assertFalse(app.zPageBriefcase.isPresentInListView(fileItem.getName()),
+				"Verify document was moved from the folder");
 
-		// click on subfolder in tree view
+		// Click on subfolder in tree view
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, subFolderItem, true);
 
 		// Verify document was moved to the selected folder
-		boolean present = app.zPageBriefcase.isPresentInListView(fileItem
-				.getName());
+		boolean present = app.zPageBriefcase.isPresentInListView(fileItem.getName());
 
-		ZAssert.assertTrue(present,
-				"Verify document was moved to the selected folder");
+		ZAssert.assertTrue(present, "Verify document was moved to the selected folder");
 	}
 
-	
+
 	@AfterMethod(groups = { "always" })
 	public void afterMethod() throws HarnessException {
 		logger.info("Checking for the Move Dialog ...");
 
 		// Check if the "Move Dialog is still open
-		DialogMove dialog = new DialogMove(app,
-				((AppAjaxClient) app).zPageBriefcase);
+		DialogMove dialog = new DialogMove(app, ((AppAjaxClient) app).zPageBriefcase);
 		if (dialog.zIsActive()) {
-			logger.warn(dialog.myPageName()
-					+ " was still active.  Cancelling ...");
+			logger.warn(dialog.myPageName() + " was still active.  Cancelling ...");
 			dialog.zClickButton(Button.B_CANCEL);
 		}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/OpenFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/OpenFile.java
@@ -25,7 +25,6 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -37,71 +36,45 @@ public class OpenFile extends FeatureBriefcaseTest {
 
 	public OpenFile() throws HarnessException {
 		logger.info("New " + OpenFile.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
-		//if (ConfigProperties.zimbraGetVersionString().contains("FOSS")) {
-		    super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
-		//}
-		
+		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");			
 	}
 
+	
 	@Test( description = "Upload file through RestUtil - open & verify through GUI", 
 			groups = { "smoke", "L0" })
+	
 	public void OpenFile_01() throws HarnessException {
+		
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
-
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 		FileItem fileItem = new FileItem(filePath);
-
 		String fileName = fileItem.getName();
-
 		final String fileText = "test";
 
 		// Upload file to server through RestUtil
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
-				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
-				+ attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepSmall();
 
 		// Click on created file
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Click on open in a separate window icon in toolbar
-	
-		DocumentBriefcaseOpen file;
-		
-		if (ConfigProperties.zimbraGetVersionString().contains("7.1."))
-			file = (DocumentBriefcaseOpen)app.zPageBriefcase
-					.zToolbarPressButton(Button.B_OPEN_IN_SEPARATE_WINDOW,
-							fileItem);
-		else
-			file = (DocumentBriefcaseOpen)app.zPageBriefcase
-					.zToolbarPressPulldown(Button.B_ACTIONS,
-							Button.B_LAUNCH_IN_SEPARATE_WINDOW,fileItem);
 
+		DocumentBriefcaseOpen file;
+		file = (DocumentBriefcaseOpen) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS,
+					Button.B_LAUNCH_IN_SEPARATE_WINDOW, fileItem);
 		app.zPageBriefcase.isOpenFileLoaded(fileName, fileText);
 
 		String text = "";
@@ -120,10 +93,9 @@ public class OpenFile extends FeatureBriefcaseTest {
 			app.zPageBriefcase.zSelectWindow("Zimbra: Briefcase");
 		}
 
-		ZAssert.assertStringContains(text, fileText,
-				"Verify document text through GUI");
+		ZAssert.assertStringContains(text, fileText, "Verify document text through GUI");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/PreviewFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/PreviewFile.java
@@ -32,15 +32,15 @@ public class PreviewFile extends FeatureBriefcaseTest {
 
 	public PreviewFile() {
 		logger.info("New " + PreviewFile.class.getCanonicalName());
-		super.startingPage = app.zPageBriefcase;		
+		super.startingPage = app.zPageBriefcase;
 	}
 
-	
-	@Test( description = "Verify JPEG fiew preview in reading pane", 
+
+	@Test( description = "Verify JPEG fiew preview in reading pane",
 			groups = { "smoke", "L1" })
-	
+
 	public void PreviewJPEGFile_01() throws HarnessException {
-		
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
@@ -54,31 +54,31 @@ public class PreviewFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"	+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// Refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
 		String name = app.zPageBriefcase.getItemNameFromListView(fileName);
 		ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
-		
-		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);	
-		SleepUtil.sleepLong();
-		
-		ZAssert.assertTrue(app.zPageBriefcase.zVerifyImageFilePreviewContents("css=img[src*='" + fileName + "']"), "Verify that image is present in the preview pane");
 
+		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);
+		SleepUtil.sleepLong();
+
+		ZAssert.assertTrue(app.zPageBriefcase.zVerifyImageFilePreviewContents("css=img[src*='" + fileName + "']"), "Verify that image is present in the preview pane");
 	}
 
-	
-	@Test( description = "Verify text fiew preview in reading pane", 
+
+	@Test( description = "Verify text fiew preview in reading pane",
 			groups = { "smoke", "L1" })
-	
+
 	public void PreviewTextFile_02() throws HarnessException {
-		
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
@@ -90,30 +90,30 @@ public class PreviewFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"	+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// Refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
 		String name = app.zPageBriefcase.getItemNameFromListView(fileName);
 		ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
-		
-		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);	
+
+		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);
 		SleepUtil.sleepLong();
 		ZAssert.assertTrue(app.zPageBriefcase.zVerifyTextFilePreviewContents(fileContent), "Verify that text file can be viewed correctly in preview pane");
-
 	}
 
-	
-	@Test( description = "Verify PDF fiew preview in reading pane", 
+
+	@Test( description = "Verify PDF fiew preview in reading pane",
 			groups = { "smoke", "L1" })
-	
+
 	public void PreviewPDFFile_03() throws HarnessException {
-		
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testpdffile.pdf";
@@ -125,30 +125,30 @@ public class PreviewFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"	+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// Refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
 		String name = app.zPageBriefcase.getItemNameFromListView(fileName);
 		ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
-		
-		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);	
+
+		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);
 		SleepUtil.sleepLong();
 		ZAssert.assertTrue(app.zPageBriefcase.zVerifyPdfFilePreviewContents(fileContent), "Verify content using PDF file preview elements");
-
 	}
 
-	
-	@Test( description = "Verify word fiew preview in reading pane", 
+
+	@Test( description = "Verify word fiew preview in reading pane",
 			groups = { "smoke", "L1" })
-	
+
 	public void PreviewWordFile_04() throws HarnessException {
-		
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testwordfile.doc";
@@ -160,30 +160,30 @@ public class PreviewFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"	+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// Refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
 		String name = app.zPageBriefcase.getItemNameFromListView(fileName);
 		ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
-		
-		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);	
+
+		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);
 		SleepUtil.sleepLong();
 		ZAssert.assertTrue(app.zPageBriefcase.zVerifyPdfFilePreviewContents(fileContent), "Verify content using PDF file preview elements");
-
 	}
 
-	
-	@Test( description = "Verify excel fiew preview in reading pane", 
+
+	@Test( description = "Verify excel fiew preview in reading pane",
 			groups = { "smoke", "L1" })
-	
+
 	public void PreviewXlsFile_05() throws HarnessException {
-		
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testexcelfile.xls";
@@ -195,29 +195,30 @@ public class PreviewFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"	+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// Refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
 		String name = app.zPageBriefcase.getItemNameFromListView(fileName);
 		ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
-		
-		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);	
+
+		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);
 		SleepUtil.sleepLong();
 		ZAssert.assertTrue(app.zPageBriefcase.zVerifyPdfFilePreviewContents(fileContent), "Verify content using PDF file preview elements");
 	}
-	
-	
-	@Test( description = "Verify power point fiew preview in reading pane", 
+
+
+	@Test( description = "Verify power point fiew preview in reading pane",
 			groups = { "smoke", "L1" })
-	
+
 	public void PreviewPptFile_06() throws HarnessException {
-		
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testpptfile.ppt";
@@ -229,16 +230,17 @@ public class PreviewFile extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"	+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// Refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
 		String name = app.zPageBriefcase.getItemNameFromListView(fileName);
 		ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
-		
-		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);	
+
+		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, file);
 		SleepUtil.sleepLong();
 		ZAssert.assertTrue(app.zPageBriefcase.zVerifyPdfFilePreviewContents(fileContent), "Verify content using PDF file preview elements");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/SendFileAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/SendFileAttachment.java
@@ -23,7 +23,6 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -36,27 +35,23 @@ public class SendFileAttachment extends FeatureBriefcaseTest {
 
 	public SendFileAttachment() throws HarnessException {
 		logger.info("New " + SendFileAttachment.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
-		//if (ConfigProperties.zimbraGetVersionString().contains("FOSS")) {
-		    super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
-		//}
-		
-		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");				
+		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
+		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test( description = "Upload file through RestUtil - click Send as attachment, Cancel & verify through GUI", 
+
+	@Test( description = "Upload file through RestUtil - click Send as attachment, Cancel & verify through GUI",
 			groups = { "functional", "L3" })
+
 	public void SendFileAttachment_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/structure.jpg";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/structure.jpg";
 
 		FileItem fileItem = new FileItem(filePath);
 
@@ -66,44 +61,29 @@ public class SendFileAttachment extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
-				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
-				+ attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepSmall();
 
 		// Click on uploaded file
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Click on Send as attachment
 		FormMailNew mailform;
-		if (ConfigProperties.zimbraGetVersionString().contains("7.1."))
-			mailform = (FormMailNew) app.zPageBriefcase.zToolbarPressPulldown(
-					Button.B_SEND, Button.O_SEND_AS_ATTACHMENT, fileItem);
-		else
-			mailform = (FormMailNew) app.zPageBriefcase.zToolbarPressPulldown(
-					Button.B_ACTIONS, Button.O_SEND_AS_ATTACHMENT, fileItem);
+		mailform = (FormMailNew) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS,
+					Button.O_SEND_AS_ATTACHMENT, fileItem);
 
 		// Verify the new mail form has attachment
-		ZAssert.assertTrue(app.zPageBriefcase
-				.sIsElementPresent(PageBriefcase.Locators.zAttachmentText.locator + ":contains("
-						+ fileName + ")"), "Verify the attachment text");
+		ZAssert.assertTrue(
+				app.zPageBriefcase.sIsElementPresent(
+						PageBriefcase.Locators.zAttachmentText.locator + ":contains(" + fileName + ")"),
+				"Verify the attachment text");
 
 		// Cancel the message
 		// A warning dialog should appear regarding losing changes
-		DialogWarning warningDlg = (DialogWarning) mailform
-				.zToolbarPressButton(Button.B_CANCEL);
+		DialogWarning warningDlg = (DialogWarning) mailform.zToolbarPressButton(Button.B_CANCEL);
 
 		ZAssert.assertNotNull(warningDlg, "Verify the dialog is returned");
 
@@ -112,76 +92,59 @@ public class SendFileAttachment extends FeatureBriefcaseTest {
 
 		warningDlg.zWaitForClose(); // Make sure the dialog is dismissed
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
 
-	@Test( description = "Send File as attachment using Right Click Context Menu & verify through GUI", 
+
+	@Test( description = "Send File as attachment using Right Click Context Menu & verify through GUI",
 			groups = { "functional", "L2" })
+
 	public void SendFileAttachment_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/structure.jpg";
-
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/structure.jpg";
 		FileItem fileItem = new FileItem(filePath);
-
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
-				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
-				+ attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// SleepUtil.sleepVerySmall();
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepSmall();
 
 		// Click on uploaded file
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Click on Send as attachment using Right Click Context Menu
-		FormMailNew mailform = (FormMailNew) app.zPageBriefcase.zListItem(
-				Action.A_RIGHTCLICK, Button.O_SEND_AS_ATTACHMENT, fileItem);
+		FormMailNew mailform = (FormMailNew) app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK,
+				Button.O_SEND_AS_ATTACHMENT, fileItem);
 
 		// Verify the new mail form has attachment
-		ZAssert.assertTrue(app.zPageBriefcase
-				.zWaitForElementPresent(PageBriefcase.Locators.zAttachmentText.locator + ":contains("
-						+ fileName + ")"), "Verify the attachment text");
+		ZAssert.assertTrue(
+				app.zPageBriefcase.zWaitForElementPresent(
+						PageBriefcase.Locators.zAttachmentText.locator + ":contains(" + fileName + ")"),
+				"Verify the attachment text");
 
 		// Cancel the message
-		// A warning dialog should appear regarding losing changes
-		DialogWarning warningDlg = (DialogWarning) mailform
-				.zToolbarPressButton(Button.B_CANCEL);
+		DialogWarning warningDlg = (DialogWarning) mailform.zToolbarPressButton(Button.B_CANCEL);
 
 		ZAssert.assertNotNull(warningDlg, "Verify the dialog is returned");
 
 		// Dismiss the dialog clicking No
-		// warningDlg.zClickButton(Button.B_NO);
 		app.zPageBriefcase.zClick("//div[@id='YesNoCancel']//td[contains(@id,'No_')]//td[contains(@id,'_title')]");
-
 
 		warningDlg.zWaitForClose(); // Make sure the dialog is dismissed
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/SendFileLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/SendFileLink.java
@@ -23,7 +23,6 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -36,29 +35,24 @@ public class SendFileLink extends FeatureBriefcaseTest {
 
 	public SendFileLink() throws HarnessException {
 		logger.info("New " + SendFileLink.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
-		//if (ConfigProperties.zimbraGetVersionString().contains("FOSS")) {
-		    super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
-		//}
-		   
+		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
-			    
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
-	}	
+	}
 
-	@Test( description = "Upload file through RestUtil - click Send Link, Cancel & verify through GUI", 
+
+	@Test( description = "Upload file through RestUtil - click Send Link, Cancel & verify through GUI",
 			groups = { "functional", "L3" })
+
 	public void SendFileLink_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 
 		FileItem fileItem = new FileItem(filePath);
 
@@ -68,34 +62,19 @@ public class SendFileLink extends FeatureBriefcaseTest {
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
-				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
-				+ attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepSmall();
-		
 		// Click on uploaded file
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Click on Send Link
 		DialogConfirm confDlg;
-		if (ConfigProperties.zimbraGetVersionString().contains("7.1."))
-			confDlg = (DialogConfirm) app.zPageBriefcase
-			.zToolbarPressPulldown(Button.B_SEND, Button.O_SEND_LINK, fileItem);
-		else
-			confDlg = (DialogConfirm) app.zPageBriefcase.zToolbarPressPulldown(
-					Button.B_ACTIONS, Button.O_SEND_LINK, fileItem);
+		confDlg = (DialogConfirm) app.zPageBriefcase.zToolbarPressPulldown(Button.B_ACTIONS, Button.O_SEND_LINK,
+					fileItem);
 
 		// Click Yes on confirmation dialog
 		FormMailNew mailform = (FormMailNew) confDlg.zClickButton(Button.B_YES);
@@ -104,14 +83,11 @@ public class SendFileLink extends FeatureBriefcaseTest {
 		ZAssert.assertTrue(mailform.zIsActive(), "Verify the new form opened");
 
 		// Verify link
-		ZAssert.assertTrue(mailform.zWaitForIframeText(
-				"css=iframe[id*=_body_ifr]", fileName),
-				"Verify the link text");
+		ZAssert.assertTrue(mailform.zWaitForIframeText("css=iframe[id*=_body_ifr]", fileName), "Verify the link text");
 
 		// Cancel the message
 		// A warning dialog should appear regarding losing changes
-		DialogWarning warningDlg = (DialogWarning) mailform
-				.zToolbarPressButton(Button.B_CANCEL);
+		DialogWarning warningDlg = (DialogWarning) mailform.zToolbarPressButton(Button.B_CANCEL);
 
 		// temporary: check if dialog exists since it was implemented recently
 		// on send link
@@ -123,55 +99,41 @@ public class SendFileLink extends FeatureBriefcaseTest {
 			warningDlg.zWaitForClose();
 		}
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
 
-	@Test( description = "Send File link using Right Click Context Menu & verify through GUI", 
+
+	@Test( description = "Send File link using Right Click Context Menu & verify through GUI",
 			groups = { "functional", "L2" })
+
 	public void SendFileLink_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
-
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 		FileItem fileItem = new FileItem(filePath);
-
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
-				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
-				+ attachmentId + "'/></doc></SaveDocumentRequest>");
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		//SleepUtil.sleepVerySmall();
-		
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepSmall();
-		
 		// Click on uploaded file
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Click on Send Link using Right Click Context Menu
-		DialogConfirm confDlg = (DialogConfirm) app.zPageBriefcase.zListItem(
-				Action.A_RIGHTCLICK, Button.O_SEND_LINK, fileItem);
+		DialogConfirm confDlg = (DialogConfirm) app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.O_SEND_LINK,
+				fileItem);
 
 		// Click Yes on confirmation dialog
 		FormMailNew mailform = (FormMailNew) confDlg.zClickButton(Button.B_YES);
@@ -180,14 +142,11 @@ public class SendFileLink extends FeatureBriefcaseTest {
 		ZAssert.assertTrue(mailform.zIsActive(), "Verify the new form opened");
 
 		// Verify link
-		ZAssert.assertTrue(mailform.zWaitForIframeText(
-				"css=iframe[id*=_body_ifr]", fileName),
-				"Verify the link text");
+		ZAssert.assertTrue(mailform.zWaitForIframeText("css=iframe[id*=_body_ifr]", fileName), "Verify the link text");
 
 		// Cancel the message
 		// A warning dialog should appear regarding losing changes
-		DialogWarning warningDlg = (DialogWarning) mailform
-				.zToolbarPressButton(Button.B_CANCEL);
+		DialogWarning warningDlg = (DialogWarning) mailform.zToolbarPressButton(Button.B_CANCEL);
 
 		// temporary: check if dialog exists since it was implemented recently
 		// on send link
@@ -199,8 +158,7 @@ public class SendFileLink extends FeatureBriefcaseTest {
 			warningDlg.zWaitForClose();
 		}
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UnTagFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UnTagFile.java
@@ -27,177 +27,74 @@ public class UnTagFile extends FeatureBriefcaseTest {
 
 	public UnTagFile() throws HarnessException {
 		logger.info("New " + UnTagFile.class.getCanonicalName());
-
-		// All tests start at the Briefcase page
 		super.startingPage = app.zPageBriefcase;
-
-		//if (ConfigProperties.zimbraGetVersionString().contains("FOSS")) {
-		    super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
-		//}
-			
+		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test( description = "Remove a tag from a File using Toolbar -> Tag -> Remove Tag", 
+
+	@Test( description = "Remove a tag from a File using Toolbar -> Tag -> Remove Tag",
 			groups = { "smoke", "L0" })
-	
+
 	public void UnTagFile_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
-		String filePath = ConfigProperties.getBaseDirectory()
-				+ "/data/public/other/testtextfile.txt";
-
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
 		String attachmentId = account.uploadFile(filePath);
 
 		// Save uploaded file to briefcase through SOAP
-		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
-				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
-				+ attachmentId + "'/></doc></SaveDocumentRequest>");
-
-		/*
-		 * String docId =
-		 * account.soapSelectValue("//mail:SaveDocumentResponse//mail:doc"
-		 * ,"id");
-		 * 
-		 * // Search for created documentaccount.soapSend(
-		 * "<SearchRequest xmlns='urn:zimbraMail' types='document'>" +
-		 * "<query>in:" + briefcaseFolder.getName() +
-		 * "</query></SearchRequest>");
-		 * 
-		 * String docId = account.soapSelectValue(
-		 * "//mail:SearchResponse//mail:doc[@name='" + docName + "']", "id");
-		 * String version = account.soapSelectValue(
-		 * "//mail:SearchResponse//mail:doc[@name='" + docName + "']", "ver");
-		 * 
-		 * account.soapSend(
-		 * "<SearchRequest xmlns='urn:zimbraMail' types='document'>" + "<query>"
-		 * + docName + "</query>" + "</SearchRequest>");
-		 * 
-		 * docId = account.soapSelectValue("//mail:doc", "id"); version =
-		 * account.soapSelectValue("//mail:doc", "ver");
-		 */
+		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
+				+ "'><upload id='" + attachmentId + "'/></doc></SaveDocumentRequest>");
 
 		// Create a tag
 		String tagName = "tag" + ConfigProperties.getUniqueString();
 
-		/*
-		 * //this flow needs page reload account.soapSend(
-		 * "<CreateTagRequest xmlns='urn:zimbraMail'>" + "<tag name='"+ tagName
-		 * +"' color='1' />" + "</CreateTagRequest>");
-		 * 
-		 * String tagId =
-		 * account.soapSelectValue("//mail:CreateTagResponse/mail:tag", "id");
-		 * 
-		 * account.soapSend( "<ItemActionRequest xmlns='urn:zimbraMail'>" +
-		 * "<action id='"+ docId +"' op='tag' tag='" + tagId + "'/>" +
-		 * "</ItemActionRequest>");
-		 * 
-		 * //ClientSessionFactory.session().selenium().refresh();
-		 */
-		/*
-		 * // this flow is using tag pull down menu // refresh briefcase page
-		 * app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder,
-		 * true);
-		 * 
-		 * SleepUtil.sleepVerySmall();
-		 * 
-		 * // Click on created document
-		 * 
-		 * app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, docItem);
-		 * 
-		 * // Click on New Tag DialogTag dialogTag = (DialogTag)
-		 * app.zPageBriefcase .zToolbarPressPulldown(Button.B_TAG,
-		 * Button.O_TAG_NEWTAG, null);
-		 * 
-		 * dialogTag.zSetTagName(tagName); dialogTag.zClickButton(Button.B_OK);
-		 */
-		
-		account.soapSend("<CreateTagRequest xmlns='urn:zimbraMail'>"
-				+ "<tag name='" + tagName + "' color='1' />"
+		account.soapSend("<CreateTagRequest xmlns='urn:zimbraMail'>" + "<tag name='" + tagName + "' color='1' />"
 				+ "</CreateTagRequest>");
 
-		// Make sure the tag was created on the server
-		// account.soapSend("<GetTagRequest xmlns='urn:zimbraMail'/>");
-		// String tagId = account.soapSelectValue(
-		//		"//mail:GetTagResponse//mail:tag[@name='" + tagName + "']",
-		//		"id");
+		TagItem tagItem = TagItem.importFromSOAP(app.zGetActiveAccount(), tagName);
 
-		TagItem tagItem = TagItem.importFromSOAP(app.zGetActiveAccount(),
-				tagName);
-		
 		ZAssert.assertNotNull(tagItem, "Verify the new tag was created");
 
 		String tagId = tagItem.getId();
-		
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
-		SleepUtil.sleepSmall();
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Click on created file
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Tag document using Right Click context menu
-		app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.O_TAG_FILE,
-				tagItem.getName(), fileItem);
-
+		app.zPageBriefcase.zListItem(Action.A_RIGHTCLICK, Button.O_TAG_FILE, tagItem.getName(), fileItem);
 
 		// Make sure the tag was applied to the document
-		account
-				.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
+		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
 						+ "<query>"
 						+ fileItem.getName()
 						+ "</query>"
 						+ "</SearchRequest>");
 
-		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc",
-				"t");
+		String id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "t");
+		ZAssert.assertNotNull(id, "Verify the search response returns the document tag id");
+		ZAssert.assertEquals(id, tagId, "Verify the tag was attached to the document");
 
-		ZAssert.assertNotNull(id,
-				"Verify the search response returns the document tag id");
-
-		ZAssert.assertEquals(id, tagId,
-				"Verify the tag was attached to the document");
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
-
-		SleepUtil.sleepSmall();
 
 		// Click on tagged file
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		/*
-		if (ConfigProperties.zimbraGetVersionString().contains(
-    			"FOSS")) {
-		    app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
 
-		} else {
-		    app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, fileItem);
-		}
-		*/
 		// Click Remove Tag
-		app.zPageBriefcase.zToolbarPressPulldown(Button.B_TAG,
-				Button.O_TAG_REMOVETAG, null);
+		app.zPageBriefcase.zToolbarPressPulldown(Button.B_TAG, Button.O_TAG_REMOVETAG, null);
 
-		
-
-		account
-				.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
+		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='document'>"
 						+ "<query>"
 						+ fileItem.getName()
 						+ "</query>"
@@ -205,10 +102,9 @@ public class UnTagFile extends FeatureBriefcaseTest {
 
 		id = account.soapSelectValue("//mail:SearchResponse//mail:doc", "t");
 
-		ZAssert.assertStringDoesNotContain(id, tagId,
-				"Verify that the tag is removed from the message");
+		ZAssert.assertStringDoesNotContain(id, tagId, "Verify that the tag is removed from the message");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UploadFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UploadFile.java
@@ -26,7 +26,6 @@ import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
 import com.zimbra.qa.selenium.framework.util.OperatingSystem;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -41,10 +40,12 @@ public class UploadFile extends FeatureBriefcaseTest {
 		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 	}
 
-	@Test( description = "Upload file through RestUtil - verify through GUI", 
+
+	@Test( description = "Upload file through RestUtil - verify through GUI",
 			groups = { "sanity", "L0" })
-	
+
 	public void UploadFile_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
@@ -64,20 +65,21 @@ public class UploadFile extends FeatureBriefcaseTest {
 				+ "<doc l='" + briefcaseFolder.getId() + "'><upload id='"
 				+ attachmentId + "'/></doc></SaveDocumentRequest>");
 
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, true);
 
 		// Verify document is created
 		String name = app.zPageBriefcase.getItemNameFromListView(fileName);
 		ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
 
-	@Test( description = "Upload file through GUI - verify through GUI", 
+
+	@Test( description = "Upload file through GUI - verify through GUI",
 			groups = { "sanity", "L0" })
-	
+
 	public void UploadFile_02() throws HarnessException {
 
 		if (OperatingSystem.isWindows() == true && !ConfigProperties.getStringProperty("browser").contains("edge")) {
@@ -91,16 +93,14 @@ public class UploadFile extends FeatureBriefcaseTest {
 				// Create file item
 				final String fileName = "testtextfile.txt";
 				final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
-
 				FileItem fileItem = new FileItem(filePath);
 
-				// refresh briefcase page
+				// Select briefcase folder
 				app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 				// Click on Upload File button in the Toolbar
 				DialogUploadFile dlg = (DialogUploadFile) app.zPageBriefcase.zToolbarPressButton(Button.B_UPLOAD_FILE, fileItem);
 
-				SleepUtil.sleepMedium();
 				app.zPageBriefcase.sClickAt("css=div[class='ZmUploadDialog'] input[name='uploadFile']", "10,10");
 
 				zUpload(filePath);
@@ -115,29 +115,27 @@ public class UploadFile extends FeatureBriefcaseTest {
 				ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
 
 			} finally {
-
 				app.zPageMain.zKeyboardKeyEvent(KeyEvent.VK_ESCAPE);
-
 			}
 
 		} else {
 			throw new SkipException("File upload operation is allowed only for Windows OS (Skipping upload tests on MS Edge for now due to intermittancy and major control issue), skipping this test...");
 		}
-
 	}
 
-	@Test( description = "Upload file through RestUtil - verify through SOAP", 
+
+	@Test( description = "Upload file through RestUtil - verify through SOAP",
 			groups = { "smoke", "L1" })
+
 	public void UploadFile_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
-
 		FileItem file = new FileItem(filePath);
-
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
@@ -145,20 +143,14 @@ public class UploadFile extends FeatureBriefcaseTest {
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend(
-
-		"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
-
-		"<doc l='" + briefcaseFolder.getId() + "'>" +
-
-		"<upload id='" + attachmentId + "'/>" +
-
-		"</doc>" +
-
-		"</SaveDocumentRequest>");
+				"<SaveDocumentRequest xmlns='urn:zimbraMail'>" +
+					"<doc l='" + briefcaseFolder.getId() + "'>" +
+					"<upload id='" + attachmentId + "'/></doc>" +
+				"</SaveDocumentRequest>");
 
 		account.soapSelectNode("//mail:SaveDocumentResponse", 1);
 
-		// search the uploaded file
+		// Search the uploaded file
 		app.zGetActiveAccount().soapSend(
 				"<SearchRequest xmlns='urn:zimbraMail' types='document'>"
 						+ "<query>" + fileName + "</query>"
@@ -168,9 +160,8 @@ public class UploadFile extends FeatureBriefcaseTest {
 		String name = account.soapSelectValue("//mail:doc", "name");
 		ZAssert.assertEquals(name, fileName, "Verify file name through SOAP");
 
-		//delete file upon test completion
+		// Delete file upon test completion
 		String id = account.soapSelectValue("//mail:doc", "id");
 		app.zPageBriefcase.deleteFileById(id);
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/CreateFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/CreateFolder.java
@@ -32,18 +32,16 @@ public class CreateFolder extends FeatureBriefcaseTest {
 
 	public CreateFolder() {
 		logger.info("New " + CreateFolder.class.getCanonicalName());
-
-		// test starts at the briefcase tab
 		super.startingPage = app.zPageBriefcase;
-		
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
 
-	@Test( description = "Create a new folder by clicking 'Create a new briefcase' on folders tree", 
+
+	@Test( description = "Create a new folder by clicking 'Create a new briefcase' on folders tree",
 			groups = { "sanity", "L0" })
-	
+
 	public void CreateFolder_01() throws HarnessException {
-		
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account,	SystemFolder.Briefcase);
@@ -59,9 +57,7 @@ public class CreateFolder extends FeatureBriefcaseTest {
 
 		_folderIsCreated = true;
 
-		SleepUtil.sleepVerySmall();
-
-		// refresh briefcase page
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
 
 		// Make sure the folder was created on the ZCS server
@@ -70,15 +66,17 @@ public class CreateFolder extends FeatureBriefcaseTest {
 
 		ZAssert.assertEquals(folder.getName(), _folderName, "Verify the server and client folder names match");
 	}
-	
+
+
 	@Bugs(ids = "67061")
-	@Test( description = "According to Comment#1 in the bug 67061 Create a new folder using 'nf' keyboard shortcut is for mail only", 
-	groups = { "functional-skip", "L4" })
+	@Test(description = "According to Comment#1 in the bug 67061 Create a new folder using 'nf' keyboard shortcut is for mail only",
+			groups = { "functional-skip", "L3-skip" })
+
 	public void CreateFolder_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		Shortcut shortcut = Shortcut.S_NEWFOLDER;
 
@@ -90,8 +88,7 @@ public class CreateFolder extends FeatureBriefcaseTest {
 		DialogCreateBriefcaseFolder createFolderDialog = (DialogCreateBriefcaseFolder) app.zPageBriefcase
 				.zKeyboardShortcut(shortcut);
 
-		ZAssert.assertNotNull(createFolderDialog,
-				"Verify the new dialog opened");
+		ZAssert.assertNotNull(createFolderDialog, "Verify the new dialog opened");
 
 		// Fill out the form with the basic details
 		createFolderDialog.zEnterFolderName(_folderName);
@@ -99,68 +96,63 @@ public class CreateFolder extends FeatureBriefcaseTest {
 
 		_folderIsCreated = true;
 
-		SleepUtil.sleepVerySmall();
-
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
-				false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
 
 		// Make sure the folder was created on the server
 		FolderItem folder = FolderItem.importFromSOAP(account, _folderName);
 		ZAssert.assertNotNull(folder, "Verify the new folder was created");
 
-		ZAssert.assertEquals(folder.getName(), _folderName,
-				"Verify the server and client folder names match");
+		ZAssert.assertEquals(folder.getName(), _folderName, "Verify the server and client folder names match");
 	}
 
-	@Test( description = "Create a new folder using context menu from root folder", 
+
+	@Test( description = "Create a new folder using context menu from root folder",
 			groups = { "functional", "L2" })
+
 	public void CreateFolder_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Set the new folder name
 		_folderName = "folder" + ConfigProperties.getUniqueString();
 
 		DialogCreateBriefcaseFolder createFolderDialog = (DialogCreateBriefcaseFolder) app.zTreeBriefcase
-				.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_NEWFOLDER,
-						briefcaseRootFolder);
+				.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_NEWFOLDER, briefcaseRootFolder);
 
 		createFolderDialog.zEnterFolderName(_folderName);
 		createFolderDialog.zClickButton(Button.B_OK);
 
 		_folderIsCreated = true;
 
-		SleepUtil.sleepVerySmall();
-
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
-				false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
 
 		// Make sure the folder was created on the ZCS server
 		FolderItem folder = FolderItem.importFromSOAP(account, _folderName);
 		ZAssert.assertNotNull(folder, "Verify the new form opened");
 
-		ZAssert.assertEquals(folder.getName(), _folderName,
-				"Verify the server and client folder names match");
+		ZAssert.assertEquals(folder.getName(), _folderName, "Verify the server and client folder names match");
 	}
 
-	@Test( description = "Create a new Briefcase folder using Briefcase app toolbar pulldown: New -> New Briefcase", 
+
+	@Test( description = "Create a new Briefcase folder using Briefcase app toolbar pulldown: New -> New Briefcase",
 			groups = { "functional", "L2" })
+
 	public void CreateFolder_04() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Set the new folder name
 		_folderName = "folder" + ConfigProperties.getUniqueString();
 
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,false);
-				
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
+
 		// Create a new briefcase folder using right click context menu + New Briefcase
 		DialogCreateBriefcaseFolder dialog = (DialogCreateBriefcaseFolder) app.zPageBriefcase
 				.zToolbarPressPulldown(Button.B_NEW, Button.O_NEW_BRIEFCASE, null);
@@ -172,19 +164,17 @@ public class CreateFolder extends FeatureBriefcaseTest {
 		dialog.zClickButton(Button.B_OK);
 
 		_folderIsCreated = true;
-		
+
 		SleepUtil.sleepVerySmall();
 
-		// refresh briefcase page
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
-				false);
-		
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
+
 		// Make sure the folder was created on the server
 		FolderItem folder = FolderItem.importFromSOAP(account, _folderName);
 		ZAssert.assertNotNull(folder, "Verify the new folder was created");
 
-		ZAssert.assertEquals(folder.getName(), _folderName,
-				"Verify the server and client folder names match");
+		ZAssert.assertEquals(folder.getName(), _folderName, "Verify the server and client folder names match");
 	}
 
 	@AfterMethod(groups = { "always" })

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/DeleteFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/DeleteFolder.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.folders;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
@@ -30,160 +29,129 @@ public class DeleteFolder extends FeatureBriefcaseTest {
 
 	public DeleteFolder() {
 		logger.info("New " + DeleteFolder.class.getCanonicalName());
-
-		// All tests start at the Briefcase page
 		super.startingPage = app.zPageBriefcase;
 	}
 
-	@Test( description = "Delete a briefcase sub-folder - Right click, Delete", 
+
+	@Test( description = "Delete a briefcase sub-folder - Right click, Delete",
 			groups = { "smoke", "L0" })
+
 	public void DeleteFolder_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
-		ZAssert.assertNotNull(briefcaseRootFolder,
-				"Verify the Briefcase root folder is available");
+		ZAssert.assertNotNull(briefcaseRootFolder, "Verify the Briefcase root folder is available");
 
-		FolderItem trash = FolderItem.importFromSOAP(app.zGetActiveAccount(),
-				SystemFolder.Trash);
+		FolderItem trash = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Trash);
 		ZAssert.assertNotNull(trash, "Verify the trash is available");
 
 		// Create the sub-folder
-		String briefcaseSubFolderName = "folder"
-				+ ConfigProperties.getUniqueString();
+		String briefcaseSubFolderName = "folder" + ConfigProperties.getUniqueString();
 
-		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>"
-				+ "<folder name='" + briefcaseSubFolderName + "' l='"
-				+ briefcaseRootFolder.getId() + "'/>"
-				+ "</CreateFolderRequest>");
+		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>" + "<folder name='" + briefcaseSubFolderName
+				+ "' l='" + briefcaseRootFolder.getId() + "'/>" + "</CreateFolderRequest>");
 
-		FolderItem briefcaseSubFolder = FolderItem.importFromSOAP(account,
-				briefcaseSubFolderName);
-		ZAssert.assertNotNull(briefcaseSubFolder,
-				"Verify the subfolder is available");
+		FolderItem briefcaseSubFolder = FolderItem.importFromSOAP(account, briefcaseSubFolderName);
+		ZAssert.assertNotNull(briefcaseSubFolder, "Verify the subfolder is available");
 
-		// refresh the Briefcase tree folder list
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
-				false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
 
 		// Delete the folder using context menu
-		app.zTreeBriefcase.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_DELETE,
-				briefcaseSubFolder);
+		app.zTreeBriefcase.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_DELETE, briefcaseSubFolder);
 
 		// Verify the folder is now in the trash
-		briefcaseSubFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(),
-				briefcaseSubFolderName);
-		ZAssert.assertNotNull(briefcaseSubFolder,
-				"Verify the subfolder is again available");
+		briefcaseSubFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(), briefcaseSubFolderName);
+		ZAssert.assertNotNull(briefcaseSubFolder, "Verify the subfolder is again available");
 		ZAssert.assertEquals(trash.getId(), briefcaseSubFolder.getParentId(),
 				"Verify the subfolder's parent is now the trash folder ID");
 	}
 
-	@Test( description = "Delete a a top level briefcase folder - Right click, Delete", 
+
+	@Test( description = "Delete a a top level briefcase folder - Right click, Delete",
 			groups = { "smoke", "L1" })
+
 	public void DeleteFolder_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
-		FolderItem userRootFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.UserRoot);
+		FolderItem userRootFolder = FolderItem.importFromSOAP(account, SystemFolder.UserRoot);
 
-		ZAssert.assertNotNull(userRootFolder,
-				"Verify the user root folder is available");
+		ZAssert.assertNotNull(userRootFolder, "Verify the user root folder is available");
 
-		FolderItem trash = FolderItem.importFromSOAP(app.zGetActiveAccount(),
-				SystemFolder.Trash);
+		FolderItem trash = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Trash);
 		ZAssert.assertNotNull(trash, "Verify the trash is available");
 
 		// Create a top level briefcase folder
-		String briefcaseTopLevelFolderName = "folder"
-				+ ConfigProperties.getUniqueString();
+		String briefcaseTopLevelFolderName = "folder" + ConfigProperties.getUniqueString();
 
-		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>"
-				+ "<folder name='" + briefcaseTopLevelFolderName + "' l='"
-				+ userRootFolder.getId() + "' view='document'/>"
-				+ "</CreateFolderRequest>");
+		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>" + "<folder name='" + briefcaseTopLevelFolderName
+				+ "' l='" + userRootFolder.getId() + "' view='document'/>" + "</CreateFolderRequest>");
 
-		FolderItem briefcaseTopLevelFolder = FolderItem.importFromSOAP(account,
-				briefcaseTopLevelFolderName);
-		ZAssert.assertNotNull(briefcaseTopLevelFolder,
-				"Verify the briefcase top level folder is available");
+		FolderItem briefcaseTopLevelFolder = FolderItem.importFromSOAP(account, briefcaseTopLevelFolderName);
+		ZAssert.assertNotNull(briefcaseTopLevelFolder, "Verify the briefcase top level folder is available");
 
-		// refresh the Briefcase tree folder list
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
-				false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
 
 		// Delete the folder using context menu
-		app.zTreeBriefcase.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_DELETE,
-				briefcaseTopLevelFolder);
+		app.zTreeBriefcase.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_DELETE, briefcaseTopLevelFolder);
 
 		// Verify the folder is now in the trash
-		briefcaseTopLevelFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(),
-				briefcaseTopLevelFolderName);
-		ZAssert.assertNotNull(briefcaseTopLevelFolder,
-				"Verify the briefcase top level folder is again available");
+		briefcaseTopLevelFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(), briefcaseTopLevelFolderName);
+		ZAssert.assertNotNull(briefcaseTopLevelFolder, "Verify the briefcase top level folder is again available");
 		ZAssert.assertEquals(trash.getId(), briefcaseTopLevelFolder.getParentId(),
 				"Verify the deleted briefcase top level folder's parent is now the trash folder ID");
 	}
 
+
 	@Bugs(ids = "80600")
-	@Test( description = "Delete a briefcase sub-folder from list view and hitting toolbar delete button", 
+	@Test( description = "Delete a briefcase sub-folder from list view and hitting toolbar delete button",
 			groups = { "functional", "L2" })
+
 	public void DeleteFolder_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
-		ZAssert.assertNotNull(briefcaseRootFolder,
-				"Verify the Briefcase root folder is available");
+		ZAssert.assertNotNull(briefcaseRootFolder, "Verify the Briefcase root folder is available");
 
-		FolderItem trash = FolderItem.importFromSOAP(app.zGetActiveAccount(),
-				SystemFolder.Trash);
+		FolderItem trash = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Trash);
 		ZAssert.assertNotNull(trash, "Verify the trash is available");
 
 		// Create the sub-folder
-		String briefcaseSubFolderName = "folder"
-				+ ConfigProperties.getUniqueString();
+		String briefcaseSubFolderName = "folder" + ConfigProperties.getUniqueString();
 
-		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>"
-				+ "<folder name='" + briefcaseSubFolderName + "' l='"
-				+ briefcaseRootFolder.getId() + "'/>"
-				+ "</CreateFolderRequest>");
+		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>" + "<folder name='" + briefcaseSubFolderName
+				+ "' l='" + briefcaseRootFolder.getId() + "'/>" + "</CreateFolderRequest>");
 
-		FolderItem briefcaseSubFolder = FolderItem.importFromSOAP(account,
-				briefcaseSubFolderName);
-		ZAssert.assertNotNull(briefcaseSubFolder,
-				"Verify the subfolder is available");
+		FolderItem briefcaseSubFolder = FolderItem.importFromSOAP(account, briefcaseSubFolderName);
+		ZAssert.assertNotNull(briefcaseSubFolder, "Verify the subfolder is available");
 
-		// refresh the Briefcase tree folder list
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
-				false);
-		
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
+
 		app.zPageBriefcase.zListItem(Action.A_LEFTCLICK, briefcaseSubFolder);
 
 		// Click on Delete document icon in toolbar
-		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase
-				.zToolbarPressButton(Button.B_DELETE, briefcaseSubFolder);
+		DialogConfirm deleteConfirm = (DialogConfirm) app.zPageBriefcase.zToolbarPressButton(Button.B_DELETE,
+				briefcaseSubFolder);
 
 		// Click OK on Confirmation dialog
 		deleteConfirm.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
 
 		// Verify the folder is now in the trash
-		briefcaseSubFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(),
-				briefcaseSubFolderName);
-		ZAssert.assertNotNull(briefcaseSubFolder,
-				"Verify the subfolder is again available");
+		briefcaseSubFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(), briefcaseSubFolderName);
+		ZAssert.assertNotNull(briefcaseSubFolder, "Verify the subfolder is again available");
 		ZAssert.assertEquals(trash.getId(), briefcaseSubFolder.getParentId(),
 				"Verify the subfolder's parent is now the trash folder ID");
 	}
-	
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/DragAndDropFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/DragAndDropFolder.java
@@ -29,19 +29,20 @@ public class DragAndDropFolder extends FeatureBriefcaseTest {
 		logger.info("New " + DragAndDropFolder.class.getCanonicalName());
 		super.startingPage = app.zPageBriefcase;
 	}
-	
-	@Test(description = "Drag one briefcase sub-folder and Drop into other", 
+
+
+	@Test(description = "Drag one briefcase sub-folder and Drop into other",
 			groups = { "functional", "L2" })
-	
+
 	public void DragAndDropFolder_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		ZAssert.assertNotNull(briefcaseRootFolder, "Verify the Briefcase root folder is available");
 
-		// Create two briefcase sub-folders:One folder to Drag & Another folder
-		// to drop into
+		// Create two briefcase sub-folders:One folder to Drag & Another folder to drop into
 		String briefcaseSubFolderName1 = "folder1" + ConfigProperties.getUniqueString();
 		String briefcaseSubFolderName2 = "folder2" + ConfigProperties.getUniqueString();
 
@@ -57,7 +58,7 @@ public class DragAndDropFolder extends FeatureBriefcaseTest {
 		FolderItem briefcaseSubFolder2 = FolderItem.importFromSOAP(account, briefcaseSubFolderName2);
 		ZAssert.assertNotNull(briefcaseSubFolder2, "Verify the second subfolder is available");
 
-		// refresh the Briefcase tree folder list
+		// Select briefcase folder
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
 
 		// Perform DND action

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/EditProperties.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/EditProperties.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.folders;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.common.soap.Element;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
@@ -30,60 +29,54 @@ public class EditProperties extends FeatureBriefcaseTest {
 
 	public EditProperties() {
 		logger.info("New " + EditProperties.class.getCanonicalName());
-
-		// All tests start at the Briefcase page
-		super.startingPage = app.zPageBriefcase;		
+		super.startingPage = app.zPageBriefcase;
 	}
 
-	@Test( description = "Edit Properties - Rename folder using context menu", 
+
+	@Test( description = "Edit Properties - Rename folder using context menu",
 			groups = { "functional", "L2" })
+
 	public void EditProperties_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseRootFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
-		ZAssert.assertNotNull(briefcaseRootFolder,
-				"Verify the Briefcase root folder is available");
+		ZAssert.assertNotNull(briefcaseRootFolder, "Verify the Briefcase root folder is available");
 
 		// Create the sub-folder
-		String subFolderName = "folder"
-				+ ConfigProperties.getUniqueString();
+		String subFolderName = "folder" + ConfigProperties.getUniqueString();
 
-		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>"
-				+ "<folder name='" + subFolderName + "' l='"
-				+ briefcaseRootFolder.getId() + "'/>"
-				+ "</CreateFolderRequest>");
+		account.soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>" + "<folder name='" + subFolderName + "' l='"
+				+ briefcaseRootFolder.getId() + "'/>" + "</CreateFolderRequest>");
 
 		// Verify the sub-folder exists on the server
-				FolderItem subFolder = FolderItem
-						.importFromSOAP(account, subFolderName);
-				ZAssert.assertNotNull(subFolder, "Verify the subfolder is available");
+		FolderItem subFolder = FolderItem.importFromSOAP(account, subFolderName);
+		ZAssert.assertNotNull(subFolder, "Verify the subfolder is available");
 
-		// refresh the Briefcase tree folder list
-		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder,
-				false);
-
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseRootFolder, false);
 
 		// Rename the folder using context menu
-		DialogEditProperties dialog = (DialogEditProperties)app.zTreeBriefcase.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_EDIT_PROPERTIES, subFolder);
+		DialogEditProperties dialog = (DialogEditProperties) app.zTreeBriefcase.zTreeItem(Action.A_RIGHTCLICK,
+				Button.B_TREE_EDIT_PROPERTIES, subFolder);
 		ZAssert.assertNotNull(dialog, "Verify the dialog opened");
-		
+
 		// Set the name, click OK
 		String subFolderName2 = "renamedfolder" + ConfigProperties.getUniqueString();
-		
+
 		dialog.zSetNewName(subFolderName2);
-		
+
 		dialog.zClickButton(Button.B_OK);
 
 		// Get all the folders and verify the new name appears and the old name disappears
-				account.soapSend("<GetFolderRequest xmlns = 'urn:zimbraMail'/>");
-				
-				Element[] eFolder1 = account.soapSelectNodes("//mail:folder[@name='"+ subFolderName +"']");
-				ZAssert.assertEquals(eFolder1.length, 0, "Verify the old folder name no longer exists");
-				
-				Element[] eFolder2 = app.zGetActiveAccount().soapSelectNodes("//mail:folder[@name='"+ subFolderName2 +"']");
-				ZAssert.assertEquals(eFolder2.length, 1, "Verify the new folder name exists");
-	
-		}
+		account.soapSend("<GetFolderRequest xmlns = 'urn:zimbraMail'/>");
+
+		Element[] eFolder1 = account.soapSelectNodes("//mail:folder[@name='" + subFolderName + "']");
+		ZAssert.assertEquals(eFolder1.length, 0, "Verify the old folder name no longer exists");
+
+		Element[] eFolder2 = app.zGetActiveAccount().soapSelectNodes("//mail:folder[@name='" + subFolderName2 + "']");
+		ZAssert.assertEquals(eFolder2.length, 1, "Verify the new folder name exists");
+
+	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/FindSharesWithFeatureDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/FindSharesWithFeatureDisabled.java
@@ -30,43 +30,35 @@ import com.zimbra.qa.selenium.projects.ajax.core.FeatureBriefcaseTest;
 import com.zimbra.qa.selenium.projects.ajax.ui.briefcase.DialogFindShares;
 
 public class FindSharesWithFeatureDisabled extends FeatureBriefcaseTest {
-	String url;
 
 	public FindSharesWithFeatureDisabled() {
-		logger.info("New "
-				+ FindSharesWithFeatureDisabled.class.getCanonicalName());
-
-		// test starts in the Briefcase tab
+		logger.info("New " + FindSharesWithFeatureDisabled.class.getCanonicalName());
 		super.startingPage = app.zPageBriefcase;
-
-		// use an account with some of the Features disabled
 		super.startingAccountPreferences.put("zimbraFeatureCalendarEnabled", "FALSE");
-		// super.startingAccountPreferences.put("zimbraFeatureTasksEnabled", "FALSE");
-	}	
+	}
+
 
 	@Bugs(ids = "60854")
-	@Test( description = "Click on Find Shares link when some of the Features are disabled - Verify Find Shares dialog is displayed", 
+	@Test( description = "Click on Find Shares link when some of the Features are disabled - Verify Find Shares dialog is displayed",
 			groups = { "functional", "L3" })
-	
+
 	public void FindSharesWithFeatureDisabled_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		new LinkItem();
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Click on Find shares link
-		DialogFindShares dialog = (DialogFindShares)app.zTreeBriefcase
-				.zPressPulldown(Button.B_TREE_FOLDERS_OPTIONS, Button.B_TREE_FIND_SHARES);
+		DialogFindShares dialog = (DialogFindShares) app.zTreeBriefcase.zPressPulldown(Button.B_TREE_FOLDERS_OPTIONS,
+				Button.B_TREE_FIND_SHARES);
 
 		// Verify Find Shares dialog is opened
-		ZAssert.assertTrue(dialog.zIsActive(),
-				"Verify Find Shares dialog is opened");
+		ZAssert.assertTrue(dialog.zIsActive(), "Verify Find Shares dialog is opened");
 
 		// Dismiss the dialog
 		dialog.zClickButton(Button.B_CANCEL);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/admin/SendFileLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/admin/SendFileLink.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.mountpoints.admin;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.FileItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
@@ -26,7 +25,6 @@ import com.zimbra.qa.selenium.framework.ui.AbsDialog;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -38,48 +36,42 @@ public class SendFileLink extends FeatureBriefcaseTest {
 
 	public SendFileLink() throws HarnessException {
 		logger.info("New " + SendFileLink.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
-		//if (ConfigProperties.zimbraGetVersionString().contains("FOSS")) {
-		    super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
-		//}
-		   
+		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
-			    
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
-	
-	@Bugs(ids="46371")
-	@Test( description = "Briefcase linking problems upon renames", 
-	groups = { "functional", "L2" })
-	public void SendFileLink_01() throws HarnessException {
 
+
+	@Bugs(ids="46371")
+	@Test( description = "Briefcase linking problems upon renames",
+			groups = { "functional", "L2" })
+
+	public void SendFileLink_01() throws HarnessException {
 
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 		String foldername = "folder" + ConfigProperties.getUniqueString();
 		String mountpointname = "mountpoint" + ConfigProperties.getUniqueString();
-
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
 		String attachmentId = ZimbraAccount.AccountA().uploadFile(filePath);
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(ZimbraAccount.AccountA(), SystemFolder.Briefcase);
-		
+
 		// Create a folder to share
 		ZimbraAccount.AccountA().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 				+		"<folder name='" + foldername + "' l='" + briefcaseFolder.getId() + "' view='document'/>"
 				+	"</CreateFolderRequest>");
-		
+
 		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountA(), foldername);
 
 		// Save uploaded file to briefcase through SOAP
 		ZimbraAccount.AccountA().soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
 				+ "<doc l='" + folder.getId() + "'><upload id='"
 				+ attachmentId + "'/></doc></SaveDocumentRequest>");
-		
+
 		// Share it
 		ZimbraAccount.AccountA().soapSend(
 					"<FolderActionRequest xmlns='urn:zimbraMail'>"
@@ -87,24 +79,24 @@ public class SendFileLink extends FeatureBriefcaseTest {
 				+			"<grant d='"+ app.zGetActiveAccount().EmailAddress +"' gt='usr' perm='rwidxa' view='document'/>"
 				+		"</action>"
 				+	"</FolderActionRequest>");
-		
+
 		// Mount it
 		app.zGetActiveAccount().soapSend(
 					"<CreateMountpointRequest xmlns='urn:zimbraMail'>"
 				+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"' view='document' color='5'/>"
 				+	"</CreateMountpointRequest>");
 
-		// refresh briefcase page
-		SleepUtil.sleepSmall();
+		// Select briefcase folder
 		app.zPageBriefcase.zToolbarPressButton(Button.B_REFRESH);
-		
+
 		String locator = "css=td[id^=zti__main_Briefcase__]:contains('" + mountpointname + "')";
 		app.zPageBriefcase.zClick(locator);
+
 		// Refersh Page
 		app.zPageBriefcase.zToolbarPressButton(Button.B_REFRESH);
 
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		
+
 		// Click on Send Link
 		DialogConfirm confDlg = (DialogConfirm) app.zPageBriefcase.zToolbarPressPulldown(
 					Button.B_ACTIONS, Button.O_SEND_LINK, fileItem);
@@ -117,14 +109,14 @@ public class SendFileLink extends FeatureBriefcaseTest {
 
 		// Verify link
 		ZAssert.assertTrue(mailform.zWaitForIframeText("css=iframe[id*=_body_ifr]", ZimbraAccount.AccountA().EmailAddress),"Verify the link text");
-		
+
 		AbsDialog warning = (AbsDialog)mailform.zToolbarPressButton(Button.B_CANCEL);
 		ZAssert.assertNotNull(warning, "Verify the dialog is returned");
-		
+
 		// Dismiss the dialog
 		warning.zClickButton(Button.B_NO);
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/manager/SendFileLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/manager/SendFileLink.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.mountpoints.manager;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.FileItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
@@ -26,7 +25,6 @@ import com.zimbra.qa.selenium.framework.ui.AbsDialog;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -38,48 +36,42 @@ public class SendFileLink extends FeatureBriefcaseTest {
 
 	public SendFileLink() throws HarnessException {
 		logger.info("New " + SendFileLink.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
-		//if (ConfigProperties.zimbraGetVersionString().contains("FOSS")) {
-		    super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
-		//}
-		   
+		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
-			    
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
-	
-	@Bugs(ids="46371")
-	@Test( description = "Briefcase linking problems upon renames", 
-	groups = { "functional", "L2" })
-	public void SendFileLink_01() throws HarnessException {
 
+
+	@Bugs(ids="46371")
+	@Test( description = "Briefcase linking problems upon renames",
+			groups = { "functional", "L2" })
+
+	public void SendFileLink_01() throws HarnessException {
 
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 		String foldername = "folder" + ConfigProperties.getUniqueString();
 		String mountpointname = "mountpoint" + ConfigProperties.getUniqueString();
-
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
 		String attachmentId = ZimbraAccount.AccountA().uploadFile(filePath);
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(ZimbraAccount.AccountA(), SystemFolder.Briefcase);
-		
+
 		// Create a folder to share
 		ZimbraAccount.AccountA().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 				+		"<folder name='" + foldername + "' l='" + briefcaseFolder.getId() + "' view='document'/>"
 				+	"</CreateFolderRequest>");
-		
+
 		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountA(), foldername);
 
 		// Save uploaded file to briefcase through SOAP
 		ZimbraAccount.AccountA().soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
 				+ "<doc l='" + folder.getId() + "'><upload id='"
 				+ attachmentId + "'/></doc></SaveDocumentRequest>");
-		
+
 		// Share it
 		ZimbraAccount.AccountA().soapSend(
 					"<FolderActionRequest xmlns='urn:zimbraMail'>"
@@ -87,24 +79,24 @@ public class SendFileLink extends FeatureBriefcaseTest {
 				+			"<grant d='"+ app.zGetActiveAccount().EmailAddress +"' gt='usr' perm='rwidx' view='document'/>"
 				+		"</action>"
 				+	"</FolderActionRequest>");
-		
+
 		// Mount it
 		app.zGetActiveAccount().soapSend(
 					"<CreateMountpointRequest xmlns='urn:zimbraMail'>"
 				+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"' view='document' color='5'/>"
 				+	"</CreateMountpointRequest>");
 
-		// refresh briefcase page
-		SleepUtil.sleepSmall();
+		// Select briefcase folder
 		app.zPageBriefcase.zToolbarPressButton(Button.B_REFRESH);
-		
+
 		String locator = "css=td[id^=zti__main_Briefcase__]:contains('" + mountpointname + "')";
 		app.zPageBriefcase.zClick(locator);
+
 		// Refersh Page
 		app.zPageBriefcase.zToolbarPressButton(Button.B_REFRESH);
 
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		
+
 		// Click on Send Link
 		DialogConfirm confDlg = (DialogConfirm) app.zPageBriefcase.zToolbarPressPulldown(
 					Button.B_ACTIONS, Button.O_SEND_LINK, fileItem);
@@ -117,14 +109,14 @@ public class SendFileLink extends FeatureBriefcaseTest {
 
 		// Verify link
 		ZAssert.assertTrue(mailform.zWaitForIframeText("css=iframe[id*=_body_ifr]", ZimbraAccount.AccountA().EmailAddress),"Verify the link text");
-		
+
 		AbsDialog warning = (AbsDialog)mailform.zToolbarPressButton(Button.B_CANCEL);
 		ZAssert.assertNotNull(warning, "Verify the dialog is returned");
-		
+
 		// Dismiss the dialog
 		warning.zClickButton(Button.B_NO);
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/viewer/SendFileLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/viewer/SendFileLink.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.mountpoints.viewer;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.FileItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
@@ -26,7 +25,6 @@ import com.zimbra.qa.selenium.framework.ui.AbsDialog;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -38,48 +36,42 @@ public class SendFileLink extends FeatureBriefcaseTest {
 
 	public SendFileLink() throws HarnessException {
 		logger.info("New " + SendFileLink.class.getCanonicalName());
-
 		super.startingPage = app.zPageBriefcase;
-
-		//if (ConfigProperties.zimbraGetVersionString().contains("FOSS")) {
-		    super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
-		//}
-		   
+		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 		super.startingAccountPreferences.put("zimbraPrefComposeFormat", "html");
-			    
 		super.startingAccountPreferences.put("zimbraPrefBriefcaseReadingPaneLocation", "bottom");
 	}
-	
-	@Bugs(ids="46371")
-	@Test( description = "Briefcase linking problems upon renames", 
-			groups = { "functional", "L2" })
-	public void SendFileLink_01() throws HarnessException {
 
+
+	@Bugs(ids="46371")
+	@Test( description = "Briefcase linking problems upon renames",
+			groups = { "functional", "L2" })
+
+	public void SendFileLink_01() throws HarnessException {
 
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/testtextfile.txt";
 		String foldername = "folder" + ConfigProperties.getUniqueString();
 		String mountpointname = "mountpoint" + ConfigProperties.getUniqueString();
-
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
 		String attachmentId = ZimbraAccount.AccountA().uploadFile(filePath);
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(ZimbraAccount.AccountA(), SystemFolder.Briefcase);
-		
+
 		// Create a folder to share
 		ZimbraAccount.AccountA().soapSend(
 					"<CreateFolderRequest xmlns='urn:zimbraMail'>"
 				+		"<folder name='" + foldername + "' l='" + briefcaseFolder.getId() + "' view='document'/>"
 				+	"</CreateFolderRequest>");
-		
+
 		FolderItem folder = FolderItem.importFromSOAP(ZimbraAccount.AccountA(), foldername);
 
 		// Save uploaded file to briefcase through SOAP
 		ZimbraAccount.AccountA().soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
 				+ "<doc l='" + folder.getId() + "'><upload id='"
 				+ attachmentId + "'/></doc></SaveDocumentRequest>");
-		
+
 		// Share it
 		ZimbraAccount.AccountA().soapSend(
 					"<FolderActionRequest xmlns='urn:zimbraMail'>"
@@ -87,24 +79,24 @@ public class SendFileLink extends FeatureBriefcaseTest {
 				+			"<grant d='"+ app.zGetActiveAccount().EmailAddress +"' gt='usr' perm='r' view='document'/>"
 				+		"</action>"
 				+	"</FolderActionRequest>");
-		
+
 		// Mount it
 		app.zGetActiveAccount().soapSend(
 					"<CreateMountpointRequest xmlns='urn:zimbraMail'>"
 				+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"' view='document' color='5'/>"
 				+	"</CreateMountpointRequest>");
 
-		// refresh briefcase page
-		SleepUtil.sleepSmall();
+		// Select briefcase folder
 		app.zPageBriefcase.zToolbarPressButton(Button.B_REFRESH);
-		
+
 		String locator = "css=td[id^=zti__main_Briefcase__]:contains('" + mountpointname + "')";
 		app.zPageBriefcase.zClick(locator);
+
 		// Refersh Page
 		app.zPageBriefcase.zToolbarPressButton(Button.B_REFRESH);
 
 		app.zPageBriefcase.zListItem(Action.A_BRIEFCASE_CHECKBOX, fileItem);
-		
+
 		// Click on Send Link
 		DialogConfirm confDlg = (DialogConfirm) app.zPageBriefcase.zToolbarPressPulldown(
 					Button.B_ACTIONS, Button.O_SEND_LINK, fileItem);
@@ -117,15 +109,14 @@ public class SendFileLink extends FeatureBriefcaseTest {
 
 		// Verify link
 		ZAssert.assertTrue(mailform.zWaitForIframeText("css=iframe[id*=_body_ifr]", ZimbraAccount.AccountA().EmailAddress),"Verify the link text");
-		
+
 		AbsDialog warning = (AbsDialog)mailform.zToolbarPressButton(Button.B_CANCEL);
 		ZAssert.assertNotNull(warning, "Verify the dialog is returned");
-		
+
 		// Dismiss the dialog
 		warning.zClickButton(Button.B_NO);
 
-		// delete file upon test completion
+		// Delete file upon test completion
 		app.zPageBriefcase.deleteFileByName(fileItem.getName());
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/performance/ZmBriefcaseAppFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/performance/ZmBriefcaseAppFolders.java
@@ -17,86 +17,76 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.performance;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.items.FolderItem;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.*;
 import com.zimbra.qa.selenium.framework.util.performance.*;
 import com.zimbra.qa.selenium.projects.ajax.core.*;
 
-
-
 public class ZmBriefcaseAppFolders extends FeatureBriefcaseTest {
 
 	public ZmBriefcaseAppFolders() {
 		logger.info("New "+ ZmBriefcaseAppFolders.class.getCanonicalName());
-
-
 		super.startingPage = app.zPageMail;
-
 	}
 
+
 	@Test( description = "Measure the time to load the briefcase app, 1 briefcase",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
+
 	public void ZmBriefcaseAppFolders_01() throws HarnessException {
 
 		// Create a folder
 		FolderItem root = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.UserRoot);
-		app.zGetActiveAccount().soapSend(
-				"<CreateFolderRequest xmlns='urn:zimbraMail'>" +
-					"<folder name='case"+ ConfigProperties.getUniqueString() + "' view='document' l='"+ root.getId() +"'/>" +
-				"</CreateFolderRequest>");
-
+		app.zGetActiveAccount().soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>" + "<folder name='case"
+						+ ConfigProperties.getUniqueString() + "' view='document' l='" + root.getId() + "'/>"
+						+ "</CreateFolderRequest>");
 
 		// Sync the changes to the client (notification block)
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
-		
-		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmBriefcaseAppOverviewPanel, "Load the briefcase app, 1 briefcase");
+
+		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmBriefcaseAppOverviewPanel,
+				"Load the briefcase app, 1 briefcase");
 
 		// Currently in the mail app
 		// Navigate to the addressbook
-		//app.zPageBriefcase.zNavigateTo();
-		app.zPageBriefcase.zClickAt("css=td[id='zb__App__Briefcase_title']","");
+		// app.zPageBriefcase.zNavigateTo();
+		app.zPageBriefcase.zClickAt("css=td[id='zb__App__Briefcase_title']", "");
 
 		PerfMetrics.waitTimestamp(token);
 
 		// Wait for the app to load
 		app.zPageBriefcase.zWaitForActive();
-
-
 	}
 
+
 	@Test( description = "Measure the time to load the briefcase app, 100 briefcases",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
+
 	public void ZmBriefcaseAppFolders_02() throws HarnessException {
 
 		// Create 100 folders
 		FolderItem root = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.UserRoot);
 		for (int i = 0; i < 100; i++) {
-			app.zGetActiveAccount().soapSend(
-					"<CreateFolderRequest xmlns='urn:zimbraMail'>" +
-						"<folder name='case"+ ConfigProperties.getUniqueString() + "' view='document' l='"+ root.getId() +"'/>" +
-					"</CreateFolderRequest>");
+			app.zGetActiveAccount().soapSend("<CreateFolderRequest xmlns='urn:zimbraMail'>" + "<folder name='case"
+							+ ConfigProperties.getUniqueString() + "' view='document' l='" + root.getId() + "'/>"
+							+ "</CreateFolderRequest>");
 		}
-
 
 		// Sync the changes to the client (notification block)
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
 
-		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmBriefcaseAppOverviewPanel, "Load the briefcase app, 100 briefcases");
+		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmBriefcaseAppOverviewPanel,
+				"Load the briefcase app, 100 briefcases");
 
 		// Currently in the mail app
 		// Navigate to the addressbook
-		//app.zPageBriefcase.zNavigateTo();
-		app.zPageBriefcase.zClickAt("css=td[id='zb__App__Briefcase_title']","");
+		// app.zPageBriefcase.zNavigateTo();
+		app.zPageBriefcase.zClickAt("css=td[id='zb__App__Briefcase_title']", "");
 
 		PerfMetrics.waitTimestamp(token);
 
 		// Wait for the app to load
 		app.zPageBriefcase.zWaitForActive();
-
-
 	}
-
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/CreateTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/CreateTag.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.tags;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -32,11 +31,12 @@ public class CreateTag extends FeatureBriefcaseTest {
 		super.startingPage = app.zPageBriefcase;
 	}
 
-	
-	@Test(description = "Create a new tag by clicking 'new tag' on folder tree", 
+
+	@Test(description = "Create a new tag by clicking 'new tag' on folder tree",
 			groups = { "functional", "L2" })
 
 	public void CreateTag_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		// Set the new tag name
@@ -57,11 +57,12 @@ public class CreateTag extends FeatureBriefcaseTest {
 		ZAssert.assertEquals(tag.getName(), name, "Verify the server and client tag names match");
 	}
 
-	
-	@Test(description = "Create a new tag using keyboard shortcuts", 
+
+	@Test(description = "Create a new tag using keyboard shortcuts",
 			groups = { "functional", "L3" })
 
 	public void CreateTag_02() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -71,7 +72,7 @@ public class CreateTag extends FeatureBriefcaseTest {
 		// Set the new tag name
 		String name = "tag" + ConfigProperties.getUniqueString();
 
-		// refresh briefcase page tags section before creating a new tag
+		// Select briefcase folder tags section before creating a new tag
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		DialogTag dialog = (DialogTag) app.zPageBriefcase.zKeyboardShortcut(shortcut);
@@ -80,12 +81,9 @@ public class CreateTag extends FeatureBriefcaseTest {
 		SleepUtil.sleepMedium();
 		// Fill out the input field
 		dialog.zSetTagName(name);
-
-		SleepUtil.sleepVerySmall();
-
 		dialog.zClickButton(Button.B_OK);
 
-		// refresh briefcase page tags section after creating a new tag
+		// Select briefcase folder tags section after creating a new tag
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Make sure the tag was created on the server
@@ -98,11 +96,12 @@ public class CreateTag extends FeatureBriefcaseTest {
 		ZAssert.assertEquals(tag.getName(), name, "Verify the server and client tag names match");
 	}
 
-	
-	@Test(description = "Create a new tag using context menu on a tag", 
+
+	@Test(description = "Create a new tag using context menu on a tag",
 			groups = { "functional", "L3" })
 
 	public void CreateTag_03() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -118,7 +117,7 @@ public class CreateTag extends FeatureBriefcaseTest {
 		// Get the tag
 		TagItem tag1 = TagItem.importFromSOAP(account, name1);
 
-		// refresh briefcase page tags section before creating a new tag
+		// Select briefcase folder tags section before creating a new tag
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Create a new tag using the context menu + New Tag
@@ -130,7 +129,7 @@ public class CreateTag extends FeatureBriefcaseTest {
 		dialog.zSetTagName(name2);
 		dialog.zClickButton(Button.B_OK);
 
-		// refresh briefcase page tags section after creating a new tag
+		// Select briefcase folder tags section after creating a new tag
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Make sure the tag was created on the server
@@ -140,11 +139,12 @@ public class CreateTag extends FeatureBriefcaseTest {
 		ZAssert.assertEquals(tag2.getName(), name2, "Verify the server and client tag names match");
 	}
 
-	
-	@Test(description = "Create a new tag using briefcase app New -> New Tag", 
+
+	@Test(description = "Create a new tag using briefcase app New -> New Tag",
 			groups = { "functional", "L3" })
 
 	public void CreateTag_04() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
@@ -152,9 +152,8 @@ public class CreateTag extends FeatureBriefcaseTest {
 		// Set the new tag name
 		String name = "tag" + ConfigProperties.getUniqueString();
 
-		// refresh briefcase page tags section before creating a new tag
+		// Select briefcase folder tags section before creating a new tag
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
-		SleepUtil.sleepVerySmall();
 
 		// Create a new tag in the Briefcase using the New pull down menu + Tag
 		DialogTag dialog = (DialogTag) app.zPageBriefcase.zToolbarPressPulldown(Button.B_NEW, Button.O_NEW_TAG, null);
@@ -165,7 +164,7 @@ public class CreateTag extends FeatureBriefcaseTest {
 		dialog.zSetTagName(name);
 		dialog.zClickButton(Button.B_OK);
 
-		// refresh briefcase page tags section after creating a new tag
+		// Select briefcase folder tags section after creating a new tag
 		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Make sure the tag was created on the server

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/DeleteTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/DeleteTag.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.tags;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.qa.selenium.framework.items.FolderItem;
 import com.zimbra.qa.selenium.framework.items.TagItem;
 import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
@@ -30,52 +29,47 @@ public class DeleteTag extends FeatureBriefcaseTest {
 
 	public DeleteTag() {
 		logger.info("New " + DeleteTag.class.getCanonicalName());
-
-		// All tests start at the Briefcase page
 		super.startingPage = app.zPageBriefcase;
 	}
 
-	@Test( description = "Delete a tag - Right click, Delete", 
+
+	@Test( description = "Delete a tag - Right click, Delete",
 			groups = { "functional", "L3" })
+
 	public void DeleteTag_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create the tag to delete
 		String name = "tag" + ConfigProperties.getUniqueString();
 
-		account.soapSend("<CreateTagRequest xmlns='urn:zimbraMail'>"
-				+ "<tag name='" + name + "' color='1' />"
+		account.soapSend("<CreateTagRequest xmlns='urn:zimbraMail'>" + "<tag name='" + name + "' color='1' />"
 				+ "</CreateTagRequest>");
 
 		// Get the tag
 		TagItem tag = TagItem.importFromSOAP(app.zGetActiveAccount(), name);
 		ZAssert.assertNotNull(tag, "Verify the tag was created");
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Delete the tag using context menu
-		DialogWarning dialog = (DialogWarning) app.zTreeBriefcase.zTreeItem(
-				Action.A_RIGHTCLICK, Button.B_TREE_DELETE, tag);
+		DialogWarning dialog = (DialogWarning) app.zTreeBriefcase.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_DELETE,
+				tag);
 		ZAssert.assertNotNull(dialog, "Verify the warning dialog opened");
 
 		// Click "Yes" to confirm
 		dialog.zClickButton(Button.B_YES);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify the tag is deleted
 		account.soapSend("<GetTagRequest xmlns='urn:zimbraMail'/>");
 
-		String tagname = account
-				.soapSelectValue("//mail:GetTagResponse//mail:tag[@name='"
-						+ name + "']", "name");
+		String tagname = account.soapSelectValue("//mail:GetTagResponse//mail:tag[@name='" + name + "']", "name");
 		ZAssert.assertNull(tagname, "Verify the tag is deleted");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/RenameTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/RenameTag.java
@@ -17,7 +17,6 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.briefcase.tags;
 
 import org.testng.annotations.Test;
-
 import com.zimbra.common.soap.Element;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
 import com.zimbra.qa.selenium.framework.items.TagItem;
@@ -31,38 +30,36 @@ public class RenameTag extends FeatureBriefcaseTest {
 
 	public RenameTag() {
 		logger.info("New " + RenameTag.class.getCanonicalName());
-
-		// All tests start at the Briefcase page
-		super.startingPage = app.zPageBriefcase;	
+		super.startingPage = app.zPageBriefcase;
 	}
 
-	@Test( description = "Rename a tag - Right click, Rename", 
+
+	@Test( description = "Rename a tag - Right click, Rename",
 			groups = { "functional", "L3" })
+
 	public void RenameTag_01() throws HarnessException {
+
 		ZimbraAccount account = app.zGetActiveAccount();
 
-		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account,
-				SystemFolder.Briefcase);
+		FolderItem briefcaseFolder = FolderItem.importFromSOAP(account, SystemFolder.Briefcase);
 
 		// Create the tag to rename
 		String name1 = "tag" + ConfigProperties.getUniqueString();
 		String name2 = "tag" + ConfigProperties.getUniqueString();
 
-		account.soapSend("<CreateTagRequest xmlns='urn:zimbraMail'>"
-				+ "<tag name='" + name1 + "' color='1' />"
+		account.soapSend("<CreateTagRequest xmlns='urn:zimbraMail'>" + "<tag name='" + name1 + "' color='1' />"
 				+ "</CreateTagRequest>");
 
 		// Get the tag
 		TagItem tag = TagItem.importFromSOAP(account, name1);
 		ZAssert.assertNotNull(tag, "Verify the tag was created");
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Rename the tag using the context menu
-		DialogRenameTag dialog = (DialogRenameTag) app.zTreeBriefcase
-				.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_RENAMETAG, tag);
+		DialogRenameTag dialog = (DialogRenameTag) app.zTreeBriefcase.zTreeItem(Action.A_RIGHTCLICK,
+				Button.B_TREE_RENAMETAG, tag);
 		ZAssert.assertNotNull(dialog, "Verify the Rename Tag dialog opened");
 
 		// Set the new name, click OK
@@ -70,20 +67,16 @@ public class RenameTag extends FeatureBriefcaseTest {
 		dialog.zSetNewName(name2);
 		dialog.zClickButton(Button.B_OK);
 
-		// refresh briefcase page
-		app.zTreeBriefcase
-				.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
+		// Select briefcase folder
+		app.zTreeBriefcase.zTreeItem(Action.A_LEFTCLICK, briefcaseFolder, false);
 
 		// Verify the tag is no longer found
 		account.soapSend("<GetTagRequest xmlns='urn:zimbraMail'/>");
 
-		Element[] eTag1 = account.soapSelectNodes("//mail:tag[@name='" + name1
-				+ "']");
-		ZAssert.assertEquals(eTag1.length, 0,
-				"Verify the old tag name no longer exists");
+		Element[] eTag1 = account.soapSelectNodes("//mail:tag[@name='" + name1 + "']");
+		ZAssert.assertEquals(eTag1.length, 0, "Verify the old tag name no longer exists");
 
-		Element[] eTag2 = account.soapSelectNodes("//mail:tag[@name='" + name2
-				+ "']");
+		Element[] eTag2 = account.soapSelectNodes("//mail:tag[@name='" + name2 + "']");
 		ZAssert.assertEquals(eTag2.length, 1, "Verify the new tag name exists");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/addresscontextmenu/AddToContactsAttendeeContextMenu.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/addresscontextmenu/AddToContactsAttendeeContextMenu.java
@@ -66,8 +66,6 @@ public class AddToContactsAttendeeContextMenu extends PrefGroupMailByMessageTest
 		app.zPageMail.sClickAt(FormContactNew.Toolbar.SAVE, "");
 		SleepUtil.sleepMedium();
 
-		// -- Data Verification
-
 		app.zGetActiveAccount().soapSend(
 				"<SearchRequest xmlns='urn:zimbraMail' types='contact'>"
 						+ "<query>#firstname:" + contactFirst + "</query>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/assistant/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/assistant/CreateAppointment.java
@@ -37,20 +37,20 @@ public class CreateAppointment extends AjaxCommonTest {
 
 
 	@Test( description = "Create a basic appointment using the Zimbra Assistant",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 
 	public void CreateAppointment_01() throws HarnessException {
+
+		// Appointment data
+		String subject = "subject" + ConfigProperties.getUniqueString();
+		String location = "location" + ConfigProperties.getUniqueString();
+		String notes = "notes" + ConfigProperties.getUniqueString();
+		String command = "appointment \"" + subject + "\" ["+ location +"] ("+ notes +")";
 
 		Calendar start = Calendar.getInstance();
 		start.add(Calendar.DATE, -7);
 		Calendar finish = Calendar.getInstance();
 		finish.add(Calendar.DATE, +7);
-
-		// Create the message data to be sent
-		String subject = "subject" + ConfigProperties.getUniqueString();
-		String location = "location" + ConfigProperties.getUniqueString();
-		String notes = "notes" + ConfigProperties.getUniqueString();
-		String command = "appointment \"" + subject + "\" ["+ location +"] ("+ notes +")";
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -77,20 +77,20 @@ public class CreateAppointment extends AjaxCommonTest {
 
 	@Bugs(ids = "53005")
 	@Test( description = "Verify location is saved when using assistant",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 
 	public void CreateAppointment_02() throws HarnessException {
+
+		// Appointment data
+		String subject = "subject" + ConfigProperties.getUniqueString();
+		String location = "location" + ConfigProperties.getUniqueString();
+		String notes = "notes" + ConfigProperties.getUniqueString();
+		String command = "appointment \"" + subject + "\" ["+ location +"] ("+ notes +")";
 
 		Calendar start = Calendar.getInstance();
 		start.add(Calendar.DATE, -7);
 		Calendar finish = Calendar.getInstance();
 		finish.add(Calendar.DATE, +7);
-
-		// Create the message data to be sent
-		String subject = "subject" + ConfigProperties.getUniqueString();
-		String location = "location" + ConfigProperties.getUniqueString();
-		String notes = "notes" + ConfigProperties.getUniqueString();
-		String command = "appointment \"" + subject + "\" ["+ location +"] ("+ notes +")";
 
 		// Click Get Mail button
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/assistant/OpenAssistant.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/assistant/OpenAssistant.java
@@ -38,7 +38,7 @@ public class OpenAssistant extends AjaxCommonTest {
 	}
 	
 	@Test( description = "Open the assistant",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void OpenAssistant_01() throws HarnessException {
 		
 		// Click Get Mail button

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/toaster/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/toaster/CreateAppointment.java
@@ -36,7 +36,7 @@ public class CreateAppointment extends AjaxCommonTest {
 	
 	public void Toaster_CreateAppointment_01() throws HarnessException {
 		
-		// Create the message data to be sent
+		// Appointment data
 		AppointmentItem appt = new AppointmentItem();
 		appt.setSubject(ConfigProperties.getUniqueString());
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/allday/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/allday/CreateAppointment.java
@@ -70,12 +70,10 @@ public class CreateAppointment extends AjaxCommonTest {
 		ZAssert.assertEquals(app.zGetActiveAccount().soapMatch("//mail:GetAppointmentResponse//mail:comp", "allDay", "1"), true, "");
 		
 		// Verify appointment exists in current view
-		if (!app.zPageCalendar.zVerifyAppointmentExists(apptSubject))
-			
+		if (!app.zPageCalendar.zVerifyAppointmentExists(apptSubject)) {
 			app.zPageCalendar.zToolbarPressButton(Button.B_NEXT_PAGE);
+		}
 		
 		ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
-		
 	}
-	
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/allday/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/allday/DeleteAppointment.java
@@ -50,7 +50,6 @@ public class DeleteAppointment extends AjaxCommonTest {
 	
 	public void DeleteAllDayAppointment_01() throws HarnessException {
 
-		//-- Data Setup
 		// Creating objects for appointment data
 		String tz, apptSubject, apptBody;
 		tz = ZTimeZone.getLocalTimeZone().getID();
@@ -103,9 +102,6 @@ public class DeleteAppointment extends AjaxCommonTest {
 			groups = { "functional", "L3" })
 	
 	public void DeleteAllDayAppointment_02() throws HarnessException {
-
-
-		//-- Data Setup
 
 		// Creating objects for appointment data
 		String tz, apptSubject, apptBody;
@@ -162,8 +158,6 @@ public class DeleteAppointment extends AjaxCommonTest {
 	
 	public void DeleteAllDayAppointment_03(String name, int keyEvent) throws HarnessException {
 
-		//-- Data Setup
-
 		// Creating objects for appointment data
 		String tz, apptSubject, apptBody;
 		tz = ZTimeZone.getLocalTimeZone().getID();
@@ -200,8 +194,7 @@ public class DeleteAppointment extends AjaxCommonTest {
         DialogConfirmDeleteAppointment dlgConfirm = (DialogConfirmDeleteAppointment)app.zPageCalendar.zKeyboardKeyEvent(keyEvent);
 		dlgConfirm.zClickButton(Button.B_YES);
 
-
-		//-- Verification
+		// Verification
 		app.zGetActiveAccount().soapSend(
 					"<SearchRequest xmlns='urn:zimbraMail' types='appointment' calExpandInstStart='"+ startUTC.addDays(-7).toMillis() +"' calExpandInstEnd='"+ startUTC.addDays(7).toMillis() +"'>"
 				+	"<query>subject:("+ apptSubject +")</query>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/allday/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/allday/GetAppointment.java
@@ -81,6 +81,5 @@ public class GetAppointment extends AjaxCommonTest {
 
 		// Verify appointment exists in current view
         ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
-
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/CreateAppointment.java
@@ -44,8 +44,6 @@ public class CreateAppointment extends AjaxCommonTest {
 
 	public void CreateRecurringAppointment_01() throws HarnessException {
 
-		//-- Data Setup
-
 		// Appointment data
 		ZDate startTime, endTime;
 		AppointmentItem appt = new AppointmentItem();
@@ -61,13 +59,10 @@ public class CreateAppointment extends AjaxCommonTest {
 		appt.setEndTime(endTime);
 		appt.setRecurring("EVERYDAY", "");
 
-
 		// Create series appointment
 		FormApptNew apptForm = (FormApptNew) app.zPageCalendar.zToolbarPressButton(Button.B_NEW);
 		apptForm.zFill(appt);
 		apptForm.zSubmit();
-
-		//-- Data Verification
 
 		// Verify the new appointment exists on the server
 		AppointmentItem actual = AppointmentItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ appt.getSubject() +")", appt.getStartTime().addDays(-7), appt.getEndTime().addDays(7));

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/DeleteInstance.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/DeleteInstance.java
@@ -41,9 +41,8 @@ public class DeleteInstance extends AjaxCommonTest {
 	}
 
 
-	@Bugs(ids = "69132")
-	@Test(
-			description = "Delete instance of recurring appointment (every month) using toolbar button in day view",
+	@Bugs (ids = "69132")
+	@Test (description = "Delete instance of recurring appointment (every month) using toolbar button in day view",
 			groups = { "functional", "L3" } )
 	
 	public void DeleteInstance_01() throws HarnessException {
@@ -89,10 +88,6 @@ public class DeleteInstance extends AjaxCommonTest {
         DialogWarning dialogSeriesOrInstance = (DialogWarning)app.zPageCalendar.zToolbarPressButton(Button.B_DELETE);
         DialogWarning confirmDelete = (DialogWarning)dialogSeriesOrInstance.zClickButton(Button.B_OK);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
 		// On the server, verify the appointment is in the trash
 		app.zGetActiveAccount().soapSend(
@@ -166,10 +161,6 @@ public class DeleteInstance extends AjaxCommonTest {
 
         DialogWarning dialogSeriesOrInstance = (DialogWarning)app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_INSTANCE_MENU, Button.O_DELETE_MENU, apptSubject);;
         dialogSeriesOrInstance.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
 		// On the server, verify the appointment is in the trash
 		app.zGetActiveAccount().soapSend(
@@ -255,10 +246,6 @@ public class DeleteInstance extends AjaxCommonTest {
         DialogWarning confirmDelete = (DialogWarning)dialogSeriesOrInstance.zClickButton(Button.B_OK);
         confirmDelete.zClickButton(Button.B_YES);
 
-
-
-        //-- Verification
-
 		// On the server, verify the appointment is in the trash
 		app.zGetActiveAccount().soapSend(
 				"<SearchRequest xmlns='urn:zimbraMail' types='appointment' calExpandInstStart='"+ startTime.addDays(-7).toMillis() +"' calExpandInstEnd='"+ endTime.addDays(7).toMillis() +"'>"
@@ -282,8 +269,5 @@ public class DeleteInstance extends AjaxCommonTest {
 		ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify instance is deleted from the calendar");
 		//boolean deleted = app.zPageCalendar.zWaitForElementDeleted(app.zPageCalendar.zGetApptLocator(apptSubject), "10000");
 		//ZAssert.assertEquals(deleted, true, "Verify instance is deleted from the calendar");
-
-
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/DeleteSeries.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/DeleteSeries.java
@@ -85,7 +85,6 @@ public class DeleteSeries extends AjaxCommonTest {
 
         app.zPageCalendar.zListItem(Action.A_LEFTCLICK, apptSubject);
 
-
         // If you select an instance and click delete button, you
         // get two dialogs:
         // First: do you want to delete the instance or series?
@@ -100,12 +99,7 @@ public class DeleteSeries extends AjaxCommonTest {
         if (confirmDelete == null) {
         	throw new HarnessException("The 'Confirm Delete' dialog never appeared.");
         }
-        // confirmDelete.zClickButton(Button.B_DELETE_ALL_OCCURRENCES);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
         // On the server, verify the appointment is in the trash
         app.zGetActiveAccount().soapSend(
@@ -181,12 +175,7 @@ public class DeleteSeries extends AjaxCommonTest {
         if (confirmDelete == null) {
         	throw new HarnessException("The 'Confirm Delete' dialog never appeared.");
         }
-        // confirmDelete.zClickButton(Button.B_DELETE_ALL_OCCURRENCES);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
         // On the server, verify the appointment is in the trash
         app.zGetActiveAccount().soapSend(
@@ -199,7 +188,6 @@ public class DeleteSeries extends AjaxCommonTest {
         		folderID,
         		FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Trash).getId(),
         		"Verify appointment is in the trash folder");
-
 
         // Verify the appointment is not in the GUI view
         ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify instance is deleted from the calendar");
@@ -270,12 +258,7 @@ public class DeleteSeries extends AjaxCommonTest {
         if (confirmDelete == null) {
         	throw new HarnessException("The 'Confirm Delete' dialog never appeared.");
         }
-        // confirmDelete.zClickButton(Button.B_DELETE_ALL_OCCURRENCES);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
         // On the server, verify the appointment is in the trash
         app.zGetActiveAccount().soapSend(
@@ -288,7 +271,6 @@ public class DeleteSeries extends AjaxCommonTest {
         		folderID,
         		FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Trash).getId(),
         		"Verify appointment is in the trash folder");
-
 
         // Verify the appointment is not in the GUI view
         ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify instance is deleted from the calendar");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/GetAppointment.java
@@ -43,12 +43,10 @@ public class GetAppointment extends AjaxCommonTest {
 	
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();
-
 
 		// Absolute dates in UTC zone
 		Calendar now = Calendar.getInstance();
@@ -83,6 +81,5 @@ public class GetAppointment extends AjaxCommonTest {
 
 		// Verify appointment exists in current view
         ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
-
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/ModifyAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/recurring/ModifyAppointment.java
@@ -23,7 +23,6 @@ import com.zimbra.qa.selenium.framework.items.AppointmentItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZDate;
 import com.zimbra.qa.selenium.framework.util.ZTimeZone;
@@ -86,7 +85,6 @@ public class ModifyAppointment extends AjaxCommonTest {
 
         // Open appointment & modify subject, body and save it
         app.zPageCalendar.zListItem(Action.A_DOUBLECLICK, apptSubject);
-        SleepUtil.sleepMedium();
         FormApptNew apptForm = new FormApptNew(app);
         appt.setSubject(editApptSubject);
         appt.setContent(editApptBody);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/CreateAppointment.java
@@ -64,7 +64,7 @@ public class CreateAppointment extends AjaxCommonTest {
 		// Fill out the form with the data
 		apptForm.zFill(appt);
 
-		// Send the message
+		// Send invite
 		apptForm.zSubmit();
 
 		// Verify the new appointment exists on the server
@@ -83,7 +83,6 @@ public class CreateAppointment extends AjaxCommonTest {
 		ZimbraResource location = new ZimbraResource(ZimbraResource.Type.LOCATION);
 		ZimbraResource equipment = new ZimbraResource(ZimbraResource.Type.EQUIPMENT);
 		AppointmentItem appt = new AppointmentItem();
-
 
 		String apptSubject, apptAttendee1, apptOptional1, apptLocation1, apptEquipment1, apptContent;
 		Calendar now = Calendar.getInstance();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/DragAndDropAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/DragAndDropAppointment.java
@@ -47,7 +47,6 @@ public class DragAndDropAppointment extends AjaxCommonTest {
 		String foldername = "folder"+ ConfigProperties.getUniqueString();
 
 		// Create a calendar to move the appointment into
-		//
 		FolderItem rootFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.UserRoot);
 
 		app.zGetActiveAccount().soapSend(
@@ -93,9 +92,8 @@ public class DragAndDropAppointment extends AjaxCommonTest {
 					"css=div[id^='zli__CLD__"+ apptId +"'] td.appt_name", // <div id="zli__CLWW__263_DWT114" .../>
 					"css=td[id='zti__main_Calendar__"+ subcalendarFolder.getId() + "_textCell']"); // <div id="zti__main_Calendar__273_textCell" .../>
 
-		//-- Server verification
+		// Verification
 		AppointmentItem newAppointment = AppointmentItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ apptSubject +")");
-
 		ZAssert.assertEquals(newAppointment.getFolder(), subcalendarFolder.getId(), "Verify the appointment moved folders");
 	}
 
@@ -174,13 +172,11 @@ public class DragAndDropAppointment extends AjaxCommonTest {
 
     	app.zPageCalendar.zDragAndDropBy(sourceLocator,destinationLocator,0,5);
 
-		//-- Server verification
+		// Verification
 
 		// Make sure the time has changed
-		// (It is difficult to know for certain what time is correct.  For
-		// now, just make sure it was moved somewhere.)
-        app.zGetActiveAccount().soapSend(
-        		"<GetAppointmentRequest id='"+ apptId + "' xmlns='urn:zimbraMail'/>");
+		// (It is difficult to know for certain what time is correct. For now, just make sure it was moved somewhere.)
+        app.zGetActiveAccount().soapSend("<GetAppointmentRequest id='"+ apptId + "' xmlns='urn:zimbraMail'/>");
         String s1 = app.zGetActiveAccount().soapSelectValue("//mail:s", "d");
         String e2 = app.zGetActiveAccount().soapSelectValue("//mail:e", "d");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/GetAppointment.java
@@ -42,8 +42,7 @@ public class GetAppointment extends AjaxCommonTest {
 	
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/DeleteTagAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/DeleteTagAppointment.java
@@ -155,7 +155,5 @@ public class DeleteTagAppointment extends AjaxCommonTest {
 
 		// Verify appointment exists in current view
         ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
-
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/TagAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/TagAppointment.java
@@ -181,6 +181,5 @@ public class TagAppointment extends AjaxCommonTest {
 		// Verify applied tag for appointment
 		app.zGetActiveAccount().soapSend("<GetAppointmentRequest xmlns='urn:zimbraMail' id='" + apptId + "'/>");
         ZAssert.assertEquals(app.zGetActiveAccount().soapSelectValue("//mail:appt", "t"), tagID, "Verify the appointment is tagged with the correct tag");
-
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/UnTagAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/UnTagAppointment.java
@@ -116,6 +116,5 @@ public class UnTagAppointment extends AjaxCommonTest {
         // Verify appointment is not tagged
         app.zGetActiveAccount().soapSend("<GetAppointmentRequest xmlns='urn:zimbraMail' id='" + apptId + "'/>");
         ZAssert.assertEquals(app.zGetActiveAccount().soapSelectValue("//mail:appt", "t"), null, "Verify appointment is not tagged");
-
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/freebusy/singleday/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/freebusy/singleday/GetAppointment.java
@@ -46,8 +46,7 @@ public class GetAppointment extends AjaxCommonTest {
 	
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 
 		// Absolute dates in UTC zone
@@ -85,6 +84,5 @@ public class GetAppointment extends AjaxCommonTest {
 		// Verify the appointment appears on the page
 		SleepUtil.sleepLong(); //test fails without sleep because calendar view rendering takes time
 		ZAssert.assertTrue(app.zPageCalendar.zGetApptLocatorFreeBusyView(app.zGetActiveAccount().EmailAddress, apptSubject), "Verify attendee free/busy row exists");
-
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/DeleteAppointment.java
@@ -287,7 +287,7 @@ public class DeleteAppointment extends AjaxCommonTest {
 
 	@Bugs(ids = "72444")
 	@Test( description = "Delete a appt by selecting and typing '.t' shortcut",
-			groups = { "functional", "L5" } )
+			groups = { "functional", "application-bug" } )
 
 	public void DeleteAppointment_04() throws HarnessException {
 
@@ -585,7 +585,7 @@ public class DeleteAppointment extends AjaxCommonTest {
 
 	@Bugs(ids = "102051")
 	@Test( description = "Hard-delete a appt by selecting and typing 'shift-del' shortcut",
-			groups = { "functional", "L5" } )
+			groups = { "functional", "application-bug" } )
 
 	public void HardDeleteAppointment_01() throws HarnessException {
 
@@ -655,7 +655,7 @@ public class DeleteAppointment extends AjaxCommonTest {
 
 	@Bugs(ids = "102051")
 	@Test( description = "Hard-delete multiple appts (3) by selecting and typing 'shift-del' shortcut",
-			groups = { "functional", "L5" })
+			groups = { "functional-skip", "application-bug" })
 
 	public void HardDeleteAppointment_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/GetAppointment.java
@@ -46,8 +46,7 @@ public class GetAppointment extends AjaxCommonTest {
 	
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String subject = ConfigProperties.getUniqueString();
 
 		// Absolute dates in UTC zone
@@ -98,8 +97,7 @@ public class GetAppointment extends AjaxCommonTest {
 
 	public void GetAppointment_02() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String subject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();
@@ -144,7 +142,6 @@ public class GetAppointment extends AjaxCommonTest {
 		}
 
 		ZAssert.assertNotNull(found, "Verify the appointment is in the list");
-
 	    ZAssert.assertEquals(found.getGSubject(), subject, "Verify the appointment subject");
 	    ZAssert.assertStringContains(found.getGFragment(), content, "Verify the appointment fragment");
 	    ZAssert.assertEquals(found.getGLocation(), location, "Verify the appointment location");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/singleday/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/singleday/DeleteAppointment.java
@@ -47,8 +47,7 @@ public class DeleteAppointment extends AjaxCommonTest {
 
 	public void DeleteAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String subject = ConfigProperties.getUniqueString();
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -61,7 +60,6 @@ public class DeleteAppointment extends AjaxCommonTest {
 				"content" + ConfigProperties.getUniqueString(),
 				"location" + ConfigProperties.getUniqueString(),
 				null);
-
 
 		// Refresh the calendar
 		app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/schedule/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/schedule/GetAppointment.java
@@ -47,14 +47,12 @@ public class GetAppointment extends AjaxCommonTest {
 	// BUG 68610: remove schedule view
 	@Bugs(ids = "69132,68610")
 	@Test( description = "View a basic appointment in the schedule view",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String subject = ConfigProperties.getUniqueString();
-
 
 		// Absolute dates in UTC zone
 		Calendar now = Calendar.getInstance();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/allday/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/allday/DeleteAppointment.java
@@ -87,7 +87,6 @@ public class DeleteAppointment extends AjaxCommonTest {
 		dlgConfirm.zClickButton(Button.B_YES);
 		dlgConfirm.zWaitForClose();
 
-
 		//-- Verification
 		SleepUtil.sleepMedium(); //testcase failing due to timing issue so added sleep
 		ZAssert.assertEquals(app.zPageCalendar.sIsElementPresent(app.zPageCalendar.zGetAllDayApptLocator(apptSubject)), false, "Verify all-day appointment is deleted");
@@ -192,7 +191,6 @@ public class DeleteAppointment extends AjaxCommonTest {
         // Delete appointment using keyboard Del and Backspace key
         DialogConfirmDeleteAppointment dlgConfirm = (DialogConfirmDeleteAppointment)app.zPageCalendar.zKeyboardKeyEvent(keyEvent);
 		dlgConfirm.zClickButton(Button.B_YES);
-
 
 		//-- Verification
 		app.zGetActiveAccount().soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/recurring/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/recurring/CreateAppointment.java
@@ -43,8 +43,6 @@ public class CreateAppointment extends AjaxCommonTest {
 
 	public void CreateRecurringAppointment_01() throws HarnessException {
 
-		//-- Data Setup
-
 		// Appointment data
 		ZDate startTime, endTime;
 		AppointmentItem appt = new AppointmentItem();
@@ -60,14 +58,10 @@ public class CreateAppointment extends AjaxCommonTest {
 		appt.setEndTime(endTime);
 		appt.setRecurring("EVERYDAY", "");
 
-		//-- GUI steps
-
 		// Create series appointment
 		FormApptNew apptForm = (FormApptNew) app.zPageCalendar.zToolbarPressButton(Button.B_NEW);
 		apptForm.zFill(appt);
 		apptForm.zSubmit();
-
-		//-- Data Verification
 
 		// Verify the new appointment exists on the server
 		SleepUtil.sleepSmall(); //test fails without sleep

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/recurring/DeleteInstance.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/recurring/DeleteInstance.java
@@ -47,8 +47,6 @@ public class DeleteInstance extends AjaxCommonTest {
 
 	public void DeleteInstance_01() throws HarnessException {
 
-		//-- Data Setup
-
 		// Appointment data
 		String tz, apptSubject, apptBody;
 		tz = ZTimeZone.getLocalTimeZone().getID();
@@ -92,8 +90,6 @@ public class DeleteInstance extends AjaxCommonTest {
         DialogWarning confirmDelete = (DialogWarning)dialogSeriesOrInstance.zClickButton(Button.B_OK);
         confirmDelete.zClickButton(Button.B_YES);
 
-        //-- Verification
-
 		// On the server, verify the appointment is in the trash
 		app.zGetActiveAccount().soapSend(
 				"<SearchRequest xmlns='urn:zimbraMail' types='appointment' calExpandInstStart='"+ startTime.addDays(-7).toMillis() +"' calExpandInstEnd='"+ endTime.addDays(7).toMillis() +"'>"
@@ -125,8 +121,6 @@ public class DeleteInstance extends AjaxCommonTest {
 			groups = { "functional", "L3" } )
 
 	public void DeleteInstance_02() throws HarnessException {
-
-		//-- Data Setup
 
 		// Appointment data
 		String tz, apptSubject, apptBody;
@@ -168,8 +162,6 @@ public class DeleteInstance extends AjaxCommonTest {
 
         DialogWarning dialogSeriesOrInstance = (DialogWarning)app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_INSTANCE_MENU, Button.O_DELETE_MENU, apptSubject);;
         dialogSeriesOrInstance.zClickButton(Button.B_YES);
-
-        //-- Verification
 
 		// On the server, verify the appointment is in the trash
 		app.zGetActiveAccount().soapSend(
@@ -213,8 +205,6 @@ public class DeleteInstance extends AjaxCommonTest {
 
 	public void DeleteInstance_03(String name, int keyEvent) throws HarnessException {
 
-		//-- Data Setup
-
 		// Appointment data
 		String tz, apptSubject, apptBody;
 		tz = ZTimeZone.getLocalTimeZone().getID();
@@ -257,8 +247,6 @@ public class DeleteInstance extends AjaxCommonTest {
         dialogSeriesOrInstance.zClickButton(Button.B_DELETE_THIS_INSTANCE);
         DialogWarning confirmDelete = (DialogWarning)dialogSeriesOrInstance.zClickButton(Button.B_OK);
         confirmDelete.zClickButton(Button.B_YES);
-
-        //-- Verification
 
 		// On the server, verify the appointment is in the trash
 		app.zGetActiveAccount().soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/recurring/DeleteSeries.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/recurring/DeleteSeries.java
@@ -84,7 +84,6 @@ public class DeleteSeries extends AjaxCommonTest {
 
         app.zPageCalendar.zListItem(Action.A_LEFTCLICK, apptSubject);
 
-
         // If you select an instance and click delete button, you
         // get two dialogs:
         // First: do you want to delete the instance or series?
@@ -99,12 +98,7 @@ public class DeleteSeries extends AjaxCommonTest {
         if (confirmDelete == null) {
         	throw new HarnessException("The 'Confirm Delete' dialog never appeared.");
         }
-        // confirmDelete.zClickButton(Button.B_DELETE_ALL_OCCURRENCES);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
         // On the server, verify the appointment is in the trash
         app.zGetActiveAccount().soapSend(
@@ -117,7 +111,6 @@ public class DeleteSeries extends AjaxCommonTest {
         		folderID,
         		FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Trash).getId(),
         		"Verify appointment is in the trash folder");
-
 
         // Verify the appointment is not in the GUI view
         ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify instance is deleted from the calendar");
@@ -180,12 +173,7 @@ public class DeleteSeries extends AjaxCommonTest {
         if (confirmDelete == null) {
         	throw new HarnessException("The 'Confirm Delete' dialog never appeared.");
         }
-        // confirmDelete.zClickButton(Button.B_DELETE_ALL_OCCURRENCES);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
         // On the server, verify the appointment is in the trash
         app.zGetActiveAccount().soapSend(
@@ -198,7 +186,6 @@ public class DeleteSeries extends AjaxCommonTest {
         		folderID,
         		FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Trash).getId(),
         		"Verify appointment is in the trash folder");
-
 
         // Verify the appointment is not in the GUI view
         ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify instance is deleted from the calendar");
@@ -269,12 +256,7 @@ public class DeleteSeries extends AjaxCommonTest {
         if (confirmDelete == null) {
         	throw new HarnessException("The 'Confirm Delete' dialog never appeared.");
         }
-        // confirmDelete.zClickButton(Button.B_DELETE_ALL_OCCURRENCES);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
         // On the server, verify the appointment is in the trash
         app.zGetActiveAccount().soapSend(
@@ -287,7 +269,6 @@ public class DeleteSeries extends AjaxCommonTest {
         		folderID,
         		FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Trash).getId(),
         		"Verify appointment is in the trash folder");
-
 
         // Verify the appointment is not in the GUI view
         ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify instance is deleted from the calendar");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/recurring/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/recurring/GetAppointment.java
@@ -44,8 +44,7 @@ public class GetAppointment extends AjaxCommonTest {
 
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();
@@ -87,9 +86,11 @@ public class GetAppointment extends AjaxCommonTest {
 		// Verify appointment exists in current view
         ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
 
-	    // Verify appt displayed in workweek view
-        app.zPageCalendar.zToolbarPressButton(Button.B_WORKWEEK_VIEW);
-		app.zPageCalendar.zWaitForElementPresent("css=div[id*=zli__CLWW__]");
-		ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
+        // Verify appt displayed in workweek view
+        if (Calendar.getInstance().get(Calendar.DAY_OF_WEEK) != Calendar.SATURDAY && Calendar.getInstance().get(Calendar.DAY_OF_WEEK) != Calendar.SUNDAY) {
+            app.zPageCalendar.zToolbarPressButton(Button.B_WORKWEEK_VIEW);
+    		app.zPageCalendar.zWaitForElementPresent("css=div[id*=zli__CLWW__]");
+    		ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
+		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/singleday/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/singleday/CreateAppointment.java
@@ -62,7 +62,7 @@ public class CreateAppointment extends AjaxCommonTest {
 		// Fill out the form with the data
 		apptForm.zFill(appt);
 
-		// Send the message
+		// Send invite
 		apptForm.zSubmit();
 
 		// Verify the new appointment exists on the server
@@ -78,10 +78,9 @@ public class CreateAppointment extends AjaxCommonTest {
 	public void CreateAppointment_02() throws HarnessException {
 
 		// Create appointment data
+		AppointmentItem appt = new AppointmentItem();
 		ZimbraResource location = new ZimbraResource(ZimbraResource.Type.LOCATION);
 		ZimbraResource equipment = new ZimbraResource(ZimbraResource.Type.EQUIPMENT);
-
-		AppointmentItem appt = new AppointmentItem();
 
 		String apptSubject, apptAttendee1, apptOptional1, apptLocation1, apptEquipment1, apptContent;
 		Calendar now = Calendar.getInstance();
@@ -158,5 +157,4 @@ public class CreateAppointment extends AjaxCommonTest {
 		ZAssert.assertEquals(actual.getSubject(), appt.getSubject(), "Subject: Verify the appointment data");
 		ZAssert.assertEquals(app.zGetActiveAccount().soapMatch("//mail:GetAppointmentResponse//mail:comp", "class", "PRI"), true, "");
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/singleday/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/singleday/DeleteAppointment.java
@@ -40,6 +40,7 @@ public class DeleteAppointment extends AjaxCommonTest {
 		};
 	}
 
+	
 	@Bugs(ids = "69132")
 	@Test( description = "Delete an appointment using Delete toolbar button in week view",
 			groups = { "smoke", "L3" })

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/singleday/DragAndDropAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/singleday/DragAndDropAppointment.java
@@ -27,23 +27,21 @@ import com.zimbra.qa.selenium.projects.ajax.core.*;
 
 public class DragAndDropAppointment extends AjaxCommonTest {
 
-
 	public DragAndDropAppointment() {
 		logger.info("New "+ DragAndDropAppointment.class.getCanonicalName());
 
-		// All tests start at the Calendar page
 		super.startingPage = app.zPageCalendar;
-
-		// Make sure we are using an account with week view
 		super.startingAccountPreferences = new HashMap<String, String>() {
-			private static final long serialVersionUID = -2913827779459595178L;
-		{
-		    put("zimbraPrefCalendarInitialView", "week");
-		}};
+			private static final long serialVersionUID = -2913827779459595178L; {
+				put("zimbraPrefCalendarInitialView", "week");
+			}
+		};
 	}
 
+	
 	@Test( description = "Drag and Drop a appointment from calendar to different calendar in week view",
 			groups = { "smoke", "L3" })
+	
 	public void DragAndDropAppointment_01() throws HarnessException {
 
 		String foldername = "folder"+ ConfigProperties.getUniqueString();
@@ -93,20 +91,16 @@ public class DragAndDropAppointment extends AjaxCommonTest {
 					"css=div[id^='zli__CLW__"+ apptId +"'] td.appt_name", // <div id="zli__CLWW__263_DWT114" .../>
 					"css=td[id='zti__main_Calendar__"+ subcalendarFolder.getId() + "_textCell']"); // <div id="zti__main_Calendar__273_textCell" .../>
 
-
-
-
-		//-- Server verification
+		// Server verification
 		AppointmentItem newAppointment = AppointmentItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ apptSubject +")");
-
 		ZAssert.assertEquals(newAppointment.getFolder(), subcalendarFolder.getId(), "Verify the appointment moved folders");
-
 	}
 
+	
 	@Test( description = "Drag and Drop a appointment from one time to a different time in week view",
 			groups = { "smoke", "L3" })
+	
 	public void DragAndDropAppointment_02() throws HarnessException {
-
 
 		// We need to create two appointments to make a locator to drag and drop to.
 		// Steps:
@@ -170,29 +164,24 @@ public class DragAndDropAppointment extends AjaxCommonTest {
 
         // Verify appointment exists in current view
         ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
-
 		SleepUtil.sleepMedium();
 
+		// Drag and drop the item
+		String sourceLocator = "css=div[id^='zli__CLW__"+ apptId +"'] td.appt_name";
+		String destinationLocator = "css=div[id^='zli__CLW__"+ otherApptId +"'] td.appt_name";
+		
+		app.zPageCalendar.zDragAndDropBy(sourceLocator,destinationLocator,0,10);
 
-		// drag and drop the item
-        	String sourceLocator = "css=div[id^='zli__CLW__"+ apptId +"'] td.appt_name";
-        	String destinationLocator = "css=div[id^='zli__CLW__"+ otherApptId +"'] td.appt_name";
-
-        	app.zPageCalendar.zDragAndDropBy(sourceLocator,destinationLocator,0,10);
-
-		//-- Server verification
+		// Server verification
 
 		// Make sure the time has changed
 		// (It is difficult to know for certain what time is correct.  For
 		// now, just make sure it was moved somewhere.)
-        app.zGetActiveAccount().soapSend(
-        		"<GetAppointmentRequest id='"+ apptId + "' xmlns='urn:zimbraMail'/>");
+        app.zGetActiveAccount().soapSend("<GetAppointmentRequest id='"+ apptId + "' xmlns='urn:zimbraMail'/>");
         String s1 = app.zGetActiveAccount().soapSelectValue("//mail:s", "d");
         String e2 = app.zGetActiveAccount().soapSelectValue("//mail:e", "d");
 
 		ZAssert.assertStringDoesNotContain(s1, s, "Verify the start time changed");
 		ZAssert.assertStringDoesNotContain(e2, e, "Verify the end time changed");
-
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/singleday/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/week/singleday/GetAppointment.java
@@ -42,8 +42,7 @@ public class GetAppointment extends AjaxCommonTest {
 
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/recurring/DeleteInstance.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/recurring/DeleteInstance.java
@@ -83,10 +83,6 @@ public class DeleteInstance extends AjaxCommonTest {
         DialogWarning confirmDelete = (DialogWarning)dialogSeriesOrInstance.zClickButton(Button.B_OK);
         confirmDelete.zClickButton(Button.B_YES);
 
-
-
-        //-- Verification
-
 		// On the server, verify the appointment is in the trash
 		app.zGetActiveAccount().soapSend(
 				"<SearchRequest xmlns='urn:zimbraMail' types='appointment' calExpandInstStart='"+ startTime.addDays(-7).toMillis() +"' calExpandInstEnd='"+ endTime.addDays(7).toMillis() +"'>"
@@ -160,10 +156,6 @@ public class DeleteInstance extends AjaxCommonTest {
         DialogWarning dialogSeriesOrInstance = (DialogWarning)app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_INSTANCE_MENU, Button.O_DELETE_MENU, apptSubject);;
         dialogSeriesOrInstance.zClickButton(Button.B_YES);
 
-
-
-        //-- Verification
-
 		// On the server, verify the appointment is in the trash
 		app.zGetActiveAccount().soapSend(
 				"<SearchRequest xmlns='urn:zimbraMail' types='appointment' calExpandInstStart='"+ startTime.addDays(-7).toMillis() +"' calExpandInstEnd='"+ endTime.addDays(7).toMillis() +"'>"
@@ -187,9 +179,9 @@ public class DeleteInstance extends AjaxCommonTest {
 		ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify instance is deleted from the calendar");
 		//boolean deleted = app.zPageCalendar.zWaitForElementDeleted(app.zPageCalendar.zGetApptLocator(apptSubject), "10000");
 		//ZAssert.assertEquals(deleted, true, "Verify instance is deleted from the calendar");
-
 	}
 
+	
 	@DataProvider(name = "DataProviderShortcutKeys")
 	public Object[][] DataProviderShortcutKeys() {
 		return new Object[][] {
@@ -197,7 +189,6 @@ public class DeleteInstance extends AjaxCommonTest {
 				new Object[] { "VK_BACK_SPACE", KeyEvent.VK_BACK_SPACE },
 		};
 	}
-
 
 	@Bugs (ids = "69132")
 	@Test (description = "Delete instance of series appointment (every week) using keyboard shortcuts Del & Backspace",
@@ -249,10 +240,6 @@ public class DeleteInstance extends AjaxCommonTest {
         DialogWarning confirmDelete = (DialogWarning)dialogSeriesOrInstance.zClickButton(Button.B_OK);
         confirmDelete.zClickButton(Button.B_YES);
 
-
-
-        //-- Verification
-
 		// On the server, verify the appointment is in the trash
 		app.zGetActiveAccount().soapSend(
 				"<SearchRequest xmlns='urn:zimbraMail' types='appointment' calExpandInstStart='"+ startTime.addDays(-7).toMillis() +"' calExpandInstEnd='"+ endTime.addDays(7).toMillis() +"'>"
@@ -276,7 +263,5 @@ public class DeleteInstance extends AjaxCommonTest {
 		ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify instance is deleted from the calendar");
 		//boolean deleted = app.zPageCalendar.zWaitForElementDeleted(app.zPageCalendar.zGetApptLocator(apptSubject), "10000");
 		//ZAssert.assertEquals(deleted, true, "Verify instance is deleted from the calendar");
-
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/recurring/DeleteSeries.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/recurring/DeleteSeries.java
@@ -93,12 +93,7 @@ public class DeleteSeries extends AjaxCommonTest {
         if (confirmDelete == null) {
         	throw new HarnessException("The 'Confirm Delete' dialog never appeared.");
         }
-        // confirmDelete.zClickButton(Button.B_DELETE_ALL_OCCURRENCES);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
         // On the server, verify the appointment is in the trash
         app.zGetActiveAccount().soapSend(
@@ -176,12 +171,7 @@ public class DeleteSeries extends AjaxCommonTest {
         if (confirmDelete == null) {
         	throw new HarnessException("The 'Confirm Delete' dialog never appeared.");
         }
-        // confirmDelete.zClickButton(Button.B_DELETE_ALL_OCCURRENCES);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
         // On the server, verify the appointment is in the trash
         app.zGetActiveAccount().soapSend(
@@ -266,12 +256,7 @@ public class DeleteSeries extends AjaxCommonTest {
         if (confirmDelete == null) {
         	throw new HarnessException("The 'Confirm Delete' dialog never appeared.");
         }
-        // confirmDelete.zClickButton(Button.B_DELETE_ALL_OCCURRENCES);
         confirmDelete.zClickButton(Button.B_YES);
-
-
-
-        //-- Verification
 
         // On the server, verify the appointment is in the trash
         app.zGetActiveAccount().soapSend(
@@ -290,8 +275,5 @@ public class DeleteSeries extends AjaxCommonTest {
         ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify instance is deleted from the calendar");
 		//boolean deleted = app.zPageCalendar.zWaitForElementDeleted(app.zPageCalendar.zGetApptLocator(apptSubject), "10000");
 		//ZAssert.assertEquals(deleted, true, "Verify instance is deleted from the calendar");
-
 	}
-
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/recurring/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/recurring/GetAppointment.java
@@ -38,11 +38,9 @@ public class GetAppointment extends AjaxCommonTest {
 	public void GetAppointment_01() throws HarnessException {
 
 		// Create the appointment on the server
-		// Create the message data to be sent
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();
-
 
 		// Absolute dates in UTC zone
 		Calendar now = Calendar.getInstance();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/CreateAppointment.java
@@ -55,7 +55,7 @@ public class CreateAppointment extends AjaxCommonTest {
 		// Fill out the form with the data
 		apptForm.zFill(appt);
 
-		// Send the message
+		// Send invite
 		apptForm.zSubmit();
 
 		// Verify the new appointment exists on the server
@@ -177,7 +177,7 @@ public class CreateAppointment extends AjaxCommonTest {
 		apptForm.zFill(appt);
         ZAssert.assertTrue(apptForm.zVerifyMeetingInPastWarning(), "Verify meeting in past warning appears");
 
-		// Send the message
+		// Send invite
 		apptForm.zSubmit();
 
 		// Verify the new appointment exists on the server

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/CreateAppointmentWithGALFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/CreateAppointmentWithGALFalse.java
@@ -35,7 +35,8 @@ public class CreateAppointmentWithGALFalse extends AjaxCommonTest {
 
 
 	@Bugs(ids = "99777")
-	@Test( description = "Create a basic appointment this zimbraFeatureGalEnabled=FALSE", groups = { "functional", "L2" } )
+	@Test( description = "Create a basic appointment this zimbraFeatureGalEnabled=FALSE", 
+			groups = { "functional", "L2" } )
 
 	public void CreateAppointmentWithGALFalse_01() throws HarnessException {
 
@@ -54,7 +55,7 @@ public class CreateAppointmentWithGALFalse extends AjaxCommonTest {
 		// Fill out the form with the data
 		apptForm.zFill(appt);
 
-		// Send the message
+		// Send invite
 		apptForm.zSubmit();
 
 		// Verify the new appointment exists on the server

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/DeleteAppointment.java
@@ -120,7 +120,6 @@ public class DeleteAppointment extends AjaxCommonTest {
 		dlgConfirm.zWaitForClose();
 
 		ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), false, "Verify appointment is deleted");
-
 	}
 
 
@@ -173,7 +172,7 @@ public class DeleteAppointment extends AjaxCommonTest {
         DialogConfirmDeleteAppointment dlgConfirm = (DialogConfirmDeleteAppointment)app.zPageCalendar.zKeyboardKeyEvent(keyEvent);
 		dlgConfirm.zClickButton(Button.B_YES);
 
-		//-- Verification
+		// Verification
 		app.zGetActiveAccount().soapSend(
 					"<SearchRequest xmlns='urn:zimbraMail' types='appointment' calExpandInstStart='"+ startUTC.addDays(-7).toMillis() +"' calExpandInstEnd='"+ startUTC.addDays(7).toMillis() +"'>"
 				+	"<query>subject:("+ apptSubject +")</query>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/DragAndDropAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/DragAndDropAppointment.java
@@ -165,13 +165,11 @@ public class DragAndDropAppointment extends AjaxCommonTest {
 
         SleepUtil.sleepMedium();
 
-		// drag and drop the item
-        	String sourceLocator = "css=div[id^='zli__CLWW__"+ apptId +"'] td.appt_name";
-        	String destinationLocator = "css=div[id^='zli__CLWW__"+ otherApptId +"'] td.appt_name";
+		// Drag and drop the item
+    	String sourceLocator = "css=div[id^='zli__CLWW__"+ apptId +"'] td.appt_name";
+    	String destinationLocator = "css=div[id^='zli__CLWW__"+ otherApptId +"'] td.appt_name";
 
-        	app.zPageCalendar.zDragAndDropBy(sourceLocator,destinationLocator,0,10);
-
-		// Server verification
+    	app.zPageCalendar.zDragAndDropBy(sourceLocator,destinationLocator,0,10);
 
 		// Make sure the time has changed
 		// (It is difficult to know for certain what time is correct.  For

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/GetAppointment.java
@@ -36,8 +36,7 @@ public class GetAppointment extends AjaxCommonTest {
 
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/ModifyAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/ModifyAppointment.java
@@ -37,6 +37,7 @@ public class ModifyAppointment extends AjaxCommonTest {
 		super.startingPage = app.zPageCalendar;
 	}
 
+	
 	@Bugs (ids = "69132")
 	@Test (description = "Modify appointment with subject & body and verify it",
 			groups = { "smoke", "L1" })

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/gui/features/ZimbraFeatureCalendarEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/gui/features/ZimbraFeatureCalendarEnabled.java
@@ -60,7 +60,7 @@ public class ZimbraFeatureCalendarEnabled extends AjaxCommonTest {
 	 */
 	@Bugs( ids = "86552")
 	@Test( description = "Load the mail tab with just Calendar enabled",
-			groups = { "functional-skip", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 	public void ZimbraFeatureCalendarEnabled_01() throws HarnessException {
 		
 		// TODO: add basic verification that a simple appointment appears

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/conversation/AcceptMeetingUsingDifferentCalendarFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/conversation/AcceptMeetingUsingDifferentCalendarFolder.java
@@ -483,7 +483,7 @@ public class AcceptMeetingUsingDifferentCalendarFolder extends AjaxCommonTest {
 
 	@Bugs (ids = "69132,65356,80407")
 	@Test (description = "Accept meeting using 'Accept -> Don't Notify Organizer'",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void AcceptMeeting_05() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/message/AcceptMeetingUsingDifferentCalendarFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/invitations/message/AcceptMeetingUsingDifferentCalendarFolder.java
@@ -492,7 +492,7 @@ public class AcceptMeetingUsingDifferentCalendarFolder extends AjaxCommonTest {
 
 	@Bugs (ids = "69132,65356,80407,96556")
 	@Test (description = "Accept meeting using 'Accept -> Don't Notify Organizer'",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void AcceptMeeting_05() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/DailyEveryXdaysEndAfterYoccurrences.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/DailyEveryXdaysEndAfterYoccurrences.java
@@ -128,9 +128,6 @@ public class DailyEveryXdaysEndAfterYoccurrences extends AjaxCommonTest {
 
 		// UI verification
 		ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), true, "Verify meeting invite is present in current calendar view");
-
-		// Switch to week view and verify correct number of recurring instances
-		app.zPageCalendar.zToolbarPressButton(Button.B_WEEK_VIEW);
 		
 		// Count no. of instances
 		int getNoOfInstances = 0;

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/DailyEveryXdaysEndByY.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/DailyEveryXdaysEndByY.java
@@ -130,9 +130,6 @@ public class DailyEveryXdaysEndByY extends AjaxCommonTest {
 		// UI verification
 		ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), true, "Verify meeting invite is present in current calendar view");
 
-		// Switch to week view and verify correct number of recurring instances
-		app.zPageCalendar.zToolbarPressButton(Button.B_WEEK_VIEW);
-				
 		int getNoOfInstances = 0;
 		for (int i = 1; i <= 3; i++) {
 			app.zPageCalendar.zToolbarPressButton(Button.B_NEXT_PAGE);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/DailyRecurringNoEndDate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/DailyRecurringNoEndDate.java
@@ -123,9 +123,6 @@ public class DailyRecurringNoEndDate extends AjaxCommonTest {
 
 		// UI verification
 		ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), true, "Verify meeting invite is present in current calendar view");
-		
-		// Switch to week view and verify correct number of recurring instances
-		app.zPageCalendar.zToolbarPressButton(Button.B_WEEK_VIEW);
 
 		int getNoOfInstances = 0;
 		for (int i = 1; i <= 3; i++) {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/WeeklyEveryXdayEndAfterYoccurrences.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/WeeklyEveryXdayEndAfterYoccurrences.java
@@ -130,9 +130,6 @@ public class WeeklyEveryXdayEndAfterYoccurrences extends AjaxCommonTest {
 		MailItem invite = MailItem.importFromSOAP(ZimbraAccount.AccountA(), "subject:("+ appt.getSubject() +")");
 		ZAssert.assertNotNull(invite, "Verify the invite is received");
 		ZAssert.assertEquals(invite.dSubject, appt.getSubject(), "Subject: Verify the appointment data");
-		
-		// Switch to week view and verify correct number of recurring instances
-		app.zPageCalendar.zToolbarPressButton(Button.B_WEEK_VIEW);
 
 		// Go to next week and verify correct number of recurring instances
 		int getNoOfInstances = 0;

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/WeeklyEveryXdayEndByY.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/WeeklyEveryXdayEndByY.java
@@ -131,9 +131,6 @@ public class WeeklyEveryXdayEndByY extends AjaxCommonTest {
 		MailItem invite = MailItem.importFromSOAP(ZimbraAccount.AccountA(), "subject:("+ appt.getSubject() +")");
 		ZAssert.assertNotNull(invite, "Verify the invite is received");
 		ZAssert.assertEquals(invite.dSubject, appt.getSubject(), "Subject: Verify the appointment data");
-		
-		// Switch to week view and verify correct number of recurring instances
-		app.zPageCalendar.zToolbarPressButton(Button.B_WEEK_VIEW);
 
 		// Go to next week and verify correct number of recurring instances
 		int getNoOfInstances = 0;

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/WeeklyRecurringNoEndDate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/create/WeeklyRecurringNoEndDate.java
@@ -124,9 +124,6 @@ public class WeeklyRecurringNoEndDate extends AjaxCommonTest {
 		// UI verification
 		ZAssert.assertEquals(app.zPageCalendar.zIsAppointmentExists(apptSubject), true, "Verify meeting invite is present in current calendar view");
 
-		// Switch to week view and verify correct number of recurring instances
-		app.zPageCalendar.zToolbarPressButton(Button.B_WEEK_VIEW);
-				
 		// Go to next week and verify correct number of recurring instances
 		int getNoOfInstances = 0;
 		for (int i = 1; i <= 3; i++) {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/delete/DeleteSeries.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/delete/DeleteSeries.java
@@ -37,7 +37,7 @@ public class DeleteSeries extends AjaxCommonTest {
 	}
 
 
-	// remove this test case and move below testcase to L2 from L5 once bug #75559 is resolved
+	@Bugs(ids = "69920,75559")
 	@Test( description = "Delete series from third instance and onwards",
 			groups = { "functional", "L2" })
 	public void DeleteSeries_01() throws HarnessException {
@@ -106,7 +106,7 @@ public class DeleteSeries extends AjaxCommonTest {
 
 	@Bugs(ids = "69920,75559")
 	@Test( description = "Delete series from third instance and onwards",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void DeleteSeries_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/modify/ModifySeries.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/modify/ModifySeries.java
@@ -462,7 +462,7 @@ public class ModifySeries extends AjaxCommonTest {
 
 	@Bugs(ids = "101610")
 	@Test( description = "Modifying daily custom series doesn't update new selection in custom repeat dialog ",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void ModifySeries_05() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/actions/Open.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/actions/Open.java
@@ -38,7 +38,7 @@ public class Open extends AjaxCommonTest {
 
 	@Bugs(ids = "103056")
 	@Test( description = "Rt-click to invite and open it",
-			groups = { "smoke", "L5" })
+			groups = { "smoke", "application-bug" })
 
 	public void OpenMeeting_01() throws HarnessException, ParseException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWhenMailFeatureDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWhenMailFeatureDisabled.java
@@ -41,7 +41,7 @@ public class CreateMeetingWhenMailFeatureDisabled extends AjaxCommonTest {
 
 
 	@Test( description = "Verify if organizer can Schedule meeting from account with Calendar enabled and Mail disabled",
-			groups = { "functional-skip", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 
 	public void CreateMeetingWhenMailFeatureDisabled_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGALFeatureDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGALFeatureDisabled.java
@@ -65,7 +65,7 @@ public class CreateMeetingWithGALFeatureDisabled extends AjaxCommonTest {
 		// Fill out the form with the data
 		apptForm.zFill(appt);
 
-		// Send the message
+		// Send invite
 		apptForm.zSubmit();
 
 		// Verify the new appointment exists on the server
@@ -109,7 +109,7 @@ public class CreateMeetingWithGALFeatureDisabled extends AjaxCommonTest {
 		// Fill out the form with the data
 		apptForm.zFill(appt);
 
-		// Send the message
+		// Send invite
 		apptForm.zSubmit();
 
 		// Verify the new appointment exists on the server

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithMultilineBody.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithMultilineBody.java
@@ -39,7 +39,7 @@ public class CreateMeetingWithMultilineBody extends AjaxCommonTest {
 
 	public void CreateMeetingWithMultilineHtmlBody_01() throws HarnessException {
 
-		// Create the message data to be sent
+		// Appointment data
 		final String attendees = ZimbraAccount.AccountC().EmailAddress;
 		final String dSubject = "subject" + ConfigProperties.getUniqueString();
 		final String dBodyHtmlBold = "<strong>BoldString</strong>";
@@ -80,7 +80,7 @@ public class CreateMeetingWithMultilineBody extends AjaxCommonTest {
 		apptForm.sClick(Locators.zTextBackgroundColorTransparent);
 		apptForm.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ENTER);
 
-		// Send the message
+		// Send invite
 		apptForm.zSubmit();
 
 		ZimbraAccount.AccountC().soapSend(
@@ -115,7 +115,7 @@ public class CreateMeetingWithMultilineBody extends AjaxCommonTest {
 
 	public void CreateMeetingWithMultilinePlainTextBody_02() throws HarnessException {
 
-		// Create the message data to be sent
+		// Appointment data
 		final String attendees = ZimbraAccount.AccountC().EmailAddress;
 		final String dSubject = "subject" + ConfigProperties.getUniqueString();
 		final String dPlainTextBody = "Plain text line 1" + '\n' + "Plain text line two" + '\n' + "Plain text line 3";
@@ -140,7 +140,7 @@ public class CreateMeetingWithMultilineBody extends AjaxCommonTest {
 		apptForm.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ENTER);
 		apptForm.zKeyboard.zTypeCharacters("Plain text line 3");
 
-		// Send the message
+		// Send invite
 		apptForm.zSubmit();
 
 		ZimbraAccount.AccountC().soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/persona/CreateAppointmentFromExternalIMAP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/persona/CreateAppointmentFromExternalIMAP.java
@@ -37,7 +37,7 @@ public class CreateAppointmentFromExternalIMAP extends AjaxCommonTest {
 
 	@Bugs(ids = "50096,104525")
 	@Test( description = "Appt. invite received from primary account though external account selected while creating appointment",
-			groups = { "smoke", "L5" })
+			groups = { "smoke", "application-bug" })
 
 	public void CreateAppointmentFromExternalIMAP_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/resetmeetingstatus/ResetStatusAfterModifyingCalendar.java
@@ -36,7 +36,7 @@ public class ResetStatusAfterModifyingCalendar extends AjaxCommonTest {
 
 	@Bugs(ids = "98476,49881")
 	@Test( description = "Check reset status of meeting after modifying calendar",
-			groups = { "functional", "L5"})
+			groups = { "functional", "application-bug"})
 
 	public void ResetStatusAfterModifyingCalendar_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/scheduler/AddOptionalAttendee.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/scheduler/AddOptionalAttendee.java
@@ -44,7 +44,7 @@ public class AddOptionalAttendee extends AjaxCommonTest {
 	}
 
 	@Test( description = "Add optional attendee from scheduler pane using keyboard Enter and Tab key",
-			groups = { "functional", "L5"},
+			groups = { "functional", "application-bug"},
 			dataProvider = "DataProviderShortcutKeys")
 
 	public void AddOptionalAttendee_01(String name, int keyEvent) throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWithDisplayMailPreference.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWithDisplayMailPreference.java
@@ -74,28 +74,28 @@ public class ViewInviteWithDisplayMailPreference extends AjaxCommonTest {
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
 		String tz = ZTimeZone.getLocalTimeZone().getID();
 
-		// Send the message from AccountB to the current login user
-				ZimbraAccount.AccountB().soapSend(
-		                "<CreateAppointmentRequest xmlns='urn:zimbraMail'>" +
-		                     "<m>"+
-		                     	"<inv><comp method='REQUEST' type='event' status='CONF' draft='0' class='PUB' fb='B' loc='' transp='O' allDay='0' name='"+ subject +"'>"+
-		                     	"<or a='"+ ZimbraAccount.AccountB().EmailAddress +"'/>" +
-		                     	"<at a='"+ app.zGetActiveAccount().EmailAddress + "' role='REQ'  ptst='NE'  rsvp='1'/>"+
-		                     	"<s d='"+ startUTC.toTimeZone(tz).toYYYYMMDDTHHMMSS() + "' tz='"+ tz +"'/>" +
-		                     	"<e d='"+ endUTC.toTimeZone(tz).toYYYYMMDDTHHMMSS() +"' tz='"+ tz +"'/>" +
-		                     "</comp></inv>" +
-		                     "<e a='"+ app.zGetActiveAccount().EmailAddress +"' t='t'/>" +
-		                     "<mp ct='multipart/alternative'>" +
-		                     	"<mp ct='text/plain'>" +
-		                     	"<content>"+ plainTextContentForSOAP +"</content>" +
-		                     	"</mp>" +
-		                     	"<mp ct='text/html'>" +
-		                     	"<content>"+ htmlContentForSOAP +"</content>" +
-		                     	"</mp>" +
-		                     "</mp>" +
-		                     "<su>"+ subject +"</su>" +
-		                     "</m>" +
-		               "</CreateAppointmentRequest>");
+		// Create invite from AccountB to the current login user
+		ZimbraAccount.AccountB().soapSend(
+				"<CreateAppointmentRequest xmlns='urn:zimbraMail'>" +
+					 "<m>"+
+						"<inv><comp method='REQUEST' type='event' status='CONF' draft='0' class='PUB' fb='B' loc='' transp='O' allDay='0' name='"+ subject +"'>"+
+						"<or a='"+ ZimbraAccount.AccountB().EmailAddress +"'/>" +
+						"<at a='"+ app.zGetActiveAccount().EmailAddress + "' role='REQ'  ptst='NE'  rsvp='1'/>"+
+						"<s d='"+ startUTC.toTimeZone(tz).toYYYYMMDDTHHMMSS() + "' tz='"+ tz +"'/>" +
+						"<e d='"+ endUTC.toTimeZone(tz).toYYYYMMDDTHHMMSS() +"' tz='"+ tz +"'/>" +
+					 "</comp></inv>" +
+					 "<e a='"+ app.zGetActiveAccount().EmailAddress +"' t='t'/>" +
+					 "<mp ct='multipart/alternative'>" +
+						"<mp ct='text/plain'>" +
+						"<content>"+ plainTextContentForSOAP +"</content>" +
+						"</mp>" +
+						"<mp ct='text/html'>" +
+						"<content>"+ htmlContentForSOAP +"</content>" +
+						"</mp>" +
+					 "</mp>" +
+					 "<su>"+ subject +"</su>" +
+					 "</m>" +
+			   "</CreateAppointmentRequest>");
 
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify appointment displayed in current view");
 
@@ -214,7 +214,7 @@ public class ViewInviteWithDisplayMailPreference extends AjaxCommonTest {
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
 		String tz = ZTimeZone.getLocalTimeZone().getID();
 
-		// Send the message from AccountB to the current login user
+		// Create invite from AccountB to the current login user
 		ZimbraAccount.AccountB().soapSend(
                 "<CreateAppointmentRequest xmlns='urn:zimbraMail'>" +
                      "<m>"+

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/admin/VerifyDisabledUI.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/admin/VerifyDisabledUI.java
@@ -34,7 +34,7 @@ public class VerifyDisabledUI extends AjaxCommonTest {
 
 	@Bugs(ids = "82558")
 	@Test( description = "Verify 'Share Calendar' menu & 'Reply' menu remains enabled on mountpoint appointment (admin share)",
-			groups = { "functional","L5" })
+			groups = { "functional","application-bug" })
 
 	public void VerifyDisabledUI_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/DeleteAppointment.java
@@ -132,7 +132,7 @@ public class DeleteAppointment extends AjaxCommonTest {
 	}
 
 	@Test( description = "Verify Delete keyboard shortcut is functional on mountpoint appointment (manager share)",
-			groups = { "functional", "L5" },
+			groups = { "functional", "application-bug" },
 			dataProvider = "DataProviderShortcutKeys")
 
 	public void DeleteAppointment_02(String name, int keyEvent) throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/VerifyDisabledUI.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/VerifyDisabledUI.java
@@ -34,7 +34,7 @@ public class VerifyDisabledUI extends AjaxCommonTest {
 
 	@Bugs(ids = "82558")
 	@Test( description = "Verify Share Calendar option remains disabled & Reply option is enabled on mountpoint appointment (manager share)",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void VerifyDisabledUI_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/readonlyappt/CreateACopy.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/readonlyappt/CreateACopy.java
@@ -37,7 +37,7 @@ public class CreateACopy extends AjaxCommonTest {
 
 	@Bugs(ids = "80322")
 	@Test( description = "Assistant right clicks to calendar invite from shared calendar and creates a copy of it",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void CreateACopy_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/readonlyappt/EditReplyAccept.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/readonlyappt/EditReplyAccept.java
@@ -36,7 +36,7 @@ public class EditReplyAccept extends AjaxCommonTest {
 
 	@Bugs(ids = "80559")
 	@Test( description = "Assistant right clicks to calendar invite from shared calendar and accepts the invite OBO boss using Edit Reply -> Accept",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void EditReplyAccept_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/readonlyappt/EditReplyDecline.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/readonlyappt/EditReplyDecline.java
@@ -36,7 +36,7 @@ public class EditReplyDecline extends AjaxCommonTest {
 
 	@Bugs(ids = "80559")
 	@Test( description = "Assistant right clicks to calendar invite from shared calendar and declines the invite OBO boss (Notify organizer)",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void EditReplyDecline_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/readonlyappt/ProposeNewTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/manager/actions/readonlyappt/ProposeNewTime.java
@@ -35,7 +35,7 @@ public class ProposeNewTime extends AjaxCommonTest {
 
 	@Bugs(ids = "80559")
 	@Test( description = "Assistant right clicks to calendar invite from shared calendar and proposes new time OBO boss",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void ProposeNewTime_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/CreateShare.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/CreateShare.java
@@ -32,6 +32,7 @@ public class CreateShare extends AjaxCommonTest {
 		super.startingPage = app.zPageCalendar;
 	}
 
+
 	@Test(description = "Share calendar folder with viewer rights", 
 			groups = { "smoke", "L1" })
 
@@ -78,8 +79,10 @@ public class CreateShare extends AjaxCommonTest {
 
 	}
 
+
 	@Test(description = "Share folder with viewer rights and Do not send mail about the share", groups = {
 			"functional", "L2" })
+
 	public void CreateShare_02() throws HarnessException {
 
 		String calendarname = "calendar" + ConfigProperties.getUniqueString();
@@ -108,7 +111,10 @@ public class CreateShare extends AjaxCommonTest {
 		ZAssert.assertNull(received, "Verify no mail is received");
 	}
 
-	@Test(description = "Share folder with viewer rights and add a multiline note to it", groups = { "functional", "L2" })
+
+	@Test(description = "Share folder with viewer rights and add a multiline note to it", 
+			groups = { "functional", "L2" })
+
 	public void CreateShare_03() throws HarnessException {
 
 		app.zPageMain.sRefresh();
@@ -151,5 +157,4 @@ public class CreateShare extends AjaxCommonTest {
 		ZAssert.assertStringContains(received.dBodyText, firstLine + "\n" + secondLine + "\n" + thirdLine,
 				"Verify the body field is correct");
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/actions/LaunchInSeparateWindow.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/actions/LaunchInSeparateWindow.java
@@ -44,7 +44,7 @@ public class LaunchInSeparateWindow extends AjaxCommonTest {
 	}
 
 
-	// remove this test case and move below testcase to L2 from L5 once bug #106999 is resolved
+	@Bugs(ids = "106999")
 	@Test( description = "Grantee with view rights launches grantor's calendar with appt in the new window and clicks on the appt",
 			groups = { "functional", "L2" })
 
@@ -142,7 +142,7 @@ public class LaunchInSeparateWindow extends AjaxCommonTest {
 
 	@Bugs(ids = "106999")
 	@Test( description = "Grantee with view rights launches grantor's calendar in the new window",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void LaunchInSeparateWindow_02() throws HarnessException {
 
@@ -202,7 +202,7 @@ public class LaunchInSeparateWindow extends AjaxCommonTest {
 
 	@Bugs(ids = "106999")
 	@Test( description = "Grantee with view rights launches grantor's calendar with appt in the new window and clicks on the appt",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void LaunchInSeparateWindow_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/actions/Reply.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/actions/Reply.java
@@ -36,7 +36,7 @@ public class Reply extends AjaxCommonTest {
 
 	@Bugs(ids = "82558")
 	@Test( description = "Grantee replies to appointment from grantor's calendar",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void Reply_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/actions/VerifyDisabledUI.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/actions/VerifyDisabledUI.java
@@ -116,7 +116,7 @@ public class VerifyDisabledUI extends AjaxCommonTest {
 
 	@Bugs(ids = "99947")
 	@Test( description = "Verify Share Calendar, Reinvite Attendees, Forward, Delete, Move & Tag Appointment right click menus are non-functional on mountpoint appointment (read-only share)",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void VerifyDisabledUI_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/viewappt/VerifyDisabledUI.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/viewappt/VerifyDisabledUI.java
@@ -114,7 +114,7 @@ public class VerifyDisabledUI extends AjaxCommonTest {
 
 	@Bugs(ids = "99947")
 	@Test( description = "Verify  disabled Create a copy, Move, Forward & Show Original menus for private appointment on mountpoint appointment (read-only share)",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void VerifyDisabledUI_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarAppFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarAppFolders.java
@@ -38,7 +38,7 @@ public class ZmCalendarAppFolders extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the calendar app, 1 calendar",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarAppFolders_01() throws HarnessException {
 
 		// Create a folder
@@ -69,7 +69,7 @@ public class ZmCalendarAppFolders extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the calendar app, 100 calendars",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarAppFolders_02() throws HarnessException {
 
 		// Create 100 folders

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewDay_Appointment1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewDay_Appointment1.java
@@ -47,7 +47,7 @@ public class ZmCalendarApp_ViewDay_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, day view, initial load",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_01() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -79,7 +79,7 @@ public class ZmCalendarApp_ViewDay_Appointment1 extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the Calendar, day view, 1 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_02() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -110,7 +110,7 @@ public class ZmCalendarApp_ViewDay_Appointment1 extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the Calendar, day view, 100 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_03() throws HarnessException {
 
 		// What is today?

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewList_Appointment1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewList_Appointment1.java
@@ -47,7 +47,7 @@ public class ZmCalendarApp_ViewList_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, list view, initial view",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_01() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -80,7 +80,7 @@ public class ZmCalendarApp_ViewList_Appointment1 extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the Calendar, list view, 1 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_02() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -113,7 +113,7 @@ public class ZmCalendarApp_ViewList_Appointment1 extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the Calendar, list view, 100 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_03() throws HarnessException {
 
 		// What is today?

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewMonth_Appointment1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewMonth_Appointment1.java
@@ -47,7 +47,7 @@ public class ZmCalendarApp_ViewMonth_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, month view, initial load",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_01() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -81,7 +81,7 @@ public class ZmCalendarApp_ViewMonth_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, month view, 1 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_02() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -114,7 +114,7 @@ public class ZmCalendarApp_ViewMonth_Appointment1 extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the Calendar, month view, 100 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_03() throws HarnessException {
 
 		// What is today?

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewSchedule_Appointment1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewSchedule_Appointment1.java
@@ -47,7 +47,7 @@ public class ZmCalendarApp_ViewSchedule_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, schedule view, initial load",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_01() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -81,7 +81,7 @@ public class ZmCalendarApp_ViewSchedule_Appointment1 extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the Calendar, schedule view, 1 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_02() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -115,7 +115,7 @@ public class ZmCalendarApp_ViewSchedule_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, schedule view, 100 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_03() throws HarnessException {
 
 		// What is today?

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewWeek_Appointment1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewWeek_Appointment1.java
@@ -47,7 +47,7 @@ public class ZmCalendarApp_ViewWeek_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, week view, initial load",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_01() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -80,7 +80,7 @@ public class ZmCalendarApp_ViewWeek_Appointment1 extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the Calendar, week view, 1 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_02() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
 
@@ -113,7 +113,7 @@ public class ZmCalendarApp_ViewWeek_Appointment1 extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the Calendar, week view, 100 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmCalendarApp_03() throws HarnessException {
 
 		// What is today?

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewWorkWeek_Appointment1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/performance/ZmCalendarApp_ViewWorkWeek_Appointment1.java
@@ -34,7 +34,7 @@ public class ZmCalendarApp_ViewWorkWeek_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, work week view, initial load",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 
 	public void ZmCalendarApp_01() throws HarnessException {
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), Calendar.getInstance().get(Calendar.HOUR_OF_DAY), 0, 0);
@@ -66,7 +66,7 @@ public class ZmCalendarApp_ViewWorkWeek_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, work week view, 1 appointment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 
 	public void ZmCalendarApp_02() throws HarnessException {
 
@@ -99,7 +99,7 @@ public class ZmCalendarApp_ViewWorkWeek_Appointment1 extends AjaxCommonTest {
 
 
 	@Test( description = "Measure the time to load the Calendar, work week view, 100 appointments",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 
 	public void ZmCalendarApp_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/reminders/mail/GetReminder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/reminders/mail/GetReminder.java
@@ -35,12 +35,11 @@ public class GetReminder extends AjaxCommonTest {
 
 	@Bugs(ids = "69132")
 	@Test( description = "Verify reminder popup when in the mail app",
-			groups = { "smoke-skip", "L4" })
+			groups = { "smoke-skip", "L3-skip" })
 
 	public void GetReminder_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 
 		// Absolute dates in UTC zone

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/ChangeLocationOfOneInstance.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/ChangeLocationOfOneInstance.java
@@ -36,7 +36,8 @@ public class ChangeLocationOfOneInstance extends AjaxCommonTest {
 
 
 	@Bugs(ids = "52682")
-	@Test( description = "Can't change location of one instance", groups = { "functional", "L2" } )
+	@Test( description = "Can't change location of one instance", 
+			groups = { "functional", "L2" } )
 
 	public void ChangeLocationOfOneInstance_01() throws HarnessException {
 
@@ -107,4 +108,3 @@ public class ChangeLocationOfOneInstance extends AjaxCommonTest {
 	}
 
 }
-

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/CreateMeetingWithEquipmentConflict.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/CreateMeetingWithEquipmentConflict.java
@@ -37,7 +37,7 @@ public class CreateMeetingWithEquipmentConflict extends AjaxCommonTest {
 
 	@Bugs(ids = "102271")
 	@Test( description = "Verify sending appt invite when Equipment resource has conflicts shows conflict dialog",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void CreateMeetingWithEquipmentConflict_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/CreateMeetingWithLocationConflict.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/CreateMeetingWithLocationConflict.java
@@ -37,7 +37,7 @@ public class CreateMeetingWithLocationConflict extends AjaxCommonTest {
 
 	@Bugs(ids = "102271")
 	@Test( description = "Verify sending appt invite when Location resource has conflicts shows conflict dialog",
-			groups = { "functional", "L5"})
+			groups = { "functional", "application-bug"})
 
 	public void CreateMeetingWithLocationConflict_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/ResourceConflictWhenOOO.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/resources/ResourceConflictWhenOOO.java
@@ -37,7 +37,7 @@ public class ResourceConflictWhenOOO extends AjaxCommonTest {
 
 	@Bugs(ids = "102271")
 	@Test( description = "Verify if OOO status of Location causes double booking",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void LocationConflictWhenOOO_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/DeleteAppointment.java
@@ -43,8 +43,7 @@ public class DeleteAppointment extends AjaxCommonTest {
 
 	public void DeleteAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/GetAppointment.java
@@ -42,7 +42,7 @@ public class GetAppointment extends AjaxCommonTest {
 
 	public void GetAppointment_01() throws HarnessException {
 
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/OpenAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/trash/OpenAppointment.java
@@ -41,8 +41,7 @@ public class OpenAppointment extends AjaxCommonTest {
 
 	public void OpenAppointment_01() throws HarnessException {
 
-		// Create the appointment on the server
-		// Create the message data to be sent
+		// Appointment data
 		String apptSubject = ConfigProperties.getUniqueString();
 		String location = "location" + ConfigProperties.getUniqueString();
 		String content = "content" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/assistant/CreateContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/assistant/CreateContact.java
@@ -33,7 +33,7 @@ public class CreateContact extends AjaxCommonTest {
 	
 	
 	@Test( description = "Create a new conntact using the Zimbra Assistant",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	
 	public void CreateContact_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/assistant/OpenAssistant.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/assistant/OpenAssistant.java
@@ -31,7 +31,7 @@ public class OpenAssistant extends AjaxCommonTest {
 	
 	
 	@Test( description = "Open the assistant",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	
 	public void OpenAssistant_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/ContactContextMenu.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/ContactContextMenu.java
@@ -131,7 +131,7 @@ public class ContactContextMenu extends AjaxCommonTest {
 	}
 
 	@Test(description = "Right click then click Advanced Search", 
-			groups = { "deprecated", "L4"})
+			groups = { "deprecated"})
 	public void AdvancedSearch_03() throws HarnessException {
 
 		ContactItem contactItem = createSelectARandomContactItem();
@@ -148,7 +148,7 @@ public class ContactContextMenu extends AjaxCommonTest {
 	}
 
 	@Test(description = "Right click then click Print", 
-			groups = { "smoke-skip", "L4" })
+			groups = { "smoke-skip", "L3-skip" })
 	public void Print_04() throws HarnessException {
 		ContactItem contactItem = createSelectARandomContactItem();
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/ForwardContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/ForwardContact.java
@@ -34,7 +34,7 @@ public class ForwardContact extends AjaxCommonTest  {
 	
 	@Bugs(ids = "77708")
 	@Test( description = "Forward a contact by click Forward on the toolbar",
-			groups = { "deprecated", "L4"})
+			groups = { "deprecated"})
 	
 	public void InDisplayViewClickForwardOnToolbar_01() throws HarnessException {
 		
@@ -92,7 +92,7 @@ public class ForwardContact extends AjaxCommonTest  {
    	}
 
 	@Test( description = "Forward an editing contact by click Forward on the toolbar",
-			groups = { "deprecated", "L4"})
+			groups = { "deprecated"})
 	
 	public void InEditViewClickForwardOnToolbar_02() throws HarnessException {
 				

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/DeleteFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/DeleteFolder.java
@@ -133,7 +133,8 @@ public class DeleteFolder extends AjaxCommonTest {
 
 	@Bugs(ids = "103601")
 	@Test(description = "Delete an addressbook folder- Use shortcut Del", 
-	groups = { "functional", "L5"})
+			groups = { "functional", "application-bug"})
+
 	public void UseShortcutDel_04() throws HarnessException {
 
 		// -- Data

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/performance/ZmContactsAppFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/performance/ZmContactsAppFolders.java
@@ -33,7 +33,7 @@ public class ZmContactsAppFolders extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the contacts app, 1 addressbook",
-			groups = { "performance", "L4"})
+			groups = { "performance", "deprecated"})
 	public void ZmContactsAppFolders_01() throws HarnessException {
 
 		// Create a folder
@@ -63,7 +63,7 @@ public class ZmContactsAppFolders extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the contacts app, 100 addressbooks",
-			groups = { "performance", "L4"})
+			groups = { "performance", "deprecated"})
 	public void ZmContactsAppFolders_02() throws HarnessException {
 
 		// Create 100 folders

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/performance/ZmContactsApp_InList_BasicContact1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/performance/ZmContactsApp_InList_BasicContact1.java
@@ -51,7 +51,7 @@ public class ZmContactsApp_InList_BasicContact1 extends AjaxCommonTest {
    }
    
    @Test( description = "Measure the time to load address book page with 1 contact item",
-         groups = {"performance", "L4"}, dataProvider = "DataProvider_LoadingApp_1Contact")
+         groups = {"performance", "deprecated"}, dataProvider = "DataProvider_LoadingApp_1Contact")
    public void ZmContactsApp_01(String logMessage) throws HarnessException {
 	   ContactItem.createContactItem(app.zGetActiveAccount());
 
@@ -67,7 +67,7 @@ public class ZmContactsApp_InList_BasicContact1 extends AjaxCommonTest {
    }
 
    @Test( description = "Measure the time to load address book page with 100 contact items",
-         groups = {"performance", "L4"})
+         groups = {"performance", "deprecated"})
    public void ZmContactsApp_02() throws HarnessException {
 
       // Loading csv file that has information for 100 contacts to speed up the setup

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/performance/ZmContactsItem_BasicContact1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/performance/ZmContactsItem_BasicContact1.java
@@ -40,7 +40,7 @@ public class ZmContactsItem_BasicContact1 extends AjaxCommonTest{
    }
 
    @Test( description="Measure the time to view Basic contact item",
-         groups={"performance", "L4"})
+         groups={"performance", "deprecated"})
    public void ZmContactsItem_01() throws HarnessException {
       // Create 2 contacts via Soap because by default the first one will be selected
       // therefore measuring the performance of loading the second one

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/assistant/CreateMailText.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/assistant/CreateMailText.java
@@ -36,7 +36,7 @@ public class CreateMailText extends PrefGroupMailByMessageTest {
 	}
 	
 	@Test( description = "Send a text mail using the Zimbra Assistant",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void CreateMailText_01() throws HarnessException {
 		
 		// Create the message data to be sent

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/assistant/OpenAssistant.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/assistant/OpenAssistant.java
@@ -36,7 +36,7 @@ public class OpenAssistant extends PrefGroupMailByMessageTest {
 	}
 	
 	@Test( description = "Open the assistant",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void OpenAssistant_01() throws HarnessException {
 		
 		// Refresh current view

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToCalendar.java
@@ -324,7 +324,7 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 	
 	@Bugs(ids = "107000")
 	@Test( description = "Bug 77131 - Cannot 'add to calendar' an ics into a shared calendar",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 			
 	public void AddToCalendar_SharedCalendar_05() throws HarnessException {
 		
@@ -421,7 +421,7 @@ public class AddToCalendar extends PrefGroupMailByMessageTest {
 	
 	@Bugs(ids = "102578")
 	@Test( description = "Links in email messages to .ics files should provide method to add to calendar",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 			
 	public void AddToCalendar_icsLink_06() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/CreateMailText.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/CreateMailText.java
@@ -275,7 +275,7 @@ public class CreateMailText extends PrefGroupMailByMessageTest {
 	}
 	
 	@Test( description = "Send a mail to 100 recipients",
-			groups = { "deprecated", "L4" } ) // The harness doesn't handle the postqueue for such a large message
+			groups = { "deprecated" } ) // The harness doesn't handle the postqueue for such a large message
 
 	public void CreateMailText_07() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/autocomplete/AutoCompleteForget.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/autocomplete/AutoCompleteForget.java
@@ -55,7 +55,7 @@ public class AutoCompleteForget extends PrefGroupMailByMessageTest {
 	
 	@Bugs(ids = "102053")
 	@Test( description = "Forget an autocomplete address - invalid email",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 	
 	public void AutoCompleteForget_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ReplyMailWithInlineImageBodyHtmlToText.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ReplyMailWithInlineImageBodyHtmlToText.java
@@ -45,7 +45,7 @@ public class ReplyMailWithInlineImageBodyHtmlToText extends PrefGroupMailByMessa
 
 	@Bugs(ids = "104342,106133")
 	@Test( description = "Verify that in reply compose screen, inline attachment shows as an attachment when changing format to from HTML to Plain Text",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 
 	public void ReplyMailWithInlineImageBodyHtmlToText_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmConv.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmConv.java
@@ -48,7 +48,7 @@ public class ZmConv extends AjaxCommonTest {
 	
 	
 	@Test( description = "Measure the performance for conversation view, preview pane, text message, initial load",
-			groups = { "performance","L4" })
+			groups = { "performance","deprecated" })
 	public void ZmMailItem_01() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/conversation02";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmMailApp.java
@@ -45,7 +45,7 @@ public class ZmMailApp extends AjaxCommonTest {
 	}
 	
 	@Test( description = "Measure the time to load the mail app, conversation view, initial load",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailApp_01() throws HarnessException {
 		
 		// Fill out the login page
@@ -66,7 +66,7 @@ public class ZmMailApp extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the mail app, conversation view, 1 conversation",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailApp_02() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
@@ -90,7 +90,7 @@ public class ZmMailApp extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the mail app, conversation view, 100 conversations",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailApp_03() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/deeplink/compose/CreateMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/deeplink/compose/CreateMail.java
@@ -138,7 +138,7 @@ public class CreateMail extends PrefGroupMailByMessageTest {
 
 	@Bugs( ids = "82734")
 	@Test( description = "Create a mail with two 'to' adn two 'cc' addresses using the deep link URL",
-			groups = { "functional", "L5" })
+			groups = { "functional", "application-bug" })
 	public void CreateMail_03() throws HarnessException {
 		
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/ModifyFolderRetentionWhenSharingDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/ModifyFolderRetentionWhenSharingDisabled.java
@@ -35,7 +35,7 @@ public class ModifyFolderRetentionWhenSharingDisabled extends PrefGroupMailByMes
 	//Same test as in 'ModifyFolderRetension.java'
 	@Bugs( ids = "97126")
 	@Test( description = "Modify a basic retention (Context menu -> Edit -> Retention) (zimbraFeatureSharingEnabled=FALSE)", 
-			groups = { "functional", "L4" } )
+			groups = { "functional", "L3" } )
 	
 	public void ModifyFolderRetentionWhenSharingDisabled_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/gui/features/ZimbraFeatureMailEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/gui/features/ZimbraFeatureMailEnabled.java
@@ -47,7 +47,7 @@ public class ZimbraFeatureMailEnabled extends PrefGroupMailByMessageTest {
 	 * @throws HarnessException
 	 */
 	@Test( description = "Load the mail tab with just Mail enabled",
-			groups = { "functional-skip", "L4" })
+			groups = { "functional-skip", "L3-skip" })
 	public void ZimbraFeatureMailEnabled_01() throws HarnessException {
 		
 		// Create the message data to be sent

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/MuteMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/MuteMessage.java
@@ -30,10 +30,10 @@ public class MuteMessage extends PrefGroupMailByMessageTest {
 		logger.info("New "+ MuteMessage.class.getCanonicalName());
 	}
 	
-	//TODO: Update the LX group appropriately when the feature is implemented  
 	@Bugs(ids = "38449")
 	@Test( description = "Mute a message (conversation) using Actions -> Mute",
-			groups = { "smoke", "L5" })
+			groups = { "smoke", "application-bug" })
+
 	public void MuteMessage_01() throws HarnessException {
 		
 		String subject = "subject"+ ConfigProperties.getUniqueString();
@@ -69,18 +69,17 @@ public class MuteMessage extends PrefGroupMailByMessageTest {
 	}
 
 	
-	//TODO: Update the LX group appropriately when the feature is implemented  
 	@Bugs( ids = "38449")
 	@Test( description = "Mute message, using 'Mute' shortcut key",
-			groups = { "functional", "L5" })
+			groups = { "functional-skip", "application-bug" })
+
 	public void MuteMessage_02() throws HarnessException {
 		throw new HarnessException("See bug https://bugzilla.zimbra.com/show_bug.cgi?id=65844");
 	}
-	
-	
-	//TODO: Update the LX group appropriately when the feature is implemented   
+		
 	@Test( description = "Mute message, using 'Right Click' -> 'Mute'",
-			groups = { "smoke", "L5" })
+			groups = { "smoke", "application-bug" })
+
 	public void MuteMessage_03() throws HarnessException {
 		
 		String subject = "subject"+ ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/RedirectMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/RedirectMessage.java
@@ -75,7 +75,7 @@ public class RedirectMessage extends PrefGroupMailByMessageTest {
 	//TODO: Remove x from groups to enable when feature is implemented  
 	@Bugs( ids = "62170")
 	@Test( description = "Redirect message, using 'Redirect' shortcut key",
-			groups = { "functional", "L5" })
+			groups = { "functional-skip", "application-bug" })
 	public void RedirectMessage_02() throws HarnessException {
 		throw new HarnessException("See bug https://bugzilla.zimbra.com/show_bug.cgi?id=62170");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/viewer/TagMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/viewer/TagMessage.java
@@ -133,7 +133,7 @@ public class TagMessage extends PrefGroupMailByMessageTest {
 
 	
 	@Test( description = "Verify Permission Denied on Tag (keyboard='t') a shared mail (read-only share)",
-			groups = { "deprecated", "L4" }) // See bug: http://bugzilla.zimbra.com/show_bug.cgi?id=79887
+			groups = { "deprecated" }) // See bug: http://bugzilla.zimbra.com/show_bug.cgi?id=79887
 	public void TagMessage_02() throws HarnessException {
 		
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/compose/CreateMailText.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/compose/CreateMailText.java
@@ -196,7 +196,7 @@ public class CreateMailText extends PrefGroupMailByMessageTest {
 
 	}
 
-	@Test(description = "Send a mail with BCC", groups = { "deprecated", "L4" })
+	@Test(description = "Send a mail with BCC", groups = { "deprecated" })
 	public void CreateMailText_04() throws HarnessException {
 
 		// Create the message data to be sent

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/mail/TagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/mail/TagMail.java
@@ -36,7 +36,7 @@ public class TagMail extends PrefGroupMailByMessageTest {
 
 	@Bugs(ids = "99519")
 	@Test( description = "Tag a message using Toolbar -> Tag -> Existing Tag - in a separate window", 
-			groups = { "functional", "L5" })
+			groups = { "functional", "L3" })
 	public void TagMail_01() throws HarnessException {
 
 		// Create the tag to delete

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/mail/UnTagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/mail/UnTagMail.java
@@ -41,7 +41,7 @@ public class UnTagMail extends PrefGroupMailByMessageTest {
 	}
 
 	@Bugs(ids = "99519")
-	@Test( description = "Un-Tag a message using Toolbar -> Tag -> Remove Tag - in a separate window", groups = { "functional", "L5" })
+	@Test( description = "Un-Tag a message using Toolbar -> Tag -> Remove Tag - in a separate window", groups = { "functional", "L3" })
 	public void UnTagMail_01() throws HarnessException {
 
 		// Create the tag to delete

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailApp.java
@@ -45,7 +45,7 @@ public class ZmMailApp extends AjaxCommonTest {
 	}
 	
 	@Test( description = "Measure the time to load the mail app, message view, initial load",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailApp_01() throws HarnessException {
 		
 		// Fill out the login page
@@ -66,7 +66,7 @@ public class ZmMailApp extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the mail app, message view, 1 message",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailApp_02() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
@@ -90,7 +90,7 @@ public class ZmMailApp extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the mail app, message view, 100 messages",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailApp_03() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailAppFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailAppFolders.java
@@ -49,7 +49,7 @@ public class ZmMailAppFolders extends AjaxCommonTest {
 	}
 	
 	@Test( description = "Measure the time to load the mail app, message view, 1 folder",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailAppFolder_01() throws HarnessException {
 
 		// Create a folder
@@ -78,7 +78,7 @@ public class ZmMailAppFolders extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the mail app, message view, 100 folders",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailAppFolder_02() throws HarnessException {
 
 		// Create 100 folders

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailItem.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailItem.java
@@ -49,7 +49,7 @@ public class ZmMailItem extends AjaxCommonTest {
 	
 	
 	@Test( description = "Measure the performance for preview pane, text message, initial load",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailItem_01() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
@@ -73,7 +73,7 @@ public class ZmMailItem extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the performance for preview pane, text message, 1 message",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailItem_02() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
@@ -97,7 +97,7 @@ public class ZmMailItem extends AjaxCommonTest {
 	}
 	
 	@Test( description = "Measure the performance for preview pane,  message with 1 attachment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailItem_03() throws HarnessException {
 		
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email05/mime01.txt";
@@ -118,7 +118,7 @@ public class ZmMailItem extends AjaxCommonTest {
 	
 	
 	@Test( description = "Measure the performance for preview pane,  message with 3 attachment",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailItem_04() throws HarnessException {
 		
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email05/mime02.txt";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailItemHTML.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailItemHTML.java
@@ -49,7 +49,7 @@ public class ZmMailItemHTML extends AjaxCommonTest {
 	
 	
 	@Test( description = "Measure the performance for preview pane, html message, initial load",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailItem_01() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
@@ -72,7 +72,7 @@ public class ZmMailItemHTML extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the performance for preview pane, html message, 1 message",
-			groups = { "performance", "L4" })
+			groups = { "performance", "deprecated" })
 	public void ZmMailItem_02() throws HarnessException {
 		
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppComposeHtml.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppComposeHtml.java
@@ -41,7 +41,7 @@ public class ZmMailAppComposeHtml extends AjaxCommonTest {
 
 	}
 
-	@Test( description = "Measure the time to load the html compose window", groups = { "performance", "L4" })
+	@Test( description = "Measure the time to load the html compose window", groups = { "performance", "deprecated" })
 	public void ZmMailAppComposeHtml_01() throws HarnessException {
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailAppCompose,"Load the compose window in html view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppComposeText.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppComposeText.java
@@ -42,7 +42,7 @@ public class ZmMailAppComposeText extends AjaxCommonTest {
 
 	}
 
-	@Test( description = "Measure the time to load the text compose  window", groups = { "performance", "L4" })
+	@Test( description = "Measure the time to load the text compose  window", groups = { "performance", "deprecated" })
 	public void ZmMailAppComposeText_01() throws HarnessException {
 
 		PerfToken token = PerfMetrics.startTimestamp(PerfKey.ZmMailAppCompose,"Load the compose window in text view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppFwdCompose.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppFwdCompose.java
@@ -48,7 +48,7 @@ public class ZmMailAppFwdCompose extends AjaxCommonTest {
 
 	}
 
-	@Test( description = "Measure the time to load Fwd-compose  window for simple message", groups = { "performance", "L4" })
+	@Test( description = "Measure the time to load Fwd-compose  window for simple message", groups = { "performance", "deprecated" })
 	public void ZmMailAppFwdCompose_01() throws HarnessException {
 
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
@@ -73,7 +73,7 @@ public class ZmMailAppFwdCompose extends AjaxCommonTest {
 	}
 	
 	
-	@Test( description = "Measure the time to load reply-compose  window for large conversation", groups = { "performance", "L4" })
+	@Test( description = "Measure the time to load reply-compose  window for large conversation", groups = { "performance", "deprecated" })
 	public void ZmMailAppFwdCompose_02() throws HarnessException {
 
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/largeconversation_mime.txt";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppReplyCompose.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppReplyCompose.java
@@ -49,7 +49,7 @@ public class ZmMailAppReplyCompose extends AjaxCommonTest {
 
 	}
 
-	@Test( description = "Measure the time to load reply-compose  window for simple message", groups = { "performance", "L4" })
+	@Test( description = "Measure the time to load reply-compose  window for simple message", groups = { "performance", "deprecated" })
 	public void ZmMailAppReplyCompose_01() throws HarnessException {
 
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
@@ -73,7 +73,7 @@ public class ZmMailAppReplyCompose extends AjaxCommonTest {
 	}
 	
 	
-	@Test( description = "Measure the time to load reply-compose  window for large conversation", groups = { "performance", "L4" })
+	@Test( description = "Measure the time to load reply-compose  window for large conversation", groups = { "performance", "deprecated" })
 	public void ZmMailAppReplyCompose_02() throws HarnessException {
 
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/largeconversation_mime.txt";
@@ -95,7 +95,7 @@ public class ZmMailAppReplyCompose extends AjaxCommonTest {
 		PerfMetrics.waitTimestamp(token);
 	}
 
-	@Test( description = "Measure the time to load reply-compose window for invite conversation", groups = { "performance", "L4" })
+	@Test( description = "Measure the time to load reply-compose window for invite conversation", groups = { "performance", "deprecated" })
 	public void ZmMailAppReplyCompose_03() throws HarnessException {
 
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/Invite_Message.txt";
@@ -118,7 +118,7 @@ public class ZmMailAppReplyCompose extends AjaxCommonTest {
 		PerfMetrics.waitTimestamp(token);
 	}
 	
-	@Test( description = "Measure the time to load reply-compose window for invite conversation with 7mb attachment", groups = { "performance", "L4" })
+	@Test( description = "Measure the time to load reply-compose window for invite conversation with 7mb attachment", groups = { "performance", "deprecated" })
 	public void ZmMailAppReplyCompose_04() throws HarnessException {
 
 		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/inviteMessageWith7MBAttachment.txt";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/quickcommands/ApplyQuickCommandMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/quickcommands/ApplyQuickCommandMessage.java
@@ -49,7 +49,7 @@ public class ApplyQuickCommandMessage extends AjaxQuickCommandTest {
 
 	@Bugs(ids = "71389")	// Hold off on GUI implementation of Quick Commands in 8.X
 	@Test( description = "Apply a Quick Command to a message",
-			groups = { "deprectated", "L4" })
+			groups = { "functional-skip" })
 	public void ApplyQuickCommandMessage_01() throws HarnessException {
 
 		// Create the message data to be sent

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Login.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Login.java
@@ -214,7 +214,7 @@ public class Login extends AjaxCommonTest {
 
 	@Bugs( ids = "66788")
 	@Test( description = "Change the zimbraMailURL and login", priority=5, 
-			groups = { "inprogress", "L4" },
+			groups = { "functional-skip", "L3-skip" },
 			dataProvider = "DataProvider_zimbraMailURL")
 	
 	public void Login04(String zimbraMailURLtemp, String notused) throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/performance/ZmMailApp.java
@@ -38,7 +38,7 @@ public class ZmMailApp extends AjaxCommonTest {
 	}
 	
 	@Test( description = "Measure the time to load the ajax client",
-			groups = { "performance", "L4"})
+			groups = { "performance", "deprecated"})
 	public void ZmMailApp01() throws HarnessException {
 		
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/gui/features/ZimbraFeatureOptionsDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/gui/features/ZimbraFeatureOptionsDisabled.java
@@ -54,7 +54,7 @@ public class ZimbraFeatureOptionsDisabled extends AjaxCommonTest {
 	@Bugs(ids="63652")	
 	@Test(
 			description = "Load the app with Preferences tab disabled", 
-			groups = { "functional-skip", "L4" }
+			groups = { "functional-skip", "L3-skip" }
 			)
 	public void ZimbraFeatureOptionsDisabled_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/gui/features/ZimbraFeatureOptionsEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/gui/features/ZimbraFeatureOptionsEnabled.java
@@ -58,7 +58,7 @@ public class ZimbraFeatureOptionsEnabled extends AjaxCommonTest {
 	 * @throws HarnessException
 	 */
 	@Bugs(ids="62011")	
-	@Test( description = "Load the Preferences tab with just Preferences enabled", groups = { "deprecated", "L4" })
+	@Test( description = "Load the Preferences tab with just Preferences enabled", groups = { "deprecated" })
 	public void ZimbraFeatureOptionsEnabled_01() throws HarnessException {
 		
 		// Go to "General"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/composing/ZimbraPrefShowComposeDirection.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/composing/ZimbraPrefShowComposeDirection.java
@@ -39,7 +39,7 @@ public class ZimbraPrefShowComposeDirection extends AjaxCommonTest {
 	}
 	@Bugs(ids = "103002")
 	@Test(description = "Verify the presence and working of direction buttons in compose mail screen",
-			groups = { "functional", "L5" })
+			groups = { "functional", "L3" })
 
 	public void ZimbraPrefShowComposeDirection_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/toaster/EmptySignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/toaster/EmptySignature.java
@@ -60,7 +60,7 @@ public class EmptySignature extends AjaxCommonTest {
 
 	}
 
-	@Test( description = "Verify Toast Msg for Empty Signature body (asp per bug comment#10)", groups = { "deprecated", "L4" })
+	@Test( description = "Verify Toast Msg for Empty Signature body (asp per bug comment#10)", groups = { "deprecated" })
 	public void EmptySignature_02() throws HarnessException {
 
 		String sigName = "signame" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/quickcommands/CreateQuickCommand.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/quickcommands/CreateQuickCommand.java
@@ -42,7 +42,7 @@ public class CreateQuickCommand extends AjaxCommonTest {
 	@Bugs(ids = "71389")	// Hold off on GUI implementation of Quick Commands in 8.X
 	@Test(
 			description = "Create a basic Quick Command",
-			groups = { "deprecated", "L4" }
+			groups = { "deprecated" }
 			)
 	public void CreateQuickCommand_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/quickcommands/DeleteQuickCommand.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/quickcommands/DeleteQuickCommand.java
@@ -39,7 +39,7 @@ public class DeleteQuickCommand extends AjaxQuickCommandTest {
 	@Bugs(ids = "71389")	// Hold off on GUI implementation of Quick Commands in 8.X
 	@Test(
 			description = "Delete a Quick Command",
-			groups = { "deprecated", "L4" }
+			groups = { "deprecated" }
 			)
 	public void DeleteQuickCommand_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/quickcommands/EditQuickCommand.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/quickcommands/EditQuickCommand.java
@@ -41,7 +41,7 @@ public class EditQuickCommand extends AjaxQuickCommandTest {
 	@Bugs(ids = "71389")	// Hold off on GUI implementation of Quick Commands in 8.X
 	@Test(
 			description = "Edit a basic Quick Command",
-			groups = { "deprecated", "L4" }
+			groups = { "deprecated" }
 			)
 	public void EditQuickCommand_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/quickcommands/GetQuickCommand.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/quickcommands/GetQuickCommand.java
@@ -40,7 +40,7 @@ public class GetQuickCommand extends AjaxQuickCommandTest {
 	@Bugs(ids = "71389")	// Hold off on GUI implementation of Quick Commands in 8.X
 	@Test(
 			description = "Get a list of basic Quick Commands",
-			groups = { "deprecated", "L4" }
+			groups = { "deprecated" }
 	)
 	public void GetQuickCommand_01() throws HarnessException {
 
@@ -56,7 +56,7 @@ public class GetQuickCommand extends AjaxQuickCommandTest {
 	@Bugs(ids = "71389")	// Hold off on GUI implementation of Quick Commands in 8.X
 	@Test(
 			description = "Verify the Quick Command data in the list",
-			groups = { "deprecated", "L4" }
+			groups = { "deprecated" }
 	)
 	public void GetQuickCommand_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/zimlets/GetZimlets.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/zimlets/GetZimlets.java
@@ -38,7 +38,7 @@ public class GetZimlets extends AjaxCommonTest {
 
 	@Test(
 			description = "View the number of zimlets in the default list",
-			groups = { "deprecated", "L4" }
+			groups = { "deprecated" }
 			)
 	public void GetZimlets_01() throws HarnessException {
 
@@ -101,7 +101,7 @@ public class GetZimlets extends AjaxCommonTest {
 	@Bugs(ids = "50123")
 	@Test(
 			description = "Verify the LinkedIn table text",
-			groups = { "deprecated", "L4" }
+			groups = { "deprecated" }
 			)
 	public void GetZimlets_02() throws HarnessException {
 
@@ -188,7 +188,7 @@ public class GetZimlets extends AjaxCommonTest {
 	@Bugs(ids = "50123")
 	@Test(
 			description = "Verify the Zimbra Social table text",
-			groups = { "deprecated", "L4" }
+			groups = { "deprecated" }
 			)
 	public void GetZimlets_06() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/search/search/SearchContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/search/search/SearchContactGroup.java
@@ -69,7 +69,7 @@ public class SearchContactGroup extends AjaxCommonTest {
 
 	@Bugs(ids = "77950")
 	@Test(description = "Search for an existing contact group, by member",
-			groups = { "deprecated","L4" })
+			groups = { "functional-skip","L3-skip" })
 	public void SearchContactGroup_02() throws HarnessException {
 
 		// -- Data

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/assistant/CreateTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/assistant/CreateTask.java
@@ -56,7 +56,7 @@ public class CreateTask extends AjaxCommonTest {
  * @throws HarnessException
  */
 	@Test( description = "Create Task using assistant", 
-			groups = { "deprecated", "L4"})
+			groups = { "deprecated"})
 	public void CreateTask_01() throws HarnessException {
 		String subject = "subject" + ConfigProperties.getUniqueString();
 		String command = "task \"" + subject + "\" Notes(hello)";
@@ -87,7 +87,7 @@ public class CreateTask extends AjaxCommonTest {
 	 */
 		@Bugs(ids="63199")
 		@Test( description = "Create Task using assistant and save it", 
-			groups = { "deprecated", "L4"})
+			groups = { "deprecated"})
 		public void CreateTask_02() throws HarnessException {
 			String subject = "subject" + ConfigProperties.getUniqueString();
 			String command = "task \"" + subject + "\" Notes(hello)";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/assistant/OpenAssistant.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/assistant/OpenAssistant.java
@@ -46,7 +46,7 @@ public class OpenAssistant extends AjaxCommonTest {
  * @throws HarnessException
  */
 	@Test( description = "Open the assistant", 
-			groups = { "deprecated", "L4"})
+			groups = { "deprecated"})
 	public void OpenAssistant_01() throws HarnessException {
 
 		// Click Get Mail button

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/gui/features/ZimbraFeatureTaskEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/gui/features/ZimbraFeatureTaskEnabled.java
@@ -61,7 +61,7 @@ public class ZimbraFeatureTaskEnabled extends AjaxCommonTest {
 	}
 	
 	@Test( description = "Load the Task tab with just Tasks enabled",
-			groups = { "functional-skip", "L4"})
+			groups = { "functional-skip", "L3-skip"})
 	public void ZimbraFeatureTaskEnabled_01() throws HarnessException {
 		
 		FolderItem taskFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Tasks);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/performance/ZmTasksAppFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/performance/ZmTasksAppFolders.java
@@ -36,7 +36,7 @@ public class ZmTasksAppFolders extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the tasks app, 1 task list",
-			groups = { "performance", "L4"})
+			groups = { "performance", "deprecated"})
 	public void ZmTasksAppFolders_01() throws HarnessException {
 
 		// Create a folder
@@ -66,7 +66,7 @@ public class ZmTasksAppFolders extends AjaxCommonTest {
 	}
 
 	@Test( description = "Measure the time to load the tasks app, 100 task lists",
-			groups = { "performance", "L4"})
+			groups = { "performance", "deprecated"})
 	public void ZmTasksAppFolders_02() throws HarnessException {
 
 		// Create 100 folders

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/performance/ZmTasksApp_InList_Task1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/performance/ZmTasksApp_InList_Task1.java
@@ -50,7 +50,7 @@ public class ZmTasksApp_InList_Task1 extends AjaxCommonTest {
    }
 
    @Test( description = "Measure the time to load Tasks page with 1 task",
-         groups = {"performance", "L4"}, dataProvider = "DataProvider_LoadingApp_1Task")
+         groups = {"performance", "deprecated"}, dataProvider = "DataProvider_LoadingApp_1Task")
    public void ZmTasksApp_01(String logMessage) throws HarnessException {
 
       String subject = "task"+ ConfigProperties.getUniqueString();
@@ -83,7 +83,7 @@ public class ZmTasksApp_InList_Task1 extends AjaxCommonTest {
    }
 
    @Test( description="Measure the time to load Tasks page with 100 tasks",
-         groups={"performance", "L4"})
+         groups={"performance", "deprecated"})
    public void ZmTasksApp_02() throws HarnessException {
 
       // Import 100 appointments using Tasks.ics and REST to speed up the setup

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/performance/ZmTasksItem_Task1.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/performance/ZmTasksItem_Task1.java
@@ -41,7 +41,7 @@ public class ZmTasksItem_Task1 extends AjaxCommonTest{
    }
 
    @Test( description="Measure the time to view a task",
-		   groups={"performance", "L4"})
+		   groups={"performance", "deprecated"})
    public void ZmTasksItem_01() throws HarnessException {
 	   String subject1 = "task1"+ ConfigProperties.getUniqueString();
 	   String subject2 = "task2"+ ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/mail/newwindow/ArchiveMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/mail/newwindow/ArchiveMessage.java
@@ -31,10 +31,9 @@ public class ArchiveMessage extends ArchiveZimletByMessageTest {
 		logger.info("New "+ ArchiveMessage.class.getCanonicalName());
 	}
 	
-	//TODO: Update the LX group appropriately when the feature is implemented 
 	@Bugs(ids = "80238")
 	@Test( description = "Archive a message from new window",
-			groups = { "smoke", "L5" })
+			groups = { "smoke-skip", "application-bug" })
 	
 	public void ArchiveMessage_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/date/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/date/GetMessage.java
@@ -189,7 +189,7 @@ public class GetMessage extends AjaxCommonTest {
 
 	@Bugs(ids="86667")
 	@Test( description = "Receive a mail with a date in subject(as Per bug this is invalid test case",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void GetMessage_05() throws HarnessException {
 		
 		// Create the message data to be sent

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/linkedin/FolderTree.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/linkedin/FolderTree.java
@@ -41,7 +41,7 @@ public class FolderTree extends AjaxCommonTest {
 	
 	@Bugs(ids = "50123")
 	@Test( description = "Verify the LinkedIn zimlet appears in the folder tree",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void FolderTree_01() throws HarnessException {
 		ZimletItem linkedin = CoreZimletItem.getCoreZimlet(CoreZimletName.com_zimbra_linkedin, app);
 		
@@ -64,7 +64,7 @@ public class FolderTree extends AjaxCommonTest {
 	}
 
 	// All these tests require the Folder tree to be fully loaded
-	@BeforeMethod( groups = { "deprecated", "L4" } )
+	@BeforeMethod( groups = { "deprecated" } )
 	public void folderTreeBeforeMethod() throws HarnessException {
 		logger.info("folderTreeBeforeMethod: start");
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/linkedinimage/FolderTree.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/linkedinimage/FolderTree.java
@@ -40,7 +40,7 @@ public class FolderTree extends AjaxCommonTest {
 	
 	@Bugs( ids = "81078")
 	@Test( description = "Verify the LinkedIn zimlet appears in the folder tree",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void FolderTree_01() throws HarnessException {
 		
 		ZimletItem linkedin = CoreZimletItem.getCoreZimlet(CoreZimletName.com_zimbra_linkedinimage, app);
@@ -65,7 +65,7 @@ public class FolderTree extends AjaxCommonTest {
 
 
 	// All these tests require the Folder tree to be fully loaded
-	@BeforeMethod( groups = { "deprecated", "L4" } )
+	@BeforeMethod( groups = { "deprecated" } )
 	public void folderTreeBeforeMethod() throws HarnessException {
 		logger.info("folderTreeBeforeMethod: start");
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/phone/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/phone/GetMessage.java
@@ -233,7 +233,7 @@ public class GetMessage extends AjaxCommonTest {
 	}
 
 	@Test( description = "Receive a mail with a phone numbers in subject( reference bug 86667)",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void GetMessage_05() throws HarnessException {
 		
 		// Create the message data to be sent

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/social/LoadSocialTab.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/social/LoadSocialTab.java
@@ -40,7 +40,7 @@ import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
 	 */
 	@Bugs(ids = "50123")
 	@Test( description = "Basic test case: Load the Social tab",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void LoadSocialTab_01() throws HarnessException {
 		
 		ZAssert.assertTrue(app.zPageSocial.zIsActive(), "Verify the social page is active");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/social/gui/features/ZimbraZimletAvailableZimlets.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/social/gui/features/ZimbraZimletAvailableZimlets.java
@@ -59,7 +59,7 @@ import com.zimbra.qa.selenium.projects.ajax.core.AjaxCommonTest;
 	 */
 	@Bugs(ids = "50123")
 	@Test( description = "Load the client with just Social enabled",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void ZimbraZimletAvailableZimlets_01() throws HarnessException {
 		
 		ZAssert.assertTrue(app.zPageSocial.zIsActive(), "Verify the social page is active");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/GetMessage.java
@@ -197,7 +197,7 @@ public class GetMessage extends AjaxCommonTest {
 
 	@Bugs(ids="86667")
 	@Test( description = "Receive a mail with a url in subject reference bug 86667",
-			groups = { "deprecated", "L4" })
+			groups = { "deprecated" })
 	public void GetMessage_05() throws HarnessException {
 		
 		// Create the message data to be sent

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/briefcase/PageBriefcase.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/briefcase/PageBriefcase.java
@@ -270,6 +270,7 @@ public class PageBriefcase extends AbsTab {
 			throw new HarnessException("Button is not present locator=" + locator + " button=" + button);
 
 		this.zClickAt(locator, "0,0");
+		SleepUtil.sleepMedium();
 
 		// If the app is busy, wait for it to become active
 		zWaitForBusyOverlay();
@@ -289,7 +290,6 @@ public class PageBriefcase extends AbsTab {
 		if (option == null)
 			throw new HarnessException("Option cannot be null!");
 
-		
 		String pulldownLocator = null;
 		String optionLocator = null;
 		AbsPage page = null;
@@ -327,6 +327,7 @@ public class PageBriefcase extends AbsTab {
 			} else {
 				throw new HarnessException("no logic defined for pulldown/option " + pulldown + "/" + option);
 			}
+			
 		} else if (pulldown == Button.B_TAG) {
 			if (option == Button.O_TAG_NEWTAG) {
 
@@ -349,6 +350,7 @@ public class PageBriefcase extends AbsTab {
 			} else {
 				throw new HarnessException("no logic defined for pulldown/option " + pulldown + "/" + option);
 			}
+			
 		} else if (pulldown == Button.B_SEND) {
 			if (option == Button.O_SEND_AS_ATTACHMENT) {
 
@@ -369,6 +371,7 @@ public class PageBriefcase extends AbsTab {
 			} else {
 				throw new HarnessException("no logic defined for pulldown/option " + pulldown + "/" + option);
 			}
+			
 		} else if (pulldown == Button.B_ACTIONS) {
 
 			pulldownLocator = "css=td[id=zb__BDLV-main__ACTIONS_MENU_dropdown]>div[class='ImgSelectPullDownArrow']";
@@ -396,6 +399,7 @@ public class PageBriefcase extends AbsTab {
 			} else {
 				throw new HarnessException("no logic defined for pulldown/option " + pulldown + "/" + option);
 			}
+			
 		} else if (pulldown == Button.B_MOVE) {
 
 			if (option == Button.O_NEW_FOLDER) {
@@ -430,11 +434,9 @@ public class PageBriefcase extends AbsTab {
 			}
 
 			this.zClick(optionLocator);
-
-			// If the app is busy, wait for it to become active
 			zWaitForBusyOverlay();
-
-			page.zWaitForActive();
+			page.zWaitForActive();			
+			SleepUtil.sleepSmall();
 
 			return (page);
 
@@ -513,7 +515,8 @@ public class PageBriefcase extends AbsTab {
 					page.zWaitForActive();
 			}
 		}
-		// Return the specified page, or null if not set
+
+		SleepUtil.sleepSmall();
 		return (page);
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/PageCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/PageCalendar.java
@@ -407,6 +407,9 @@ public class PageCalendar extends AbsTab {
 	}
 
 	public int zGetAppointmentCountWeekView(String subject) throws HarnessException {
+		// Switch to week view and verify correct number of recurring instances
+		zToolbarPressButton(Button.B_WEEK_VIEW);
+		
 		return sGetXpathCount("//div[@class='calendar_body']//div[contains(@id, 'zli__CLW__')]//td[contains(text(), '" + subject + "')]");
 		//return sGetCssCount("css=div[class='calendar_body'] div[id^='zli__CLW'] td[class='appt_name']:contains('" + subject + "')");
 	}


### PR DESCRIPTION
ZCS-3416: Formatting of all Calendar, Briefcase tests and renamed group L4 to deprecated, L5 to application-bug.

L4 and L5 group name wasn't indicating the group purpose, renamed it to meaningful name so it can be understandable better.

	L4 renamed to deprecated
	L5 renamed to application-bug

Rest all is formatting so it doesn't require any review, entire Calendar and Briefcase app tests are formatted better and lets maintain it and will do for rest of the apps too.