### PR TITLE
ZCS-3297: Fix for remaining calendar and mail test cases for MS Edge browser

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithMultilineBody.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingWithMultilineBody.java
@@ -138,7 +138,7 @@ public class CreateMeetingWithMultilineBody extends AjaxCommonTest {
 		apptForm.zFillField(Field.Attendees, attendees);
 
 		// Enter multiline body plain text
-		apptForm.sFocus(Locators.zPlainTextBodyField);
+		apptForm.sClick(Locators.zPlainTextBodyField);
 		apptForm.zKeyboard.zTypeCharacters("Plain text line 1");
 		apptForm.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ENTER);
 		apptForm.zKeyboard.zTypeCharacters("Plain text line two");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/CreateMailText.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/CreateMailText.java
@@ -84,7 +84,7 @@ public class CreateMailText extends PrefGroupMailByMessageTest {
 		mailform.zFillField(Field.Subject, subject);
 
 		// Enter multiline plain text
-		mailform.sFocus(Locators.zPlainTextBodyField);
+		mailform.sClick(Locators.zPlainTextBodyField);
 		mailform.zKeyboard.zTypeCharacters("Plain text line 1");
 		mailform.zKeyboard.zTypeKeyEvent(KeyEvent.VK_ENTER);
 		mailform.zKeyboard.zTypeCharacters("Plain text line two");


### PR DESCRIPTION
Fixed below mentioned tests: 
com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.CreateMailText:CreateMailWithMultilineText_02
com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.organizer.singleday.create.CreateMeetingWithMultilineBody:CreateMeetingWithMultilinePlainTextBody_02

![remainingmailedge](https://user-images.githubusercontent.com/15122239/32771271-369fa372-c948-11e7-874e-0a30d849cd7d.JPG)
![remainingcalendaredge](https://user-images.githubusercontent.com/15122239/32771272-36cc7672-c948-11e7-9dbd-bdca70a64dea.JPG)
