### PR TITLE
ZCS-3117: Selenium: Fix remaining full suite issues along with providing possible fixes for intermittent failures

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCommonTest.java
@@ -200,7 +200,7 @@ public class AdminCommonTest {
 				for (int i = 0; i <= 10; i++) {
 					if (ClientSessionFactory.session().webDriver()
 							.findElement(By.cssSelector("css=div[id='ztih__AppAdmin__Home_textCell']")) != null) {
-						app.zPageLogin.sRefresh();
+						app.zPageLogin.zRefreshMainUI();
 						SleepUtil.sleepVeryVeryLong();
 						SleepUtil.sleepVeryVeryLong();
 						if (ClientSessionFactory.session().webDriver()

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/certificates/InstallSelfSignedCertificate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/certificates/InstallSelfSignedCertificate.java
@@ -82,7 +82,7 @@ public class InstallSelfSignedCertificate extends AdminCommonTest {
 
 			// Restart zimbra services
 			staf.execute("zmmailboxdctl restart");
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 
 			ZimbraAdminAccount.AdminConsoleAdmin().provision();
 			ZimbraAdminAccount.AdminConsoleAdmin().authenticate();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddDirectMemberOfDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddDirectMemberOfDistributionList.java
@@ -100,7 +100,7 @@ public class AddDirectMemberOfDistributionList extends AdminCommonTest {
 		
 		ZAssert.assertEquals(dlMember.getText(), dl1.getEmailAddress(), "Verify that " + dl1.getEmailAddress() + "is a member of " + dl2.getEmailAddress());
 		
-		app.zPageManageDistributionList.sRefresh();
+		app.zPageManageDistributionList.zRefreshMainUI();
 		
 		startingPage.zNavigateTo();
 		

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddIndirectMemberOfDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddIndirectMemberOfDistributionList.java
@@ -114,7 +114,7 @@ public class AddIndirectMemberOfDistributionList extends AdminCommonTest {
 		
 		
 		// Refresh to get the changes
-		app.zPageManageDistributionList.sRefresh();
+		app.zPageManageDistributionList.zRefreshMainUI();
 		
 		startingPage.zNavigateTo();
 		

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/ChangeGALConfiguration.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/ChangeGALConfiguration.java
@@ -91,7 +91,7 @@ public class ChangeGALConfiguration extends AdminCommonTest {
 		//Verification through IU
 
 		//Refresh the admin console
-		app.zPageManageDomains.sRefresh();
+		app.zPageManageDomains.zRefreshMainUI();
 		app.zPageMain.zWaitTillElementPresent(Locators.zLogoffDropDownArrow);
 		app.zPageManageDomains.zNavigateTo();
 
@@ -191,7 +191,7 @@ public class ChangeGALConfiguration extends AdminCommonTest {
 		//Verification through IU
 
 		//Refresh the admin console
-		app.zPageManageDomains.sRefresh();
+		app.zPageManageDomains.zRefreshMainUI();
 		app.zPageMain.zWaitTillElementPresent(Locators.zLogoffDropDownArrow);
 		app.zPageManageDomains.zNavigateTo();
 

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/MTA/CheckMTASettings.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/MTA/CheckMTASettings.java
@@ -108,7 +108,7 @@ public class CheckMTASettings extends AdminCommonTest {
 			app.zPageManageMTA.zToolbarPressButton(Button.B_SAVE);
 
 			//Verify through UI that the MTA configuration change made above is present  
-			app.zPageManageMTA.sRefresh();
+			app.zPageManageMTA.zRefreshMainUI();
 			app.zPageMain.zWaitForActive();
 			app.zPageManageGlobalSettings.zNavigateTo();
 			app.zPageManageMTA.zNavigateTo();		

--- a/src/java/com/zimbra/qa/selenium/projects/admin/ui/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/ui/PageMain.java
@@ -173,7 +173,7 @@ public class PageMain extends AbsTab {
 	}
 
 	public void zHandleDialogs() throws HarnessException {
-		sRefresh();
+		zRefreshMainUI();
 	}
 
 		/*// Opened dialogs

--- a/src/java/com/zimbra/qa/selenium/projects/admin/ui/PageManageDomains.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/ui/PageManageDomains.java
@@ -125,7 +125,7 @@ public class PageManageDomains extends AbsTab {
 
 		//Refresh the page if page is not the main page
 		if(!sIsElementPresent(Locators.CONFIGURE_ICON)) {
-			sRefresh();
+			zRefreshMainUI();
 		}
 		sClick(Locators.CONFIGURE_ICON);
 		zWaitForWorkInProgressDialogInVisible();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCommonTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCommonTest.java
@@ -72,7 +72,7 @@ public class AjaxCommonTest {
 	public static boolean allDayTest = false;
 
 	WebElement we = null;
-	private WebDriver webDriver = ClientSessionFactory.session().webDriver();
+	protected WebDriver webDriver = ClientSessionFactory.session().webDriver();
 	protected static Logger logger = LogManager.getLogger(AjaxCommonTest.class);
 
 	protected StafServicePROCESS staf = new StafServicePROCESS();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxQuickCommandTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxQuickCommandTest.java
@@ -230,7 +230,7 @@ public class AjaxQuickCommandTest extends AjaxCommonTest {
 
 		
 		// Re-login to pick up the new preferences
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// The AjaxCommonTest.commonTestBeforeMethod() method will log into the client
 		logger.info("addQuickCommands: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/ViewChangeViaMenu.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/ViewChangeViaMenu.java
@@ -46,7 +46,7 @@ public class ViewChangeViaMenu extends AjaxCommonTest {
         ZAssert.assertTrue(app.zPageCalendar.sIsElementPresent(Locators.CalendarViewWeekCSS), "Changed to week view");
 
         // Context menu hidden after switching views so applying work around
-        app.zPageMain.sRefresh();
+        app.zPageMain.zRefreshMainUI();
         app.zPageCalendar.zNavigateTo();
 
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_VIEW_MENU, Button.O_VIEW_MONTH_SUB_MENU, "Month");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/TagAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/TagAppointment.java
@@ -160,7 +160,7 @@ public class TagAppointment extends AjaxCommonTest {
         String apptId = appt.dApptID;
 
         // Work around
-        app.zPageMain.sRefresh();
+        app.zPageMain.zRefreshMainUI();
         app.zPageCalendar.zNavigateTo();
 
         // Create new tag using context menu and apply it to appointment

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/UnTagAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/tags/UnTagAppointment.java
@@ -104,7 +104,7 @@ public class UnTagAppointment extends AjaxCommonTest {
 		app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
 
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Remove tag from appointment using context menu

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/DeleteAppointment.java
@@ -549,7 +549,7 @@ public class DeleteAppointment extends AjaxCommonTest {
 		app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
 
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Right click the item, select delete

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/DragAndDropAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/DragAndDropAppointment.java
@@ -83,11 +83,11 @@ public class DragAndDropAppointment extends AjaxCommonTest {
 
         // Drag and drop the item
         String locator;
-        if (app.zPageCalendar.zIsWeekend()) {
-        	locator = "css=div[id^='zli__CLWW__";
-        } else {
-        	locator = "css=div[id^='zli__CLW__";
-        }
+		if (app.zPageCalendar.zIsWeekend()) {
+			locator = "css=div[id^='zli__CLW__";
+		} else {
+			locator = "css=div[id^='zli__CLWW__";
+		}
 
 		// Select the item
 		app.zPageCalendar.zDragAndDrop(
@@ -170,11 +170,11 @@ public class DragAndDropAppointment extends AjaxCommonTest {
 
         // Drag and drop the item
         String locator;
-        if (app.zPageCalendar.zIsWeekend()) {
-        	locator = "css=div[id^='zli__CLW__";
-        } else {
-        	locator = "css=div[id^='zli__CLWW__";
-        }
+		if (app.zPageCalendar.zIsWeekend()) {
+			locator = "css=div[id^='zli__CLW__";
+		} else {
+			locator = "css=div[id^='zli__CLWW__";
+		}
 
     	String sourceLocator = locator + apptId + "'] td.appt_name";
     	String destinationLocator = locator + otherApptId + "'] td.appt_name";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/attributes/ZimbraCalResLocationDisplayName.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/attributes/ZimbraCalResLocationDisplayName.java
@@ -68,7 +68,7 @@ public class ZimbraCalResLocationDisplayName extends AjaxCommonTest {
 		}
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		String tz = ZTimeZone.getLocalTimeZone().getID();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/attributes/ZimbraFeatureGroupCalendarEnabledFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/attributes/ZimbraFeatureGroupCalendarEnabledFalse.java
@@ -56,7 +56,7 @@ public class ZimbraFeatureGroupCalendarEnabledFalse extends AjaxCommonTest {
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Creating object for appointment data
@@ -127,7 +127,7 @@ public class ZimbraFeatureGroupCalendarEnabledFalse extends AjaxCommonTest {
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Compose appointment and send it to invitee

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/attributes/ZimbraFeatureHtmlComposeEnabledFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/attributes/ZimbraFeatureHtmlComposeEnabledFalse.java
@@ -51,7 +51,7 @@ public class ZimbraFeatureHtmlComposeEnabledFalse extends AjaxCommonTest {
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/ChangeCustomColorWithExcludeFB.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/ChangeCustomColorWithExcludeFB.java
@@ -118,8 +118,8 @@ public class ChangeCustomColorWithExcludeFB extends AjaxCommonTest {
 		AppointmentItem appt1 = new AppointmentItem();
 		appt1.setSubject(apptSubject1);
 		appt1.setAttendees(organizer.EmailAddress);
-		appt1.setStartTime(new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0));
-		appt1.setEndTime(new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0));
+		appt1.setStartTime(new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0));
+		appt1.setEndTime(new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0));
 		appt1.setContent(apptContent1);
 
 		// Create meeting with attendee who was organizer of the earlier appt and does have conflicing appt
@@ -217,8 +217,8 @@ public class ChangeCustomColorWithExcludeFB extends AjaxCommonTest {
 		AppointmentItem appt1 = new AppointmentItem();
 		appt1.setSubject(apptSubject1);
 		appt1.setAttendees(organizer.EmailAddress);
-		appt1.setStartTime(new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0));
-		appt1.setEndTime(new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0));
+		appt1.setStartTime(new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0));
+		appt1.setEndTime(new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0));
 		appt1.setContent(apptContent1);
 
 		// Create meeting with attendee who was organizer of the earlier appt and does have conflicing appt

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/CheckFreeBusyURLLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/CheckFreeBusyURLLink.java
@@ -95,10 +95,13 @@ public class CheckFreeBusyURLLink extends AjaxCommonTest {
         SleepUtil.sleepMedium();
 		ZAssert.assertStringContains(app.zPageCalendar.sGetLocation(), viewName,  "URL for "+ label +" view is open");
 
-		if (label != "Day") {
-			// Verify if all views show free busy status
-			String body = app.zPageCalendar.sGetBodyText();
-			ZAssert.assertStringContains( body, "Busy" , "Verify free busy view is visible and no error is thrown");
+		if (label.equals("Work Week") && app.zPageCalendar.zIsWeekend()) {
+			app.zPageCalendar.sClickAt(Locators.WeekViewOnFBLink, "");
+			SleepUtil.sleepMedium();
 		}
+
+		// Verify if all views show free busy status
+		String body = app.zPageCalendar.sGetBodyText();
+		ZAssert.assertStringContains( body, "Busy" , "Verify free busy view is visible and no error is thrown");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/VerifyNestedState.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/VerifyNestedState.java
@@ -84,7 +84,7 @@ public class VerifyNestedState extends AjaxCommonTest {
         ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
 
 	    // Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 	    SleepUtil.sleepLong();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/CreateACopy.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/CreateACopy.java
@@ -72,7 +72,7 @@ public class CreateACopy extends AjaxCommonTest {
 				+	"</CreateAppointmentRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Verify appointment exists in current view

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/modify/ModifyInstanceModifySeries.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/recurring/modify/ModifyInstanceModifySeries.java
@@ -164,7 +164,7 @@ public class ModifyInstanceModifySeries extends AjaxCommonTest {
 		String modifiedSecondInstanceBody = ConfigProperties.getUniqueString();
 		String modifiedSixthInstanceBody = ConfigProperties.getUniqueString();
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		app.zPageCalendar.zToolbarPressButton(Button.B_TODAY);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/actions/Cancel.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/actions/Cancel.java
@@ -110,7 +110,7 @@ public class Cancel extends AjaxCommonTest {
 	    	      "</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Absolute dates in UTC zone

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
@@ -107,7 +107,7 @@ public class CreateMeeting extends AjaxCommonTest {
 		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		AppointmentItem appt = new AppointmentItem();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingByChangingBodyTextFormat.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingByChangingBodyTextFormat.java
@@ -45,7 +45,7 @@ public class CreateMeetingByChangingBodyTextFormat extends AjaxCommonTest {
 		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment data
@@ -90,7 +90,7 @@ public class CreateMeetingByChangingBodyTextFormat extends AjaxCommonTest {
 		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment data
@@ -136,7 +136,7 @@ public class CreateMeetingByChangingBodyTextFormat extends AjaxCommonTest {
 		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment data

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingInSharedCalendarWithMailFeatureDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingInSharedCalendarWithMailFeatureDisabled.java
@@ -95,8 +95,7 @@ public class CreateMeetingInSharedCalendarWithMailFeatureDisabled extends AjaxCo
 			  "</ModifyAccountRequest>");
 
 			// Refresh UI
-			app.zPageMain.sRefreshPage();
-			app.zPageMain.zWaitTillElementPresent(PageMail.Locators.zCalendarZimletsPane);
+			app.zPageMain.zRefreshUITillElementPresent(PageMail.Locators.zCalendarZimletsPane);
 
 			// Compose appointment on shared mailbox
 			FormApptNew apptForm = (FormApptNew) app.zPageCalendar.zToolbarPressButton(Button.B_NEW);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGALFeatureDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGALFeatureDisabled.java
@@ -48,7 +48,7 @@ public class CreateMeetingWithGALFeatureDisabled extends AjaxCommonTest {
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment
@@ -92,7 +92,7 @@ public class CreateMeetingWithGALFeatureDisabled extends AjaxCommonTest {
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGroupCalendarFeatureDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGroupCalendarFeatureDisabled.java
@@ -53,7 +53,7 @@ public class CreateMeetingWithGroupCalendarFeatureDisabled extends AjaxCommonTes
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/persona/CreateAppointmentFromExternalIMAP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/persona/CreateAppointmentFromExternalIMAP.java
@@ -71,7 +71,7 @@ public class CreateAppointmentFromExternalIMAP extends AjaxCommonTest {
 			+	"</CreateDataSourceRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment data

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWithDisplayMailPreference.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWithDisplayMailPreference.java
@@ -126,7 +126,7 @@ public class ViewInviteWithDisplayMailPreference extends AjaxCommonTest {
 		}
 
 		// Work around for getting correct body locator
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Navigate to preference -> Mail and set display mail pref to Text and verify
 		app.zPagePreferences.zNavigateTo();
@@ -207,7 +207,7 @@ public class ViewInviteWithDisplayMailPreference extends AjaxCommonTest {
 		String multilineTextContentForSOAP = "line 1\nline two\n\n\nline 3";
 
 		// Work around for getting correct body locator
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		Calendar now = Calendar.getInstance();
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
@@ -257,7 +257,7 @@ public class ViewInviteWithDisplayMailPreference extends AjaxCommonTest {
 		}
 
 		// Work around for getting correct body locator
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		app.zGetActiveAccount().soapSend(
 				"<GetPrefsRequest xmlns='urn:zimbraAccount'>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/admin/actions/Create.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/admin/actions/Create.java
@@ -92,7 +92,7 @@ public class Create extends AjaxCommonTest {
 			+	"</CreateIdentityRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		appt.setSubject(apptSubject);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/CreateShare.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/mountpoints/viewer/CreateShare.java
@@ -117,7 +117,7 @@ public class CreateShare extends AjaxCommonTest {
 
 	public void CreateShare_03() throws HarnessException {
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create a folder

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contactgroups/CreateContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contactgroups/CreateContactGroup.java
@@ -260,7 +260,7 @@ public class CreateContactGroup extends AjaxCommonTest  {
 		String email=ZimbraAccount.AccountA().EmailAddress.substring(0,ZimbraAccount.AccountA().EmailAddress.indexOf('@'));
 		
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 
 		// search for a GAL

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/CreateFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/CreateFolder.java
@@ -89,7 +89,7 @@ public class CreateFolder extends AjaxCommonTest {
 		String folderName = "folder" + ConfigProperties.getUniqueString();
 		
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 
 		// Right click on Contacts -> New Addressbook

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/CreateTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/CreateTag.java
@@ -88,7 +88,7 @@ public class CreateTag extends PrefGroupMailByMessageTest {
 	public void CreateTag_03() throws HarnessException {
 		
 		// Work around due to duplicate dialog ids
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 		
 		// Set the new tag name

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/TagContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/TagContact.java
@@ -46,7 +46,7 @@ public class TagContact extends ContactsPrefShowSelectionCheckbox {
 	public void ClickPulldownMenuTagNewTag_01() throws HarnessException {
 
 		// Work around due to duplicate dialog ids
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 
 		// -- Data

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/TagContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/TagContactGroup.java
@@ -59,7 +59,7 @@ public class TagContactGroup extends AjaxCommonTest  {
 		app.zPageContacts.zToolbarPressButton(Button.B_REFRESH);
 		
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 		
 		// Select the contact

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/UnTagContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/UnTagContactGroup.java
@@ -257,7 +257,7 @@ public class UnTagContactGroup extends AjaxCommonTest  {
 	public void UnTagContactGroup_06() throws HarnessException {			
 		
 		// Work around due to duplicate dialog ids
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 		
 		//-- Data

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/OpenAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/OpenAttachment.java
@@ -67,11 +67,12 @@ public class OpenAttachment extends PrefGroupMailByMessageTest {
 			
 			// Left click on the attachment
 			window = (SeparateWindowOpenAttachment)display.zListAttachmentItem(Action.A_LEFTCLICK, item);
-			window.zWaitForActive();
-			ZAssert.assertTrue(window.zIsActive(), "Verify the attachment is open");
+
+			for (String winHandle : webDriver.getWindowHandles()) {
+				webDriver.switchTo().window(winHandle);
+			}
 			
 			//Verify show original window with proper content
-			SleepUtil.sleepMedium();
 			String content = window.sGetBodyText();
 			ZAssert.assertStringContains(content, attachmentcontent, "Verify the content in the attachment");
 			

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/OpenAttachmentFromEMLAttachedInMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/OpenAttachmentFromEMLAttachedInMessage.java
@@ -54,9 +54,12 @@ public class OpenAttachmentFromEMLAttachedInMessage extends PrefGroupMailByMessa
 
 			// Select eml attachment in mail			
 			window = (SeparateWindowDisplayMail)app.zPageMail.zToolbarPressButton(Button.B_EML_ATTACHEMENT);
-			SleepUtil.sleepMedium();
+			SleepUtil.sleepLongMedium();
 			window.zSetWindowTitle(subjecteml);
-			ZAssert.assertTrue(window.zIsActive(), "Verify the window is active");
+
+			for (String winHandle : webDriver.getWindowHandles()) {
+				webDriver.switchTo().window(winHandle);
+			}
 
 			//Verify that doc file attachment is present under eml file attached in a mail
 			ZAssert.assertTrue(window.sIsElementPresent("css=td a[id='zv__MSG__MSG-1_attLinks_2.1_main']:contains('fileconvE5cNFS.doc')"), "Verify .doc  present as attachment");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/ReplyFromSentFolderWithReplyToHeader.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/ReplyFromSentFolderWithReplyToHeader.java
@@ -94,7 +94,7 @@ public class ReplyFromSentFolderWithReplyToHeader extends PrefGroupMailByMessage
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -210,7 +210,7 @@ public class ReplyFromSentFolderWithReplyToHeader extends PrefGroupMailByMessage
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Click in sent
 		app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Sent));

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendAs.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendAs.java
@@ -56,7 +56,7 @@ public class SendAs extends PrefGroupMailByMessageTest {
 			+	"</GrantRightsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);
@@ -113,7 +113,7 @@ public class SendAs extends PrefGroupMailByMessageTest {
 			+	"</GrantRightsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- DATA
 		final String subject = "subject13977785775182543";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendAsDistList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendAsDistList.java
@@ -51,7 +51,7 @@ public class SendAsDistList extends PrefGroupMailByMessageTest {
 		list.grantRight(app.zGetActiveAccount(), "sendAsDistList");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 	
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendOnBehalfOf.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendOnBehalfOf.java
@@ -51,7 +51,7 @@ public class SendOnBehalfOf extends PrefGroupMailByMessageTest {
 				+	"</GrantRightsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendOnBehalfOfDistList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendOnBehalfOfDistList.java
@@ -50,7 +50,7 @@ public class SendOnBehalfOfDistList extends PrefGroupMailByMessageTest {
 		list.grantRight(app.zGetActiveAccount(), "sendOnBehalfOfDistList");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/personas/FromAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/personas/FromAlias.java
@@ -69,7 +69,7 @@ public class FromAlias extends PrefGroupMailByMessageTest {
 			+	"</CreateIdentityRequest>");
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/personas/FromAllowAddress.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/personas/FromAllowAddress.java
@@ -67,7 +67,7 @@ public class FromAllowAddress extends PrefGroupMailByMessageTest {
 			+	"</CreateIdentityRequest>");
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/personas/FromExternalIMAP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/personas/FromExternalIMAP.java
@@ -66,7 +66,7 @@ public class FromExternalIMAP extends PrefGroupMailByMessageTest {
 			+	"</CreateDataSourceRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/personas/FromExternalPOP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/personas/FromExternalPOP.java
@@ -66,7 +66,7 @@ public class FromExternalPOP extends PrefGroupMailByMessageTest {
 			+	"</CreateDataSourceRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/quickreply/personas/FromAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/quickreply/personas/FromAlias.java
@@ -97,7 +97,7 @@ public class FromAlias extends PrefGroupMailByConversationTest {
 		
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/ExpandFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/ExpandFolder.java
@@ -71,7 +71,7 @@ public class ExpandFolder extends PrefGroupMailByMessageTest {
 			+	"</SetMailboxMetadataRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Expand folder1
 		app.zTreeMail.zTreeItem(Action.A_TREE_EXPAND, folder1);
@@ -147,7 +147,7 @@ public class ExpandFolder extends PrefGroupMailByMessageTest {
 			+	"</SetMailboxMetadataRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		//-- GUI
 		
@@ -236,7 +236,7 @@ public class ExpandFolder extends PrefGroupMailByMessageTest {
 			+	"</SetMailboxMetadataRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		//-- GUI
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/accounts/GetExternalIMAP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/accounts/GetExternalIMAP.java
@@ -100,7 +100,7 @@ public class GetExternalIMAP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// If the datasource has never been synced, then an empty title bar appears
 		app.zTreeMail.zRightClickAt("css=div[id='zov__main_Mail'] td[id$='_textCell']:contains("+ foldername +")", "");
@@ -212,7 +212,7 @@ public class GetExternalIMAP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// If the datasource has never been synced, then an empty title bar appears
 		app.zTreeMail.zRightClickAt("css=div[id='zov__main_Mail'] td[id$='_textCell']:contains("+ foldername +")", "");
@@ -339,7 +339,7 @@ public class GetExternalIMAP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// If the datasource has never been synced, then an empty title bar appears
 		app.zTreeMail.zRightClickAt("css=div[id='zov__main_Mail'] td[id$='_textCell']:contains("+ foldername +")", "");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/accounts/GetExternalPOP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/accounts/GetExternalPOP.java
@@ -98,7 +98,7 @@ public class GetExternalPOP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Click on the folder and select Sync
 		app.zTreeMail.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_FOLDER_GET_EXTERNAL, folder);
@@ -203,7 +203,7 @@ public class GetExternalPOP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Click on the folder and select Sync
 		app.zTreeMail.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_FOLDER_GET_EXTERNAL, folder);
@@ -319,7 +319,7 @@ public class GetExternalPOP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Click on the folder and select Sync
 		app.zTreeMail.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_FOLDER_GET_EXTERNAL, folder);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/accounts/GetGmailImap.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/accounts/GetGmailImap.java
@@ -80,7 +80,7 @@ public class GetGmailImap extends PrefGroupMailByMessageTest {
 					+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 					+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// If the datasource has never been synced, then an empty title bar appears
 		app.zTreeMail.zRightClickAt("css=div[id='zov__main_Mail'] td[id$='_textCell']:contains("+ foldername +")", "");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/group/messages/SortByDateGroupByDateAscending.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/group/messages/SortByDateGroupByDateAscending.java
@@ -113,7 +113,7 @@ public class SortByDateGroupByDateAscending extends PrefGroupMailByMessageTest {
 							+	"</SetMailboxMetadataRequest>");
 
 			// Refresh web-client to load the changes done. It is required as the next soap request overwrites the changes done by previous request if done without refresh. 
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 
 			// Sort by Date in ascending order
 			app.zGetActiveAccount().soapSend(
@@ -122,7 +122,7 @@ public class SortByDateGroupByDateAscending extends PrefGroupMailByMessageTest {
 							+ 	"</ModifyPrefsRequest>");
 
 			// Refresh web-client to load the changes done
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 
 			// Click on Inbox
 			app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, inbox);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DeleteMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DeleteMail.java
@@ -385,7 +385,7 @@ public class DeleteMail extends PrefGroupMailByMessageTest {
 			}
 		
 		// Refresh current view
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//Refreshing it twice as single refresh does not work sometimes
 		app.zPageMail.zVerifyMailExists(subject[52]);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/admin/ForwardMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/admin/ForwardMail.java
@@ -101,7 +101,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -195,7 +195,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/admin/ReplyMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/admin/ReplyMail.java
@@ -100,7 +100,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -196,7 +196,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/manager/ForwardMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/manager/ForwardMail.java
@@ -102,7 +102,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -196,7 +196,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/manager/ReplyMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/manager/ReplyMail.java
@@ -101,7 +101,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -196,7 +196,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/viewer/ForwardMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/viewer/ForwardMail.java
@@ -100,7 +100,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -194,7 +194,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/viewer/ReplyMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mountpoints/viewer/ReplyMail.java
@@ -100,7 +100,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -194,7 +194,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newtab/OpenInTabSharedMailFolders.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newtab/OpenInTabSharedMailFolders.java
@@ -24,7 +24,6 @@ import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -170,14 +169,10 @@ public class OpenInTabSharedMailFolders extends PrefGroupMailByMessageTest {
 		app.zTreeMail.zTreeItem(Action.A_TREE_EXPAND, mountpoint);
 		
 		//Click on subfolder
-		SleepUtil.sleep(5000);
 		app.zTreeMail.zRightClickAt(locator,"");
 		
 		//Click on Open in tab option
 		app.zTreeMail.zClickAt(OpenInTab, "");
-				
-		// Wait for the page
-		SleepUtil.sleep(5000);
 		
 		// Remember to close the search view
 		try {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/attributes/ZimbraHelpAdvancedURL.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/attributes/ZimbraHelpAdvancedURL.java
@@ -64,7 +64,7 @@ public class ZimbraHelpAdvancedURL extends AjaxCommonTest {
 							+ "<a n='zimbraVirtualHostname'>" + ConfigProperties.getStringProperty("server.host")
 							+ "</a>" + "</ModifyDomainRequest>");
 			
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 			app.zPageMain.zToolbarPressPulldown(Button.B_ACCOUNT, Button.O_PRODUCT_HELP);
 			SleepUtil.sleepMedium();
 			
@@ -111,7 +111,7 @@ public class ZimbraHelpAdvancedURL extends AjaxCommonTest {
 
 			SleepUtil.sleepVeryLong();
 			for (int i = 0; i <= 10; i++) {
-				app.zPageLogin.sRefresh();
+				app.zPageLogin.zRefreshMainUI();
 				if (app.zPageLogin.sIsElementPresent("css=input[class^='ZLoginButton']") == true || 
 						app.zPageLogin.sIsElementPresent("css=div[id$='parent-ZIMLET'] td[id$='ZIMLET_textCell']") == true) {
 					break;

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Login.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Login.java
@@ -271,7 +271,7 @@ public class Login extends AjaxCommonTest {
 
 				SleepUtil.sleepVeryLong();
 				for (int i = 0; i <= 10; i++) {
-					app.zPageLogin.sRefresh();
+					app.zPageLogin.zRefreshMainUI();
 					if (app.zPageLogin.sIsElementPresent("css=input[class^='ZLoginButton']") == true || 
 							app.zPageLogin.sIsElementPresent("css=div[id$='parent-ZIMLET'] td[id$='ZIMLET_textCell']") == true) {
 						break;

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
@@ -51,7 +51,7 @@ public class LoginWithCsrfTokenCheckDisabled extends AjaxCommonTest {
 			SleepUtil.sleepVeryLong();
 			
 			for (int i=0; i<=5; i++) {
-				app.zPageMain.sRefreshPage();
+				app.zPageMain.zRefreshUI();
 				if (app.zPageLogin.sIsElementPresent("css=input[class^='ZLoginButton']") == true || 
 						app.zPageLogin.sIsElementPresent("css=div[id$='parent-ZIMLET'] td[id$='ZIMLET_textCell']") == true) {
 					break;
@@ -86,7 +86,7 @@ public class LoginWithCsrfTokenCheckDisabled extends AjaxCommonTest {
 			SleepUtil.sleepVeryLong();
 
 			for (int i=0; i<=5; i++) {
-				app.zPageMain.sRefreshPage();
+				app.zPageMain.zRefreshUI();
 				if (app.zPageLogin.sIsElementPresent("css=input[class^='ZLoginButton']") == true || 
 						app.zPageLogin.sIsElementPresent("css=div[id$='parent-ZIMLET'] td[id$='ZIMLET_textCell']") == true) {
 					break;

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DelegateSendAsSaveCopyOfMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DelegateSendAsSaveCopyOfMessage.java
@@ -53,7 +53,7 @@ public class DelegateSendAsSaveCopyOfMessage extends PrefGroupMailByMessageTest 
 				+ "<pref name='zimbraPrefDelegatedSendSaveTarget'>owner</pref>" + "</ModifyPrefsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// -- GUI Steps
 
@@ -101,7 +101,7 @@ public class DelegateSendAsSaveCopyOfMessage extends PrefGroupMailByMessageTest 
 				+ "<pref name='zimbraPrefDelegatedSendSaveTarget'>sender</pref>" + "</ModifyPrefsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// -- GUI Steps
 
@@ -150,7 +150,7 @@ public class DelegateSendAsSaveCopyOfMessage extends PrefGroupMailByMessageTest 
 				+ "<pref name='zimbraPrefDelegatedSendSaveTarget'>both</pref>" + "</ModifyPrefsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// -- GUI Steps
 
@@ -198,7 +198,7 @@ public class DelegateSendAsSaveCopyOfMessage extends PrefGroupMailByMessageTest 
 				+ "<pref name='zimbraPrefDelegatedSendSaveTarget'>none</pref>" + "</ModifyPrefsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// -- GUI Steps
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DelegateSendOnBehalfOfSaveCopyOfMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DelegateSendOnBehalfOfSaveCopyOfMessage.java
@@ -60,7 +60,7 @@ public class DelegateSendOnBehalfOfSaveCopyOfMessage extends PrefGroupMailByMess
 			+	"</ModifyPrefsRequest>");
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 
@@ -113,7 +113,7 @@ public class DelegateSendOnBehalfOfSaveCopyOfMessage extends PrefGroupMailByMess
 
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 
@@ -168,7 +168,7 @@ public class DelegateSendOnBehalfOfSaveCopyOfMessage extends PrefGroupMailByMess
 
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 
@@ -221,7 +221,7 @@ public class DelegateSendOnBehalfOfSaveCopyOfMessage extends PrefGroupMailByMess
 
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisableExternalAccountCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisableExternalAccountCreation.java
@@ -53,7 +53,7 @@ public class DisableExternalAccountCreation extends AjaxCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
@@ -72,7 +72,7 @@ public class DisableExternalAccountCreation extends AjaxCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
@@ -90,7 +90,7 @@ public class DisableExternalAccountCreation extends AjaxCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisablePersonaCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/DisablePersonaCreation.java
@@ -51,7 +51,7 @@ public class DisablePersonaCreation extends AjaxCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
@@ -69,7 +69,7 @@ public class DisablePersonaCreation extends AjaxCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/EditDelegate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/EditDelegate.java
@@ -50,7 +50,7 @@ public class EditDelegate extends AjaxCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Navigate to preferences -> accounts
 		app.zPagePreferences.zNavigateTo();
@@ -121,7 +121,7 @@ public class EditDelegate extends AjaxCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		AbsDialog errorDialog = app.zPageMain.zGetErrorDialog(DialogErrorID.Zimbra);
@@ -204,7 +204,7 @@ public class EditDelegate extends AjaxCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		// Navigate to preferences -> notifications
@@ -269,7 +269,7 @@ public class EditDelegate extends AjaxCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		// Navigate to preferences -> notifications
@@ -334,7 +334,7 @@ public class EditDelegate extends AjaxCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		AbsDialog errorDialog = app.zPageMain.zGetErrorDialog(DialogErrorID.Zimbra);
@@ -410,7 +410,7 @@ public class EditDelegate extends AjaxCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		// Navigate to preferences -> notifications

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/RemoveDelegate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/accounts/RemoveDelegate.java
@@ -63,7 +63,7 @@ public class RemoveDelegate extends AjaxCommonTest {
 		//-- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		AbsDialog errorDialog = app.zPageMain.zGetErrorDialog(DialogErrorID.Zimbra);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/attributes/ZimbraFeatureContactsDetailedSearchEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/attributes/ZimbraFeatureContactsDetailedSearchEnabled.java
@@ -98,7 +98,7 @@ public class ZimbraFeatureContactsDetailedSearchEnabled extends PrefGroupMailByM
 	    
 		} finally {	
 			// Refresh due to skipped issue
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 		}
 	}		
 
@@ -179,7 +179,7 @@ public class ZimbraFeatureContactsDetailedSearchEnabled extends PrefGroupMailByM
 		} finally {
 			
 			// Refresh due to skipped issue
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 		}
 		
 	}		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/calendar/ShowHideDeclinedMeetings.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/calendar/ShowHideDeclinedMeetings.java
@@ -61,7 +61,7 @@ public class ShowHideDeclinedMeetings extends AjaxCommonTest {
 	  "</ModifyAccountRequest>");
 
 	// Refresh UI
-	app.zPageMain.sRefresh();
+	app.zPageMain.zRefreshMainUI();
 	app.zPageCalendar.zNavigateTo();
 
 	ZimbraAccount.AccountA().soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/calendar/ZimbraPrefCalendarFirstDayOfWeek.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/calendar/ZimbraPrefCalendarFirstDayOfWeek.java
@@ -56,9 +56,6 @@ public class ZimbraPrefCalendarFirstDayOfWeek extends AjaxCommonTest {
 		// Navigate to preferences -> calendar
 		app.zTreePreferences.zTreeItem(Action.A_LEFTCLICK, TreeItem.Calendar);
 
-		// Change the default appointment duration
-		app.zPagePreferences.zToolbarPressPulldown(Button.O_DEFAULT_APPOINTMENT_DURATION, Button.O_APPOINTMENT_DURATION_90);
-		
 		// Save preferences
 		app.zPagePreferences.zToolbarPressButton(Button.B_SAVE);
 		DialogWarning dialog = (DialogWarning) new DialogWarning(DialogWarning.DialogWarningID.ReloadApplication, app, app.zPagePreferences);
@@ -70,7 +67,13 @@ public class ZimbraPrefCalendarFirstDayOfWeek extends AjaxCommonTest {
 		ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(2), "Wed", "Second day matched");
 		ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(3), "Thu", "Third day matched");
 		ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(4), "Fri", "Fourth day matched");
-		ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(6), "Mon", "Fifth day matched");
+		if (app.zPageCalendar.zIsWeekend()) {
+			ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(5), "Sat", "Fifth day matched");
+			ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(6), "Sun", "Sixth day matched");
+			ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(7), "Mon", "Seventh day matched");
+        } else {
+			ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(5), "Mon", "Fifth day matched");
+        }
 	}
 	
 	@AfterMethod(groups={"always"})

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/filters/CreateFilter.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/filters/CreateFilter.java
@@ -87,7 +87,7 @@ public class CreateFilter extends AjaxCommonTest {
 	public void CreateFilter_02() throws HarnessException {
     	
     	// Work around
-    	app.zPageMain.sRefresh();
+    	app.zPageMain.zRefreshMainUI();
     	app.zPagePreferences.zNavigateTo();
 
 		String filterName = "Outfilter";

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/composing/ZimbraPrefShowComposeDirection.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/composing/ZimbraPrefShowComposeDirection.java
@@ -37,7 +37,7 @@ public class ZimbraPrefShowComposeDirection extends AjaxCommonTest {
 		super.startingPage = app.zPageMail;
 		super.startingAccountPreferences.put("zimbraPrefShowComposeDirection", "FALSE");
 	}
-	@Bugs(ids = "103002")
+	@Bugs(ids = "ZCS-3528")
 	@Test(description = "Verify the presence and working of direction buttons in compose mail screen",
 			groups = { "functional", "L3" })
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ChangeSignatureAndVerifyBody.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ChangeSignatureAndVerifyBody.java
@@ -71,7 +71,7 @@ public class ChangeSignatureAndVerifyBody extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);
@@ -138,7 +138,7 @@ public class ChangeSignatureAndVerifyBody extends AjaxCommonTest {
 
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse.java
@@ -52,7 +52,7 @@ public class ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse extends A
 						+ "</id>" + "<a n='zimbraFeatureHtmlComposeEnabled'>FALSE</a>" + "</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ComposeHtmlMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ComposeHtmlMsgWithHtmlSignature.java
@@ -59,7 +59,7 @@ public class ComposeHtmlMsgWithHtmlSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ComposeMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ComposeMsgWithTextSignature.java
@@ -54,7 +54,7 @@ public class ComposeMsgWithTextSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/CreateTextSignatureAndAddInComposedHtmlMesage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/CreateTextSignatureAndAddInComposedHtmlMesage.java
@@ -47,7 +47,7 @@ public class CreateTextSignatureAndAddInComposedHtmlMesage extends AjaxCommonTes
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/DeleteHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/DeleteHtmlSignature.java
@@ -61,7 +61,7 @@ public class DeleteHtmlSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.app.zPagePreferences.zNavigateTo();
 
 		logger.info("CreateSignature: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/DeleteTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/DeleteTextSignature.java
@@ -55,7 +55,7 @@ public class DeleteTextSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.app.zPagePreferences.zNavigateTo();
 
 		logger.info("CreateSignature: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/EditHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/EditHtmlSignature.java
@@ -57,7 +57,7 @@ public class EditHtmlSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.app.zPagePreferences.zNavigateTo();
 
 		logger.info("CreateSignature: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/EditTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/EditTextSignature.java
@@ -54,7 +54,7 @@ public class EditTextSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.app.zPagePreferences.zNavigateTo();
 
 		logger.info("CreateSignature: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ForwardMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ForwardMsgWithHtmlSignature.java
@@ -60,7 +60,7 @@ public class ForwardMsgWithHtmlSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ForwardMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ForwardMsgWithTextSignature.java
@@ -57,7 +57,7 @@ public class ForwardMsgWithTextSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyHtmlSignatureAboveIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyHtmlSignatureAboveIncludeMsg.java
@@ -56,7 +56,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyHtmlSignatureBelowIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyHtmlSignatureBelowIncludeMsg.java
@@ -58,7 +58,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyTextSignatureAboveIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyTextSignatureAboveIncludeMsg.java
@@ -56,7 +56,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyTextSignatureBelowIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/FwdReplyTextSignatureBelowIncludeMsg.java
@@ -55,7 +55,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyAllMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyAllMsgWithHtmlSignature.java
@@ -52,7 +52,7 @@ public class ReplyAllMsgWithHtmlSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyAllMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyAllMsgWithTextSignature.java
@@ -57,7 +57,7 @@ public class ReplyAllMsgWithTextSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithHtmlSignature.java
@@ -52,7 +52,7 @@ public class ReplyMsgWithHtmlSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithTextSignature.java
@@ -57,7 +57,7 @@ public class ReplyMsgWithTextSignature extends AjaxCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithTwoThreeLineTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyMsgWithTwoThreeLineTextSignature.java
@@ -97,7 +97,7 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends AjaxCommonTest {
 						+ "</ModifyIdentityRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		FolderItem inboxFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Inbox);
 		// Signature is created

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyToMsgWithSignatureContainingImage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyToMsgWithSignatureContainingImage.java
@@ -78,7 +78,7 @@ public class ReplyToMsgWithSignatureContainingImage extends AjaxCommonTest {
 				+ "</CreateSignatureRequest>");
 
 		// Refresh UI so that signature get loaded
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/outofoffice/ZimbraPrefOutOfOfficeReplyEnabledFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/outofoffice/ZimbraPrefOutOfOfficeReplyEnabledFalse.java
@@ -53,7 +53,7 @@ public class ZimbraPrefOutOfOfficeReplyEnabledFalse extends AjaxCommonTest {
 						+ "<a n='zimbraPrefOutOfOfficeReply'>" + autoReplyMessage + "</a>"
 						+ "<a n='zimbraPrefOutOfOfficeStatusAlertOnLogin'>TRUE</a>" + "</ModifyAccountRequest>");
 		
-		app.zPageMain.sRefreshPage();
+		app.zPageMain.zRefreshUI();
 
 		// Client must display out of office dialog, wait for some time and take an action on it
 		SleepUtil.sleepLong();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/search/search/SearchAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/search/search/SearchAppointment.java
@@ -102,7 +102,7 @@ public class SearchAppointment extends AjaxCommonTest {
 				null);		
 
 		// Refresh the UI (work around due to active dialogs found when running as a second test and directly using app.zPageCalendar.zNavigateTo();)
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_VIEW_MENU, Button.O_VIEW_LIST_SUB_MENU, "List");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/CreateTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/CreateTag.java
@@ -111,7 +111,7 @@ public class CreateTag extends AjaxCommonTest {
 		app.zPageTasks.zToolbarPressButton(Button.B_REFRESH);
 		
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageTasks.zNavigateTo();
 
 		// Create a new tag using the context menu + New Tag

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/conversation/ArchiveZimletByConversationTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/conversation/ArchiveZimletByConversationTest.java
@@ -64,7 +64,7 @@ public class ArchiveZimletByConversationTest extends PrefGroupMailByConversation
 			initializeArchiveFolder();
 
 			// Refresh UI
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 
 		}
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/mail/ArchiveZimletByMessageTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/mail/ArchiveZimletByMessageTest.java
@@ -65,7 +65,7 @@ public class ArchiveZimletByMessageTest extends PrefGroupMailByMessageTest {
 			initializeArchiveFolder();
 			
 			// To refresh the zimlet settings: Logout/Login
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 			app.zPageMail.zNavigateTo();
 		}
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/PageLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/PageLogin.java
@@ -105,7 +105,7 @@ public class PageLogin extends AbsTab {
 	public void zLogin(ZimbraAccount account) throws HarnessException {
 		logger.debug("login(ZimbraAccount account)" + account.EmailAddress);
 
-		tracer.trace("Login to the "+ MyApplication.myApplicationName() +" using user/password "+ account.EmailAddress +"/"+ account.Password);
+		tracer.trace("Login to the " + MyApplication.myApplicationName() + " using user/password " + account.EmailAddress + "/" + account.Password);
 
 		zNavigateTo();
 
@@ -113,28 +113,13 @@ public class PageLogin extends AbsTab {
 
 		try {
 
+			((AppAjaxClient)MyApplication).zPageMain.zRefreshUITillElementPresent(Locators.zBtnLogin);
+
 			zSetLoginName(account.EmailAddress);
 			zSetLoginPassword(account.Password);
 			sClick(Locators.zBtnLogin);
 			SleepUtil.sleepLong();
 			zWaitForBusyOverlay();
-
-			// 1st login retry (sometime account creation remains fast and entire execution stuck due to non-existence of the account)
-			if (zIsVisiblePerPosition(Locators.zBtnLogin, 0, 0) == true || zIsVisiblePerPosition("css=div[id='ZLoginErrorPanel'] td:contains('The username or password is incorrect')", 0, 0) == true) {
-				logger.error("1st login failed or account not created successfully, retried using " + account.EmailAddress);
-				ZimbraAccount.ResetAccountZCS();
-				account = ZimbraAccount.AccountZCS();
-				zSetLoginName(account.EmailAddress);
-				SleepUtil.sleepVerySmall();
-				zSetLoginPassword(account.Password);
-				SleepUtil.sleepSmall();
-				sClick(Locators.zBtnLogin);
-				SleepUtil.sleepLong();
-				zWaitForBusyOverlay();
-
-			} else {
-				logger.info("1st login retry - successfully logged in using " + account.EmailAddress);
-			}
 
 			((AppAjaxClient)MyApplication).zPageMain.zWaitForActive(100000);
 			((AppAjaxClient)MyApplication).zSetActiveAccount(account);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/PageMain.java
@@ -319,7 +319,7 @@ public class PageMain extends AbsTab {
 			if (!zIndex.equals("auto") && !zIndex.equals("") && !zIndex.equals(null)
 					&& Integer.parseInt(zIndex) >= 700) {
 				logger.info("##### Found active dialog #####");
-				sRefresh();
+				zRefreshMainUI();
 				dialogLocators = webDriver().findElements(By.cssSelector("div[class^='Dwt'][class$='Dialog']"));
 				totalDialogs = dialogLocators.size();
 				for (int j = totalDialogs - 1; j >= 0; j--) {
@@ -548,7 +548,7 @@ public class PageMain extends AbsTab {
 		// Navigate to app
 		if (!appTab.zIsActive()) {
 
-			sRefresh();
+			zRefreshMainUI();
 			appTab.zNavigateTo();
 
 			// Check UI loading

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/DialogSendUpdatetoAttendees.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/DialogSendUpdatetoAttendees.java
@@ -76,12 +76,13 @@ public class DialogSendUpdatetoAttendees extends DialogWarning {
 
 		this.sClickAt(locator, "");
 		this.zWaitForBusyOverlay();
+		SleepUtil.sleepSmall();
 
 		if (button == Button.B_OK) {
 			Stafpostqueue sp = new Stafpostqueue();
 			sp.waitForPostqueue();
 		}
-		SleepUtil.sleepMedium();
+		SleepUtil.sleepLong();
 
 		return (page);
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/FormApptNew.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/FormApptNew.java
@@ -546,7 +546,7 @@ public class FormApptNew extends AbsForm {
 			throw new HarnessException("locator was null for button " + button);
 
 		// Click it
-		this.sClick(locator);
+		this.sClickAt(locator, "");
 		this.zWaitForBusyOverlay();
 
 		if (button == Button.B_SEND || button == Button.B_SAVE || button == Button.B_SAVEANDCLOSE) {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/PageCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/PageCalendar.java
@@ -2197,13 +2197,13 @@ public class PageCalendar extends AbsTab {
 			FolderItem folder = (FolderItem) dynamic;
 
 			pulldownLocator = "css=td#zb__CLD__MOVE_MENU_dropdown>div";
-			
-	        if (zIsWeekend()) {
+
+			if (zIsWeekend()) {
 				optionLocator = "css=td#zti__ZmFolderChooser_CalendarCLW__" + folder.getId() + "_textCell";
-	        } else {
-	        	optionLocator = "css=td#zti__ZmFolderChooser_CalendarCLWW__" + folder.getId() + "_textCell";
-	        }
-	        
+			} else {
+				optionLocator = "css=td#zti__ZmFolderChooser_CalendarCLWW__" + folder.getId() + "_textCell";
+			}
+
 			page = null;
 
 		} else {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/PageCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/calendar/PageCalendar.java
@@ -460,12 +460,12 @@ public class PageCalendar extends AbsTab {
 
 	public String zReturnDayWeek(int number) throws HarnessException {
 		String locator;
-        if (zIsWeekend()) {
-        	locator = "css=div[id^='zv__CLW";
-        } else {
-        	locator = "css=div[id^='zv__CLWW";
-        }
-		return sGetText(locator + " div[class='calendar_heading'] div[class^='calendar_heading_day']:nth-child(" + number + ")");
+		if (zIsWeekend()) {
+			locator = "css=div[id^='zv__CLW'] ";
+		} else {
+			locator = "css=div[id^='zv__CLWW'] ";
+		}
+		return sGetText(locator + "div[class='calendar_heading'] div[class^='calendar_heading_day']:nth-child(" + number + ")");
 	}
 
 	public String zGetRecurringLink() throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/SeparateWindowDisplayMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/SeparateWindowDisplayMail.java
@@ -1013,6 +1013,8 @@ public class SeparateWindowDisplayMail extends AbsSeparateWindow {
 		this.sClick(optionLocator);
 		zWaitForBusyOverlay();
 
+		SleepUtil.sleepMedium();
+
 		if (doPostfixCheck) {
 			// Make sure the response is delivered before proceeding
 			Stafpostqueue sp = new Stafpostqueue();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/TreeMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/mail/TreeMail.java
@@ -366,6 +366,10 @@ public class TreeMail extends AbsTree {
 			this.sMouseDown(locator);
 			this.zWaitForBusyOverlay();
 
+			// Work around for discarding zimbra tooltip
+			this.sMouseOver(Locators.ztih__main_Mail__ZIMLET_ID);
+			SleepUtil.sleepVerySmall();
+
 			// No page to return
 			return (null);
 
@@ -379,6 +383,10 @@ public class TreeMail extends AbsTree {
 
 			this.sMouseDown(locator);
 			this.zWaitForBusyOverlay();
+
+			// Work around for discarding zimbra tooltip
+			this.sMouseOver(Locators.ztih__main_Mail__ZIMLET_ID);
+			SleepUtil.sleepVerySmall();
 
 			// No page to return
 			return (null);
@@ -459,6 +467,10 @@ public class TreeMail extends AbsTree {
 			this.zWaitForBusyOverlay();
 			SleepUtil.sleepSmall();
 
+			// Work around for discarding zimbra tooltip
+			this.sMouseOver(Locators.ztih__main_Mail__ZIMLET_ID);
+			SleepUtil.sleepVerySmall();
+
 			// No page to return
 			return (null);
 
@@ -473,6 +485,10 @@ public class TreeMail extends AbsTree {
 			this.sClickAt(locator,"");
 			this.zWaitForBusyOverlay();
 			SleepUtil.sleepSmall();
+
+			// Work around for discarding zimbra tooltip
+			this.sMouseOver(Locators.ztih__main_Mail__ZIMLET_ID);
+			SleepUtil.sleepVerySmall();
 
 			// No page to return
 			return (null);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/ui/search/PageSearch.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/ui/search/PageSearch.java
@@ -731,6 +731,8 @@ public class PageSearch extends AbsTab {
 
 	public List<MailItem> zListGetMessages() throws HarnessException {
 
+		SleepUtil.sleepMedium();
+
 		List<MailItem> items = new ArrayList<MailItem>();
 
 		String listLocator = null, listLocator1 = null, listLocator2 = null, rowLocator = null, rowLocator1 = null,

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/CreateContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/CreateContact.java
@@ -88,7 +88,7 @@ public class CreateContact extends TouchCommonTest  {
 		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(app.zGetActiveAccount(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify the subfolder is available");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Select the contact from contact list
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/Delete.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/Delete.java
@@ -86,7 +86,7 @@ public class Delete extends TouchCommonTest  {
 		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(app.zGetActiveAccount(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify the subfolder is available");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Select the contact from contact list
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/EditContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/EditContact.java
@@ -88,7 +88,7 @@ public class EditContact extends TouchCommonTest  {
 		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(app.zGetActiveAccount(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify the subfolder is available");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Select the contact from contact list
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/MoveContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/MoveContact.java
@@ -87,7 +87,7 @@ public class MoveContact extends TouchCommonTest  {
 		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(app.zGetActiveAccount(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify the subfolder is available");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Select the contact from contact list in mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/TagContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/manager/TagContact.java
@@ -88,7 +88,7 @@ public class TagContact extends TouchCommonTest  {
 		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(app.zGetActiveAccount(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify the subfolder is available");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Create a tag
 		TagItem tagItem = TagItem.CreateUsingSoap(app.zGetActiveAccount());	

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/viewer/Delete.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/viewer/Delete.java
@@ -86,7 +86,7 @@ public class Delete extends TouchCommonTest  {
 		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(app.zGetActiveAccount(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify the subfolder is available");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Select the contact from contact list
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/viewer/TagContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/contacts/mountpoint/viewer/TagContact.java
@@ -88,7 +88,7 @@ public class TagContact extends TouchCommonTest  {
 		FolderMountpointItem mountpoint = FolderMountpointItem.importFromSOAP(app.zGetActiveAccount(), mountpointname);
 		ZAssert.assertNotNull(mountpoint, "Verify the subfolder is available");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Create a tag
 		TagItem tagItem = TagItem.CreateUsingSoap(app.zGetActiveAccount());	

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/DeleteMount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/DeleteMount.java
@@ -65,7 +65,7 @@ public class DeleteMount extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Delete the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/MoveMount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/MoveMount.java
@@ -83,7 +83,7 @@ public class MoveMount extends PrefGroupMailByMessageTest {
 				"</CreateFolderRequest>");
 		FolderItem folder = FolderItem.importFromSOAP(app.zGetActiveAccount(), folderName);
 		ZAssert.assertNotNull(folderName, "Verify the subfolder is available");
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Select the mount folder from the list
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);
@@ -96,7 +96,7 @@ public class MoveMount extends PrefGroupMailByMessageTest {
 		createFolderPage.zClickButton(Button.B_SAVE);
 
 		// Click Get Mail button
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// SOAP Verify the folder is in the other Subfolder
 		mountpoint = FolderMountpointItem.importFromSOAP(app.zGetActiveAccount(), mountpointname);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/RenameMount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/RenameMount.java
@@ -68,7 +68,7 @@ public class RenameMount extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Select the folder from the list and Rename
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);
@@ -76,7 +76,7 @@ public class RenameMount extends PrefGroupMailByMessageTest{
 		createFolderPage.zSelectFolder(mountpointname);
 		createFolderPage.zEnterFolderName(renameMountFolder);
 		createFolderPage.zClickButton(Button.B_SAVE);
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		createFolderPage.zSelectOrganizer();
 
 		//-- Verification

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/DeleteMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/DeleteMail.java
@@ -80,7 +80,7 @@ public class DeleteMail extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Delete the email in the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/FlagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/FlagMail.java
@@ -80,7 +80,7 @@ public class FlagMail extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Flag the email in the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/ForwardMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/ForwardMail.java
@@ -82,7 +82,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		//Select the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/MarkAsUnread.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/MarkAsUnread.java
@@ -80,7 +80,7 @@ public class MarkAsUnread extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Flag the email in the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/TagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/manager/TagMail.java
@@ -81,7 +81,7 @@ public class TagMail extends PrefGroupMailByMessageTest{
 		// Create a tag
 		TagItem tagItem = TagItem.CreateUsingSoap(app.zGetActiveAccount());
 		String tagName = tagItem.getName();
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Flag the email in the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/DeleteMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/DeleteMail.java
@@ -82,7 +82,7 @@ public class DeleteMail extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Try to delete the email in the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/MarkUnReadMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/MarkUnReadMail.java
@@ -80,7 +80,7 @@ public class MarkUnReadMail extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		//Mark mail as unread then read
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/Replymail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/Replymail.java
@@ -80,7 +80,7 @@ public class Replymail extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Try to delete the email in the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/SpamMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/SpamMail.java
@@ -81,7 +81,7 @@ public class SpamMail extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Try to mark the email as spam in the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/TagMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/mountpoints/viewer/TagMail.java
@@ -83,7 +83,7 @@ public class TagMail extends PrefGroupMailByMessageTest{
 						+		"<link l='1' name='"+ mountpointname +"'  rid='"+ folder.getId() +"' zid='"+ ZimbraAccount.AccountA().ZimbraId +"'/>"
 						+	"</CreateMountpointRequest>");
 
-		app.zPageMain.sRefresh();	
+		app.zPageMain.zRefreshMainUI();	
 
 		// Try to tag the email in the mount folder
 		PageCreateFolder createFolderPage = new PageCreateFolder(app, startingPage);

--- a/src/java/com/zimbra/qa/selenium/projects/touch/ui/calendar/PageCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/ui/calendar/PageCalendar.java
@@ -191,7 +191,7 @@ public class PageCalendar extends AbsTab {
 		String locator = "css=div[class='x-dock x-dock-vertical x-sized'] div[class='zcs-menu-label']:contains('" + folderName + "')";
 		
 		if ( folderName != "Calendar") {
-			this.sRefresh();
+			this.zRefreshMainUI();
 			SleepUtil.sleepVeryLong();
 			SleepUtil.sleepLong();
 		}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalQuickCommandTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalQuickCommandTest.java
@@ -230,7 +230,7 @@ public class UniversalQuickCommandTest extends UniversalCommonTest {
 
 		
 		// Re-login to pick up the new preferences
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// The UniversalCommonTest.commonTestBeforeMethod() method will log into the client
 		logger.info("addQuickCommands: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/ViewChangeViaMenu.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/ViewChangeViaMenu.java
@@ -48,7 +48,7 @@ public class ViewChangeViaMenu extends CalendarWorkWeekTest {
         ZAssert.assertTrue(app.zPageCalendar.sIsElementPresent(Locators.CalendarViewWeekCSS), "Changed to week view");
         
         // Context menu hidden after switching views so applying work around
-        app.zPageMain.sRefresh();
+        app.zPageMain.zRefreshMainUI();
         app.zPageCalendar.zNavigateTo();
 
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_VIEW_MENU, Button.O_VIEW_MONTH_SUB_MENU, "Month");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/day/singleday/tags/TagAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/day/singleday/tags/TagAppointment.java
@@ -168,7 +168,7 @@ public class TagAppointment extends UniversalCommonTest {
         String apptId = appt.dApptID;
         
         // Work around
-        app.zPageMain.sRefresh();
+        app.zPageMain.zRefreshMainUI();
         app.zPageCalendar.zNavigateTo();
         
         // Create new tag using context menu and apply it to appointment

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/day/singleday/tags/UnTagAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/day/singleday/tags/UnTagAppointment.java
@@ -106,7 +106,7 @@ public class UnTagAppointment extends UniversalCommonTest {
 		app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
 
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Remove tag from appointment using context menu

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/list/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/appointments/views/list/DeleteAppointment.java
@@ -614,7 +614,7 @@ public class DeleteAppointment extends UniversalCommonTest {
 		app.zPageCalendar.zToolbarPressButton(Button.B_REFRESH);
 		
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Right click the item, select delete

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/attributes/ZimbraCalResLocationDisplayName.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/attributes/ZimbraCalResLocationDisplayName.java
@@ -70,7 +70,7 @@ public class ZimbraCalResLocationDisplayName extends CalendarWorkWeekTest {
 		}
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		String tz = ZTimeZone.getLocalTimeZone().getID();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/attributes/ZimbraFeatureGroupCalendarEnabledFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/attributes/ZimbraFeatureGroupCalendarEnabledFalse.java
@@ -57,7 +57,7 @@ public class ZimbraFeatureGroupCalendarEnabledFalse extends CalendarWorkWeekTest
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		// Creating object for appointment data
@@ -127,7 +127,7 @@ public class ZimbraFeatureGroupCalendarEnabledFalse extends CalendarWorkWeekTest
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 	
 		// Compose appointment and send it to invitee

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/attributes/ZimbraFeatureHtmlComposeEnabledFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/attributes/ZimbraFeatureHtmlComposeEnabledFalse.java
@@ -52,7 +52,7 @@ public class ZimbraFeatureHtmlComposeEnabledFalse extends CalendarWorkWeekTest {
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		// Create appointment

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/folders/VerifyNestedState.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/folders/VerifyNestedState.java
@@ -83,7 +83,7 @@ public class VerifyNestedState extends CalendarWorkWeekTest {
         ZAssert.assertTrue(app.zPageCalendar.zVerifyAppointmentExists(apptSubject), "Verify appointment displayed in current view");
         
 	    // Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 	    SleepUtil.sleepLong();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/CreateACopy.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/attendee/singleday/actions/CreateACopy.java
@@ -73,7 +73,7 @@ public class CreateACopy extends CalendarWorkWeekTest {
 				+	"</CreateAppointmentRequest>");
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
         
 		// Verify appointment exists in current view

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/actions/Cancel.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/actions/Cancel.java
@@ -121,7 +121,7 @@ public class Cancel extends CalendarWorkWeekTest {
 	    	      "</ModifyAccountRequest>");
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 	    
 		// Absolute dates in UTC zone

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
@@ -107,7 +107,7 @@ public class CreateMeeting extends CalendarWorkWeekTest {
 		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		AppointmentItem appt = new AppointmentItem();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingByChangingBodyTextFormat.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingByChangingBodyTextFormat.java
@@ -46,7 +46,7 @@ public class CreateMeetingByChangingBodyTextFormat extends CalendarWorkWeekTest 
 		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		// Create appointment data
@@ -91,7 +91,7 @@ public class CreateMeetingByChangingBodyTextFormat extends CalendarWorkWeekTest 
 		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		// Create appointment data
@@ -137,7 +137,7 @@ public class CreateMeetingByChangingBodyTextFormat extends CalendarWorkWeekTest 
 		ZimbraAccount.AccountZCS().modifyAccountPreferences(startingAccountPreferences);
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		// Create appointment data

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingInSharedCalendarWithMailFeatureDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingInSharedCalendarWithMailFeatureDisabled.java
@@ -92,7 +92,7 @@ public class CreateMeetingInSharedCalendarWithMailFeatureDisabled extends Calend
 	    	      "</ModifyAccountRequest>");
 	    
 	    // Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 	    
 		// Compose appointment on shared mailbox

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGALFeatureDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGALFeatureDisabled.java
@@ -49,7 +49,7 @@ public class CreateMeetingWithGALFeatureDisabled extends CalendarWorkWeekTest {
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment
@@ -93,7 +93,7 @@ public class CreateMeetingWithGALFeatureDisabled extends CalendarWorkWeekTest {
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGroupCalendarFeatureDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithGroupCalendarFeatureDisabled.java
@@ -53,7 +53,7 @@ public class CreateMeetingWithGroupCalendarFeatureDisabled extends CalendarWorkW
 			+	"</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 
 		// Create appointment

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/persona/CreateAppointmentFromExternalIMAP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/create/persona/CreateAppointmentFromExternalIMAP.java
@@ -72,7 +72,7 @@ public class CreateAppointmentFromExternalIMAP extends CalendarWorkWeekTest {
 			+	"</CreateDataSourceRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		// Create appointment data

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWithDisplayMailPreference.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWithDisplayMailPreference.java
@@ -126,7 +126,7 @@ public class ViewInviteWithDisplayMailPreference extends CalendarWorkWeekTest {
 		}
 		
 		// Work around for getting correct body locator
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Navigate to preference -> Mail and set display mail pref to Text and verify
 		app.zPagePreferences.zNavigateTo();
@@ -206,7 +206,7 @@ public class ViewInviteWithDisplayMailPreference extends CalendarWorkWeekTest {
 		String multilineTextContentForSOAP = "line 1\nline two\n\n\nline 3";
 		
 		// Work around for getting correct body locator
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		Calendar now = calendarWeekDayUTC;
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
@@ -255,7 +255,7 @@ public class ViewInviteWithDisplayMailPreference extends CalendarWorkWeekTest {
 		}
 		
 		// Work around for getting correct body locator
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		app.zGetActiveAccount().soapSend(
 				"<GetPrefsRequest xmlns='urn:zimbraAccount'>"

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/mountpoints/admin/actions/Create.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/calendar/mountpoints/admin/actions/Create.java
@@ -93,7 +93,7 @@ public class Create extends CalendarWorkWeekTest {
 			+	"</CreateIdentityRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		appt.setSubject(apptSubject);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/contactgroups/CreateContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/contactgroups/CreateContactGroup.java
@@ -260,7 +260,7 @@ public class CreateContactGroup extends UniversalCommonTest  {
 		String email=ZimbraAccount.AccountA().EmailAddress.substring(0,ZimbraAccount.AccountA().EmailAddress.indexOf('@'));
 		
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 
 		// search for a GAL

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/folders/CreateFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/folders/CreateFolder.java
@@ -89,7 +89,7 @@ public class CreateFolder extends UniversalCommonTest {
 		String folderName = "folder" + ConfigProperties.getUniqueString();
 		
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 
 		// Right click on Contacts -> New Addressbook

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/CreateTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/CreateTag.java
@@ -88,7 +88,7 @@ public class CreateTag extends PrefGroupMailByMessageTest {
 	public void CreateTag_03() throws HarnessException {
 		
 		// Work around due to duplicate dialog ids
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 		
 		// Set the new tag name

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/TagContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/TagContact.java
@@ -46,7 +46,7 @@ public class TagContact extends ContactsPrefShowSelectionCheckbox {
 	public void ClickPulldownMenuTagNewTag_01() throws HarnessException {
 
 		// Work around due to duplicate dialog ids
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 
 		// -- Data

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/TagContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/TagContactGroup.java
@@ -59,7 +59,7 @@ public class TagContactGroup extends UniversalCommonTest  {
 		app.zPageContacts.zToolbarPressButton(Button.B_REFRESH);
 		
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 		
 		// Select the contact

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/UnTagContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/contacts/tags/UnTagContactGroup.java
@@ -257,7 +257,7 @@ public class UnTagContactGroup extends UniversalCommonTest  {
 	public void UnTagContactGroup_06() throws HarnessException {			
 		
 		// Work around due to duplicate dialog ids
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageContacts.zNavigateTo();
 		
 		//-- Data

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/ReplyFromSentFolderWithReplyToHeader.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/ReplyFromSentFolderWithReplyToHeader.java
@@ -94,7 +94,7 @@ public class ReplyFromSentFolderWithReplyToHeader extends PrefGroupMailByMessage
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -210,7 +210,7 @@ public class ReplyFromSentFolderWithReplyToHeader extends PrefGroupMailByMessage
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Click in sent
 		app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Sent));

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/delegates/SendAs.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/delegates/SendAs.java
@@ -56,7 +56,7 @@ public class SendAs extends PrefGroupMailByMessageTest {
 			+	"</GrantRightsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);
@@ -113,7 +113,7 @@ public class SendAs extends PrefGroupMailByMessageTest {
 			+	"</GrantRightsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- DATA
 		final String subject = "subject13977785775182543";

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/delegates/SendAsDistList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/delegates/SendAsDistList.java
@@ -51,7 +51,7 @@ public class SendAsDistList extends PrefGroupMailByMessageTest {
 		list.grantRight(app.zGetActiveAccount(), "sendAsDistList");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 	
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/delegates/SendOnBehalfOf.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/delegates/SendOnBehalfOf.java
@@ -51,7 +51,7 @@ public class SendOnBehalfOf extends PrefGroupMailByMessageTest {
 				+	"</GrantRightsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/delegates/SendOnBehalfOfDistList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/delegates/SendOnBehalfOfDistList.java
@@ -50,7 +50,7 @@ public class SendOnBehalfOfDistList extends PrefGroupMailByMessageTest {
 		list.grantRight(app.zGetActiveAccount(), "sendOnBehalfOfDistList");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/personas/FromAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/personas/FromAlias.java
@@ -69,7 +69,7 @@ public class FromAlias extends PrefGroupMailByMessageTest {
 			+	"</CreateIdentityRequest>");
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/personas/FromAllowAddress.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/personas/FromAllowAddress.java
@@ -67,7 +67,7 @@ public class FromAllowAddress extends PrefGroupMailByMessageTest {
 			+	"</CreateIdentityRequest>");
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/personas/FromExternalIMAP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/personas/FromExternalIMAP.java
@@ -66,7 +66,7 @@ public class FromExternalIMAP extends PrefGroupMailByMessageTest {
 			+	"</CreateDataSourceRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/personas/FromExternalPOP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/compose/personas/FromExternalPOP.java
@@ -66,7 +66,7 @@ public class FromExternalPOP extends PrefGroupMailByMessageTest {
 			+	"</CreateDataSourceRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Create the message data to be sent
 		String subject = "subject" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/conversation/quickreply/personas/FromAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/conversation/quickreply/personas/FromAlias.java
@@ -97,7 +97,7 @@ public class FromAlias extends PrefGroupMailByConversationTest {
 		
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/ExpandFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/ExpandFolder.java
@@ -71,7 +71,7 @@ public class ExpandFolder extends PrefGroupMailByMessageTest {
 			+	"</SetMailboxMetadataRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		// Expand folder1
 		app.zTreeMail.zTreeItem(Action.A_TREE_EXPAND, folder1);
@@ -147,7 +147,7 @@ public class ExpandFolder extends PrefGroupMailByMessageTest {
 			+	"</SetMailboxMetadataRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		//-- GUI
 		
@@ -236,7 +236,7 @@ public class ExpandFolder extends PrefGroupMailByMessageTest {
 			+	"</SetMailboxMetadataRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		//-- GUI
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetExternalIMAP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetExternalIMAP.java
@@ -100,7 +100,7 @@ public class GetExternalIMAP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// If the datasource has never been synced, then an empty title bar appears
 		app.zTreeMail.zRightClickAt("css=div[id='zov__main_Mail'] td[id$='_textCell']:contains("+ foldername +")", "");
@@ -212,7 +212,7 @@ public class GetExternalIMAP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// If the datasource has never been synced, then an empty title bar appears
 		app.zTreeMail.zRightClickAt("css=div[id='zov__main_Mail'] td[id$='_textCell']:contains("+ foldername +")", "");
@@ -339,7 +339,7 @@ public class GetExternalIMAP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// If the datasource has never been synced, then an empty title bar appears
 		app.zTreeMail.zRightClickAt("css=div[id='zov__main_Mail'] td[id$='_textCell']:contains("+ foldername +")", "");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetExternalPOP.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetExternalPOP.java
@@ -98,7 +98,7 @@ public class GetExternalPOP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Click on the folder and select Sync
 		app.zTreeMail.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_FOLDER_GET_EXTERNAL, folder);
@@ -203,7 +203,7 @@ public class GetExternalPOP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Click on the folder and select Sync
 		app.zTreeMail.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_FOLDER_GET_EXTERNAL, folder);
@@ -319,7 +319,7 @@ public class GetExternalPOP extends PrefGroupMailByMessageTest {
 			+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 			+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Click on the folder and select Sync
 		app.zTreeMail.zTreeItem(Action.A_RIGHTCLICK, Button.B_TREE_FOLDER_GET_EXTERNAL, folder);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetGmailImap.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/folders/accounts/GetGmailImap.java
@@ -80,7 +80,7 @@ public class GetGmailImap extends PrefGroupMailByMessageTest {
 					+			"fromDisplay='Foo Bar' fromAddress='"+ app.zGetActiveAccount().EmailAddress +"' />"
 					+	"</CreateDataSourceRequest>");
 
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// If the datasource has never been synced, then an empty title bar appears
 		app.zTreeMail.zRightClickAt("css=div[id='zov__main_Mail'] td[id$='_textCell']:contains("+ foldername +")", "");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/group/messages/SortByDateGroupByDateAscending.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/group/messages/SortByDateGroupByDateAscending.java
@@ -113,7 +113,7 @@ public class SortByDateGroupByDateAscending extends PrefGroupMailByMessageTest {
 							+	"</SetMailboxMetadataRequest>");
 
 			// Refresh web-client to load the changes done. It is required as the next soap request overwrites the changes done by previous request if done without refresh. 
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 
 			// Sort by Date in ascending order
 			app.zGetActiveAccount().soapSend(
@@ -122,7 +122,7 @@ public class SortByDateGroupByDateAscending extends PrefGroupMailByMessageTest {
 							+ 	"</ModifyPrefsRequest>");
 
 			// Refresh web-client to load the changes done
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 
 			// Click on Inbox
 			app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, inbox);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/DeleteMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mail/DeleteMail.java
@@ -385,7 +385,7 @@ public class DeleteMail extends PrefGroupMailByMessageTest {
 			}
 		
 		// Refresh current view
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//Refreshing it twice as single refresh does not work sometimes
 		app.zPageMail.zVerifyMailExists(subject[52]);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/admin/ForwardMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/admin/ForwardMail.java
@@ -101,7 +101,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -195,7 +195,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/admin/ReplyMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/admin/ReplyMail.java
@@ -100,7 +100,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -196,7 +196,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/manager/ForwardMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/manager/ForwardMail.java
@@ -102,7 +102,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -196,7 +196,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/manager/ReplyMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/manager/ReplyMail.java
@@ -101,7 +101,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -196,7 +196,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/viewer/ForwardMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/viewer/ForwardMail.java
@@ -100,7 +100,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -194,7 +194,7 @@ public class ForwardMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/viewer/ReplyMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/mail/mountpoints/viewer/ReplyMail.java
@@ -100,7 +100,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			
@@ -194,7 +194,7 @@ public class ReplyMail extends PrefGroupMailByMessageTest {
 		//-- GUI
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		try {
 			

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/attributes/ZimbraHelpAdvancedURL.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/attributes/ZimbraHelpAdvancedURL.java
@@ -64,7 +64,7 @@ public class ZimbraHelpAdvancedURL extends UniversalCommonTest {
 							+ "<a n='zimbraVirtualHostname'>" + ConfigProperties.getStringProperty("server.host")
 							+ "</a>" + "</ModifyDomainRequest>");
 			
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 			app.zPageMain.zToolbarPressPulldown(Button.B_ACCOUNT, Button.O_PRODUCT_HELP);
 			SleepUtil.sleepMedium();
 			
@@ -111,7 +111,7 @@ public class ZimbraHelpAdvancedURL extends UniversalCommonTest {
 
 			SleepUtil.sleepVeryLong();
 			for (int i = 0; i <= 10; i++) {
-				app.zPageLogin.sRefresh();
+				app.zPageLogin.zRefreshMainUI();
 				if (app.zPageLogin.sIsElementPresent("css=input[class^='ZLoginButton']") == true || 
 						app.zPageLogin.sIsElementPresent("css=div[id$='parent-ZIMLET'] td[id$='ZIMLET_textCell']") == true) {
 					break;

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/Login.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/Login.java
@@ -271,7 +271,7 @@ public class Login extends UniversalCommonTest {
 
 				SleepUtil.sleepVeryLong();
 				for (int i = 0; i <= 10; i++) {
-					app.zPageLogin.sRefresh();
+					app.zPageLogin.zRefreshMainUI();
 					if (app.zPageLogin.sIsElementPresent("css=input[class^='ZLoginButton']") == true || 
 							app.zPageLogin.sIsElementPresent("css=div[id$='parent-ZIMLET'] td[id$='ZIMLET_textCell']") == true) {
 						break;

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
@@ -51,7 +51,7 @@ public class LoginWithCsrfTokenCheckDisabled extends UniversalCommonTest {
 			SleepUtil.sleepVeryLong();
 			
 			for (int i=0; i<=5; i++) {
-				app.zPageMain.sRefreshPage();
+				app.zPageMain.zRefreshUI();
 				if (app.zPageLogin.sIsElementPresent("css=input[class^='ZLoginButton']") == true || 
 						app.zPageLogin.sIsElementPresent("css=div[id$='parent-ZIMLET'] td[id$='ZIMLET_textCell']") == true) {
 					break;
@@ -89,7 +89,7 @@ public class LoginWithCsrfTokenCheckDisabled extends UniversalCommonTest {
 			SleepUtil.sleepVeryLong();
 
 			for (int i=0; i<=5; i++) {
-				app.zPageMain.sRefreshPage();
+				app.zPageMain.zRefreshUI();
 				if (app.zPageLogin.sIsElementPresent("css=input[class^='ZLoginButton']") == true || 
 						app.zPageLogin.sIsElementPresent("css=div[id$='parent-ZIMLET'] td[id$='ZIMLET_textCell']") == true) {
 					break;

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/DelegateSendAsSaveCopyOfMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/DelegateSendAsSaveCopyOfMessage.java
@@ -53,7 +53,7 @@ public class DelegateSendAsSaveCopyOfMessage extends PrefGroupMailByMessageTest 
 				+ "<pref name='zimbraPrefDelegatedSendSaveTarget'>owner</pref>" + "</ModifyPrefsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// -- GUI Steps
 
@@ -101,7 +101,7 @@ public class DelegateSendAsSaveCopyOfMessage extends PrefGroupMailByMessageTest 
 				+ "<pref name='zimbraPrefDelegatedSendSaveTarget'>sender</pref>" + "</ModifyPrefsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// -- GUI Steps
 
@@ -150,7 +150,7 @@ public class DelegateSendAsSaveCopyOfMessage extends PrefGroupMailByMessageTest 
 				+ "<pref name='zimbraPrefDelegatedSendSaveTarget'>both</pref>" + "</ModifyPrefsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// -- GUI Steps
 
@@ -198,7 +198,7 @@ public class DelegateSendAsSaveCopyOfMessage extends PrefGroupMailByMessageTest 
 				+ "<pref name='zimbraPrefDelegatedSendSaveTarget'>none</pref>" + "</ModifyPrefsRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// -- GUI Steps
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/DelegateSendOnBehalfOfSaveCopyOfMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/DelegateSendOnBehalfOfSaveCopyOfMessage.java
@@ -60,7 +60,7 @@ public class DelegateSendOnBehalfOfSaveCopyOfMessage extends PrefGroupMailByMess
 			+	"</ModifyPrefsRequest>");
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 
@@ -113,7 +113,7 @@ public class DelegateSendOnBehalfOfSaveCopyOfMessage extends PrefGroupMailByMess
 
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 
@@ -168,7 +168,7 @@ public class DelegateSendOnBehalfOfSaveCopyOfMessage extends PrefGroupMailByMess
 
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 
@@ -221,7 +221,7 @@ public class DelegateSendOnBehalfOfSaveCopyOfMessage extends PrefGroupMailByMess
 
 		
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		
 		//-- GUI Steps
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/DisableExternalAccountCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/DisableExternalAccountCreation.java
@@ -53,7 +53,7 @@ public class DisableExternalAccountCreation extends UniversalCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
@@ -72,7 +72,7 @@ public class DisableExternalAccountCreation extends UniversalCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
@@ -90,7 +90,7 @@ public class DisableExternalAccountCreation extends UniversalCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/DisablePersonaCreation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/DisablePersonaCreation.java
@@ -51,7 +51,7 @@ public class DisablePersonaCreation extends UniversalCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();
@@ -69,7 +69,7 @@ public class DisablePersonaCreation extends UniversalCommonTest {
 						+	"</ModifyAccountRequest>");
 
 		// Refresh Web-client
-		app.zPageMail.sRefresh();
+		app.zPageMail.zRefreshMainUI();
 
 		// Navigate to Preferences-->Accounts
 		startingPage.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/EditDelegate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/EditDelegate.java
@@ -50,7 +50,7 @@ public class EditDelegate extends UniversalCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Navigate to preferences -> accounts
 		app.zPagePreferences.zNavigateTo();
@@ -121,7 +121,7 @@ public class EditDelegate extends UniversalCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		AbsDialog errorDialog = app.zPageMain.zGetErrorDialog(DialogErrorID.Zimbra);
@@ -204,7 +204,7 @@ public class EditDelegate extends UniversalCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		// Navigate to preferences -> notifications
@@ -269,7 +269,7 @@ public class EditDelegate extends UniversalCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		// Navigate to preferences -> notifications
@@ -334,7 +334,7 @@ public class EditDelegate extends UniversalCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		AbsDialog errorDialog = app.zPageMain.zGetErrorDialog(DialogErrorID.Zimbra);
@@ -410,7 +410,7 @@ public class EditDelegate extends UniversalCommonTest {
 		// -- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		// Navigate to preferences -> notifications

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/RemoveDelegate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/accounts/RemoveDelegate.java
@@ -63,7 +63,7 @@ public class RemoveDelegate extends UniversalCommonTest {
 		//-- GUI Steps
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.startingPage.zNavigateTo();
 
 		AbsDialog errorDialog = app.zPageMain.zGetErrorDialog(DialogErrorID.Zimbra);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/attributes/ZimbraFeatureContactsDetailedSearchEnabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/attributes/ZimbraFeatureContactsDetailedSearchEnabled.java
@@ -98,7 +98,7 @@ public class ZimbraFeatureContactsDetailedSearchEnabled extends PrefGroupMailByM
 	    
 		} finally {	
 			// Refresh due to skipped issue
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 		}
 	}		
 
@@ -179,7 +179,7 @@ public class ZimbraFeatureContactsDetailedSearchEnabled extends PrefGroupMailByM
 		} finally {
 			
 			// Refresh due to skipped issue
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 		}
 		
 	}		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/calendar/ShowHideDeclinedMeetings.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/calendar/ShowHideDeclinedMeetings.java
@@ -61,7 +61,7 @@ public class ShowHideDeclinedMeetings extends CalendarWorkWeekTest {
 	  "</ModifyAccountRequest>");
 
 	// Refresh UI
-	app.zPageMain.sRefresh();
+	app.zPageMain.zRefreshMainUI();
 	app.zPageCalendar.zNavigateTo();
 
 	ZimbraAccount.AccountA().soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/filters/CreateFilter.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/filters/CreateFilter.java
@@ -87,7 +87,7 @@ public class CreateFilter extends UniversalCommonTest {
 	public void CreateFilter_02() throws HarnessException {
     	
     	// Work around
-    	app.zPageMain.sRefresh();
+    	app.zPageMain.zRefreshMainUI();
     	app.zPagePreferences.zNavigateTo();
 
 		String filterName = "Outfilter";

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ChangeSignatureAndVerifyBody.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ChangeSignatureAndVerifyBody.java
@@ -71,7 +71,7 @@ public class ChangeSignatureAndVerifyBody extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);
@@ -138,7 +138,7 @@ public class ChangeSignatureAndVerifyBody extends UniversalCommonTest {
 
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		// Open the new mail form
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_NEW);

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse.java
@@ -52,7 +52,7 @@ public class ChangeSignatureWhenzimbraFeatureHtmlComposeEnabledIsFalse extends U
 						+ "</id>" + "<a n='zimbraFeatureHtmlComposeEnabled'>FALSE</a>" + "</ModifyAccountRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ComposeHtmlMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ComposeHtmlMsgWithHtmlSignature.java
@@ -59,7 +59,7 @@ public class ComposeHtmlMsgWithHtmlSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ComposeMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ComposeMsgWithTextSignature.java
@@ -54,7 +54,7 @@ public class ComposeMsgWithTextSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/CreateTextSignatureAndAddInComposedHtmlMesage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/CreateTextSignatureAndAddInComposedHtmlMesage.java
@@ -47,7 +47,7 @@ public class CreateTextSignatureAndAddInComposedHtmlMesage extends UniversalComm
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/DeleteHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/DeleteHtmlSignature.java
@@ -61,7 +61,7 @@ public class DeleteHtmlSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.app.zPagePreferences.zNavigateTo();
 
 		logger.info("CreateSignature: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/DeleteTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/DeleteTextSignature.java
@@ -55,7 +55,7 @@ public class DeleteTextSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.app.zPagePreferences.zNavigateTo();
 
 		logger.info("CreateSignature: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/EditHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/EditHtmlSignature.java
@@ -57,7 +57,7 @@ public class EditHtmlSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.app.zPagePreferences.zNavigateTo();
 
 		logger.info("CreateSignature: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/EditTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/EditTextSignature.java
@@ -54,7 +54,7 @@ public class EditTextSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		this.app.zPagePreferences.zNavigateTo();
 
 		logger.info("CreateSignature: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ForwardMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ForwardMsgWithHtmlSignature.java
@@ -60,7 +60,7 @@ public class ForwardMsgWithHtmlSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ForwardMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ForwardMsgWithTextSignature.java
@@ -57,7 +57,7 @@ public class ForwardMsgWithTextSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyHtmlSignatureAboveIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyHtmlSignatureAboveIncludeMsg.java
@@ -56,7 +56,7 @@ public class FwdReplyHtmlSignatureAboveIncludeMsg extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyHtmlSignatureBelowIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyHtmlSignatureBelowIncludeMsg.java
@@ -58,7 +58,7 @@ public class FwdReplyHtmlSignatureBelowIncludeMsg extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyTextSignatureAboveIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyTextSignatureAboveIncludeMsg.java
@@ -56,7 +56,7 @@ public class FwdReplyTextSignatureAboveIncludeMsg extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyTextSignatureBelowIncludeMsg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/FwdReplyTextSignatureBelowIncludeMsg.java
@@ -55,7 +55,7 @@ public class FwdReplyTextSignatureBelowIncludeMsg extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyAllMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyAllMsgWithHtmlSignature.java
@@ -52,7 +52,7 @@ public class ReplyAllMsgWithHtmlSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyAllMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyAllMsgWithTextSignature.java
@@ -57,7 +57,7 @@ public class ReplyAllMsgWithTextSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithHtmlSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithHtmlSignature.java
@@ -52,7 +52,7 @@ public class ReplyMsgWithHtmlSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithTextSignature.java
@@ -57,7 +57,7 @@ public class ReplyMsgWithTextSignature extends UniversalCommonTest {
 						+ "</CreateSignatureRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithTwoThreeLineTextSignature.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyMsgWithTwoThreeLineTextSignature.java
@@ -97,7 +97,7 @@ public class ReplyMsgWithTwoThreeLineTextSignature extends UniversalCommonTest {
 						+ "</ModifyIdentityRequest>");
 
 		// Refresh UI
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		FolderItem inboxFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Inbox);
 		// Signature is created

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyToMsgWithSignatureContainingImage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/mail/signatures/ReplyToMsgWithSignatureContainingImage.java
@@ -78,7 +78,7 @@ public class ReplyToMsgWithSignatureContainingImage extends UniversalCommonTest 
 				+ "</CreateSignatureRequest>");
 
 		// Refresh UI so that signature get loaded
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 
 		logger.info("CreateSignature: finish");
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/outofoffice/ZimbraPrefOutOfOfficeReplyEnabledFalse.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/preferences/outofoffice/ZimbraPrefOutOfOfficeReplyEnabledFalse.java
@@ -53,7 +53,7 @@ public class ZimbraPrefOutOfOfficeReplyEnabledFalse extends UniversalCommonTest 
 						+ "<a n='zimbraPrefOutOfOfficeReply'>" + autoReplyMessage + "</a>"
 						+ "<a n='zimbraPrefOutOfOfficeStatusAlertOnLogin'>TRUE</a>" + "</ModifyAccountRequest>");
 		
-		app.zPageMain.sRefreshPage();
+		app.zPageMain.zRefreshUI();
 
 		// Client must display out of office dialog, wait for some time and take an action on it
 		SleepUtil.sleepLong();

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/search/search/SearchAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/search/search/SearchAppointment.java
@@ -102,7 +102,7 @@ public class SearchAppointment extends UniversalCommonTest {
 				null);
 
 		// Refresh the UI (work around due to active dialogs found when running as a second test and directly using app.zPageCalendar.zNavigateTo();)
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageCalendar.zNavigateTo();
 		
 		app.zPageCalendar.zListItem(Action.A_RIGHTCLICK, Button.O_VIEW_MENU, Button.O_VIEW_LIST_SUB_MENU, "List");

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/tasks/tags/CreateTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/tasks/tags/CreateTag.java
@@ -111,7 +111,7 @@ public class CreateTag extends UniversalCommonTest {
 		app.zPageTasks.zToolbarPressButton(Button.B_REFRESH);
 		
 		// Work around
-		app.zPageMain.sRefresh();
+		app.zPageMain.zRefreshMainUI();
 		app.zPageTasks.zNavigateTo();
 
 		// Create a new tag using the context menu + New Tag

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/archive/conversation/ArchiveZimletByConversationTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/archive/conversation/ArchiveZimletByConversationTest.java
@@ -64,7 +64,7 @@ public class ArchiveZimletByConversationTest extends PrefGroupMailByConversation
 			initializeArchiveFolder();
 
 			// Refresh UI
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 
 		}
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/archive/mail/ArchiveZimletByMessageTest.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/tests/zimlets/archive/mail/ArchiveZimletByMessageTest.java
@@ -65,7 +65,7 @@ public class ArchiveZimletByMessageTest extends PrefGroupMailByMessageTest {
 			initializeArchiveFolder();
 			
 			// To refresh the zimlet settings: Logout/Login
-			app.zPageMain.sRefresh();
+			app.zPageMain.zRefreshMainUI();
 			app.zPageMail.zNavigateTo();
 		}
 		

--- a/src/java/com/zimbra/qa/selenium/projects/universal/ui/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/ui/PageMain.java
@@ -322,7 +322,7 @@ public class PageMain extends AbsTab {
 			if (!zIndex.equals("auto") && !zIndex.equals("") && !zIndex.equals(null)
 					&& Integer.parseInt(zIndex) >= 700) {
 				logger.info("##### Found active dialog #####");
-				sRefresh();
+				zRefreshMainUI();
 				dialogLocators = webDriver().findElements(By.cssSelector("div[class^='Dwt'][class$='Dialog']"));
 				totalDialogs = dialogLocators.size();
 				for (int j = totalDialogs - 1; j >= 0; j--) {
@@ -547,7 +547,7 @@ public class PageMain extends AbsTab {
 		// Navigate to app
 		if (!appTab.zIsActive()) {
 
-			sRefresh();
+			zRefreshMainUI();
 			appTab.zNavigateTo();
 
 			// Check UI loading


### PR DESCRIPTION
ZCS-3117: Selenium: Fix entire remaining full suite along with providing possible fixes for intermittent failures

**(1) Renamed sRefresh to zRefresh related methods to better understand that starts with "s" is selenium core method an "z" is zimbra customized methods (AbsSeleniumObject.java):**

	// Refreshes UI without considering anything else
	public void zRefreshUI() throws HarnessException {

	// Refreshes UI till loading completes successfully
	public void zRefreshMainUI() throws HarnessException {

	// Refreshes UI till specified element gets visible 
	public Boolean zRefreshUITillElementPresent(String locator) throws HarnessException {

**(2) For fast execution, if there is some internal server error or anything in login page then below code will try 3 times for login objects check (AbsSeleniumObject.java):**

	((AppAjaxClient)MyApplication).zPageMain.zRefreshUITillElementPresent(Locators.zBtnLogin);

**(3) I think two tests failed on weekend when calling zReturnDayWeek method because work week not found during weekends, fixed using:**

	public String zReturnDayWeek(int number) throws HarnessException {
		String locator;
		if (zIsWeekend()) {
			locator = "css=div[id^='zv__CLW'] ";
		} else {
			locator = "css=div[id^='zv__CLWW'] ";
		}
		return sGetText(locator + "div[class='calendar_heading'] div[class^='calendar_heading_day']:nth-child(" + number + ")");
	}

**(4) Two calendar folder related tests failed because of unnecessary tooltip issue, fixed by hovering somewhere else using:**

	// Work around for discarding zimbra tooltip
	this.sMouseOver(Locators.ztih__main_Mail__ZIMLET_ID);
	SleepUtil.sleepVerySmall();

**(5) Drag n drop tests failed because of weekend/work week locator issue, fixed using:**

    // Drag and drop the item
    String locator;
	if (app.zPageCalendar.zIsWeekend()) {
		locator = "css=div[id^='zli__CLW__";
	} else {
		locator = "css=div[id^='zli__CLWW__";
	}

	// Select the item
	app.zPageCalendar.zDragAndDrop(
				locator + apptId + "'] td.appt_name",
				"css=td[id='zti__main_Calendar__" + subcalendarFolder.getId() + "_textCell']");

**(6) CheckFreeBusyURLLink_01 failed especially on weekend due to week/weekend locator issue, fixed using:**

	if (label.equals("Work Week") && app.zPageCalendar.zIsWeekend()) {
		app.zPageCalendar.sClickAt(Locators.WeekViewOnFBLink, "");
		SleepUtil.sleepMedium();
	}

**(7) WeeklyEveryXdayEndAfterYoccurrences_01 test failed because of counting recurring instances especially on weekend, fixed using:**

	// Go to next week and verify correct number of recurring instances
	int getNoOfInstances = 0;
	for (int i = 1; i <= 4; i++) {
		getNoOfInstances = app.zPageCalendar.zGetAppointmentCountWeekView(apptSubject) + getNoOfInstances;
		app.zPageCalendar.zToolbarPressButton(Button.B_NEXT_PAGE);
	}
	ZAssert.assertEquals(getNoOfInstances, noOfInstances, "Verify correct no. of recurring instances are present in calendar week view");

**(8) OpenTextAttachment_01 & OpenAttachmentInForwardEmail_01 test failed because of considering wrong window, fixed using:**

	for (String winHandle : webDriver.getWindowHandles()) {
		webDriver.switchTo().window(winHandle);
	}

**(9) ZimbraPrefCalendarFirstDayOfWeek_01 test failed on wrong week day consideration, fixed using:**

	ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(1), "Tue", "First day matched");
	ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(2), "Wed", "Second day matched");
	ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(3), "Thu", "Third day matched");
	ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(4), "Fri", "Fourth day matched");
	if (app.zPageCalendar.zIsWeekend()) {
		ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(5), "Sat", "Fifth day matched");
		ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(6), "Sun", "Sixth day matched");
		ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(7), "Mon", "Seventh day matched");
    } else {
		ZAssert.assertStringContains(app.zPageCalendar.zReturnDayWeek(5), "Mon", "Fifth day matched");
    }

**(10) Trash MoveAppointment_01 test failed because of week/weekend locator using, fixed using same way by taking week/work week locator, for e.g.**

	pulldownLocator = "css=td#zb__CLD__MOVE_MENU_dropdown>div";
			
	if (zIsWeekend()) {
		optionLocator = "css=td#zti__ZmFolderChooser_CalendarCLW__" + folder.getId() + "_textCell";
	} else {
		optionLocator = "css=td#zti__ZmFolderChooser_CalendarCLWW__" + folder.getId() + "_textCell";
	}

**(11) ChangeCustomColorWithExcludeFB regressed due to recent time change of all appointments, fixed it by using same time which we used earlier**

All build related issues are fixed by making changes in Ajax and Universal UI too, Universal project rest of the changes needs to be taken care by replacing entire project whenever Universal project selenium automation starts.