### PR TITLE
ZCS-3117: Setting start date, time, end date, time in sequence

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingUsingMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingUsingMessage.java
@@ -69,8 +69,8 @@ public class CreateMeetingUsingMessage extends AjaxCommonTest {
 
 		FormApptNew apptForm = new FormApptNew(app);
 		apptForm.zFillField(Field.StartDate, startUTC);
-		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.StartTime, startUTC);
+		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.EndTime, endUTC);
 		ZAssert.assertEquals(apptForm.zGetApptSubject(), subject, "Verify populated appointment subject from message");
 		ZAssert.assertStringContains(apptForm.zGetApptBodyHtml(), "Bold and Italics", "Verify populated appointment body from message");
@@ -130,8 +130,8 @@ public class CreateMeetingUsingMessage extends AjaxCommonTest {
 
 		FormApptNew apptForm = new FormApptNew(app);
 		apptForm.zFillField(Field.StartDate, startUTC);
-		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.StartTime, startUTC);
+		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.EndTime, endUTC);
 		ZAssert.assertEquals(apptForm.zGetApptSubject(), subject, "Verify populated appointment subject from message");
 		ZAssert.assertStringContains(apptForm.zGetApptBodyHtml(), content, "Verify populated appointment body from message");
@@ -190,8 +190,8 @@ public class CreateMeetingUsingMessage extends AjaxCommonTest {
 
 		FormApptNew apptForm = new FormApptNew(app);
 		apptForm.zFillField(Field.StartDate, startUTC);
-		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.StartTime, startUTC);
+		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.EndTime, endUTC);
 		ZAssert.assertEquals(apptForm.zGetApptSubject(), subject, "Verify populated appointment subject from message");
 		ZAssert.assertStringContains(apptForm.zGetApptBodyValue(), fullContent, "Verify populated appointment body from message");
@@ -250,8 +250,8 @@ public class CreateMeetingUsingMessage extends AjaxCommonTest {
 
 		FormApptNew apptForm = new FormApptNew(app);
 		apptForm.zFillField(Field.StartDate, startUTC);
-		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.StartTime, startUTC);
+		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.EndTime, endUTC);
 		ZAssert.assertEquals(apptForm.zGetApptSubject(), subject, "Verify populated appointment subject from message");
 		ZAssert.assertStringContains(apptForm.zGetApptBodyValue(), fullContent, "Verify populated appointment body from message");
@@ -309,8 +309,8 @@ public class CreateMeetingUsingMessage extends AjaxCommonTest {
 
 		FormApptNew apptForm = new FormApptNew(app);
 		apptForm.zFillField(Field.StartDate, startUTC);
-		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.StartTime, startUTC);
+		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.EndTime, endUTC);
 		ZAssert.assertEquals(apptForm.zGetApptSubject(), subject, "Verify populated appointment subject from message");
 		ZAssert.assertStringContains(apptForm.zGetApptBodyHtml(), content, "Verify populated appointment body from message");
@@ -368,8 +368,8 @@ public class CreateMeetingUsingMessage extends AjaxCommonTest {
 
 		FormApptNew apptForm = new FormApptNew(app);
 		apptForm.zFillField(Field.StartDate, startUTC);
-		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.StartTime, startUTC);
+		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.EndTime, endUTC);
 		ZAssert.assertEquals(apptForm.zGetApptSubject(), subject, "Verify populated appointment subject from message");
 		ZAssert.assertStringContains(apptForm.zGetApptBodyHtml(), content, "Verify populated appointment body from message");
@@ -428,10 +428,11 @@ public class CreateMeetingUsingMessage extends AjaxCommonTest {
 
 		FormApptNew apptForm = new FormApptNew(app);
 		apptForm.zFillField(Field.StartDate, startUTC);
-		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.StartTime, startUTC);
+		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.EndTime, endUTC);
 		ZAssert.assertEquals(apptForm.zGetApptSubject(), subject, "Verify populated appointment subject from message");
+		ZAssert.assertStringContains(apptForm.zGetApptBodyValue(), fullContent, "Verify populated appointment body from message");
 		apptForm.zSubmit();
 
 		// Verify appointment exists on the server
@@ -488,8 +489,8 @@ public class CreateMeetingUsingMessage extends AjaxCommonTest {
 
 		FormApptNew apptForm = new FormApptNew(app);
 		apptForm.zFillField(Field.StartDate, startUTC);
-		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.StartTime, startUTC);
+		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.EndTime, endUTC);
 		ZAssert.assertEquals(apptForm.zGetApptSubject(), subject, "Verify populated appointment subject from message");
 		ZAssert.assertStringContains(apptForm.zGetApptBodyValue(), fullContent, "Verify populated appointment body from message");
@@ -547,8 +548,8 @@ public class CreateMeetingUsingMessage extends AjaxCommonTest {
 
 		FormApptNew apptForm = new FormApptNew(app);
 		apptForm.zFillField(Field.StartDate, startUTC);
-		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.StartTime, startUTC);
+		apptForm.zFillField(Field.EndDate, endUTC);
 		apptForm.zFillField(Field.EndTime, endUTC);
 		ZAssert.assertEquals(apptForm.zGetApptSubject(), subject, "Verify populated appointment subject from message");
 		apptForm.zSubmit();


### PR DESCRIPTION
ZCS-3117: Setting start date, time, end date, time in sequence

![calendar result](https://user-images.githubusercontent.com/21263826/32603277-1c85e6e0-c56f-11e7-904b-8898ee01b8a0.png)
