### PR TITLE
ZCS-3659: Fix for the failing CheckMTASettings test case in Admin console full suite

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/MTA/CheckMTASettings.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/MTA/CheckMTASettings.java
@@ -47,9 +47,6 @@ public class CheckMTASettings extends AdminCommonTest {
 
 	public CheckMTASettings() {
 		logger.info("New "+ CheckMTASettings.class.getCanonicalName());
-
-		//All the test tests start from Global settings page
-		super.startingPage = app.zPageManageGlobalSettings;
 	}
 
 	/**
@@ -97,7 +94,8 @@ public class CheckMTASettings extends AdminCommonTest {
 			}
 			ZAssert.assertTrue(present, "MTA restriction changes are not reflected in SOAP response");
 
-			// Navigating to MTA configuration page to make MTA configuration changes through Admin UI 
+			// Navigating to MTA configuration page to make MTA configuration changes through Admin UI
+			app.zPageManageGlobalSettings.zNavigateTo();
 			app.zPageManageMTA.zNavigateTo();
 			SleepUtil.sleepMedium();
 


### PR DESCRIPTION
Initially, the test case was written considering that the Admin console would check the existing MTA settings done through CLI and update the new MTA settings done through UI based on that. This would not require Admin console refresh in between.

Later, it was found that this was a generic issue with Admin console. For many other such configurations, admin console needs to be refreshed explicitly to consider the changes done through CLI otherwise changes done through UI will also overwrite the changes done through CLI

So, the test case has been updated as per the existing admin console flow to update MTA settings through CLI and UI. 