### PR TITLE
ZCS-3577, ZCS-3112: Improve framework test PASSED/FAILED status and unique test entry in harness log file

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/util/staf/StafAbstract.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/staf/StafAbstract.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
@@ -32,6 +31,7 @@ import com.ibm.staf.STAFMarshallingContext;
 import com.ibm.staf.STAFResult;
 import com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain;
 import com.zimbra.qa.selenium.framework.util.*;
+import com.zimbra.qa.selenium.staf.StafIntegration;
 
 /**
  * A wrapper class to create STAF classes
@@ -50,14 +50,6 @@ public class StafAbstract {
 	protected STAFResult StafResult = null;
 	protected String StafResponse = null;
 
-	// STAF log
-	public String sHarnessLogFileName = "STAF.log";
-	public String sHarnessLogFileFolderPath;
-	public String sHarnessLogFilePath;
-	public Path pHarnessLogFilePath;
-	public File fHarnessLogFile;
-	public File fHarnessLogFileFolder;
-
 	public StafAbstract() {
 		logger.info("new "+ StafAbstract.class.getCanonicalName());
 
@@ -65,18 +57,19 @@ public class StafAbstract {
 		StafService = "PING";
 		StafParms = "PING";
 
-		// Harness log
-		sHarnessLogFileFolderPath = "C:\\";
-		sHarnessLogFilePath = sHarnessLogFileFolderPath + "\\" + sHarnessLogFileName;
-		pHarnessLogFilePath = Paths.get(sHarnessLogFileFolderPath, sHarnessLogFileName);
-		fHarnessLogFile = new File(sHarnessLogFilePath);
-		fHarnessLogFileFolder = new File(sHarnessLogFileFolderPath);
-		if (!fHarnessLogFileFolder.exists()) {
-			fHarnessLogFileFolder.mkdirs();
+		// STAF log
+		StafIntegration.sSTAFLogFileFolderPath = ExecuteHarnessMain.testoutputfoldername + "/debug/projects";
+		StafIntegration.sSTAFLogFilePath = StafIntegration.sSTAFLogFileFolderPath + "\\" + StafIntegration.sSTAFLogFileName;
+		StafIntegration.pSTAFLogFilePath = Paths.get(StafIntegration.sSTAFLogFileFolderPath, StafIntegration.sSTAFLogFileName);
+		StafIntegration.fSTAFLogFile = new File(StafIntegration.sSTAFLogFilePath);
+		StafIntegration.fSTAFLogFileFolder = new File(StafIntegration.sSTAFLogFileFolderPath);
+		if (!StafIntegration.fSTAFLogFileFolder.exists()) {
+			StafIntegration.fSTAFLogFileFolder.mkdirs();
 		}
 		try {
-			fHarnessLogFile.delete();
-			fHarnessLogFile.createNewFile();
+			if (!StafIntegration.fSTAFLogFile.exists()) {
+				StafIntegration.fSTAFLogFile.createNewFile();
+			}
 		} catch (IOException e1) {
 			e1.printStackTrace();
 		}
@@ -209,7 +202,7 @@ public class StafAbstract {
 		logger.info("STAF Command: " + getStafCommand(StafServer));
 
 		try {
-			Files.write(pHarnessLogFilePath, Arrays.asList("STAF Command: " + getStafCommand(StafServer) + "\n"),
+			Files.write(StafIntegration.pSTAFLogFilePath, Arrays.asList("STAF Command: " + getStafCommand(StafServer) + "\n"),
 					Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 		} catch (IOException e) {
 			e.printStackTrace();
@@ -247,11 +240,11 @@ public class StafAbstract {
         try {
         	if (StafResult.rc == STAFResult.Ok) {
         		logger.info("STAF Response (success): " + StafResponse);
-				Files.write(pHarnessLogFilePath, Arrays.asList("STAF Response (success): " + StafResponse + "\n"),
+				Files.write(StafIntegration.pSTAFLogFilePath, Arrays.asList("STAF Response (success): " + StafResponse + "\n"),
 						Charset.forName("UTF-8"), StandardOpenOption.APPEND);
         	} else {
         		logger.info("STAF Response (failed): " + StafResponse);
-        		Files.write(pHarnessLogFilePath, Arrays.asList("STAF Response: (failed): " + StafResponse + "\n"),
+				Files.write(StafIntegration.pSTAFLogFilePath, Arrays.asList("STAF Response: (failed): " + StafResponse + "\n"),
 						Charset.forName("UTF-8"), StandardOpenOption.APPEND);
         	}
 		} catch (IOException e) {


### PR DESCRIPTION
ZCS-3577, ZCS-3112: Improve framework test PASSED/FAILED status and unique test entry in harness log file

1. Harness.log will show whether test PASSED or FAILED?
![harnesslog](https://user-images.githubusercontent.com/21263826/32712092-b0255e2a-c868-11e7-859b-6cd85f7ff2eb.png)
![test passed-failed status](https://user-images.githubusercontent.com/21263826/32712104-bc7bdac8-c868-11e7-8440-d45e6167b022.png)

2. STAF.log would be available in portal at same location where harness.log present with all STAF commands output.
![staflog](https://user-images.githubusercontent.com/21263826/32712118-dcbe3b3c-c868-11e7-8e63-e11c240a1084.png)

3. Removed drawbacks of overwriting test-output everytime. It would create new folder according to current time.
![separate runwise folder](https://user-images.githubusercontent.com/21263826/32712233-8518725c-c869-11e7-95bd-c1e7574706e9.png)

4. Added hour and minutes instead of seconds execution time. It may need some improvement, will do after seeing how these changes goes for long runs.

5. Fixed retry count to count retriedTests list instead of count.  It may need some improvement, will do after seeing how these changes goes for individual runs and nature of retry.

6. Code optimization and made more simple to manage harness and STAF from single location StafIntegration.java.