### PR TITLE
ZCS-3608: Resetting admin account when test fails and replaced commontTest to core

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAdminAccount.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAdminAccount.java
@@ -265,11 +265,6 @@ public class ZimbraAdminAccount extends ZimbraAccount {
 		return (_AdminConsoleAdmin);
 	}
 
-	public static synchronized void ResetAccountAdminConsoleAdmin() {
-		logger.warn("AdminConsoleAdmin is being reset");
-		_AdminConsoleAdmin = null;
-	}
-
 	private static ZimbraAdminAccount _AdminConsoleAdmin = null;
 
 	/**
@@ -279,9 +274,11 @@ public class ZimbraAdminAccount extends ZimbraAccount {
 	 * server2, then all accounts need to be reset, otherwise the second request
 	 * will have references to server1.
 	 */
-	public static void reset() {
-		ZimbraAdminAccount._AdminConsoleAdmin = null;
-		ZimbraAdminAccount._GlobalAdmin = null;
+	public static synchronized void ResetAdminAccount() {
+		logger.warn("AdminConsoleAdmin is being reset");
+		_AdminConsoleAdmin = null;
+		_GlobalAdmin = null;
+		AdminConsoleAdmin();
 	}
 
 	/**

--- a/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCore.java
@@ -93,7 +93,7 @@ public class AdminCore {
 	}
 
 	@BeforeSuite(groups = { "always" })
-	public void commonTestBeforeSuite() throws HarnessException {
+	public void coreBeforeSuite() throws HarnessException {
 
 		logger.info("BeforeSuite: start");
 
@@ -149,13 +149,13 @@ public class AdminCore {
 	}
 
 	@BeforeClass(groups = { "always" })
-	public void commonTestBeforeClass() throws HarnessException {
+	public void coreBeforeClass() throws HarnessException {
 		logger.info("BeforeClass: start");
 		logger.info("BeforeClass: finish");
 	}
 
 	@BeforeMethod(groups = { "always" })
-	public void commonTestBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
+	public void coreBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
 		logger.info("BeforeMethod: start");
 
 		// Get the test name & description
@@ -181,7 +181,7 @@ public class AdminCore {
 		// If a startinAccount is defined, then make sure we are authenticated
 		// as that user
 		if (startingAccount != null) {
-			logger.debug("commonTestBeforeMethod: startingAccount is defined");
+			logger.debug("coreBeforeMethod: startingAccount is defined");
 
 			zHandleNetworkModulesNGDialog();
 
@@ -221,7 +221,7 @@ public class AdminCore {
 
 		// If a startingPage is defined, then make sure we are on that page
 		if (startingPage != null) {
-			logger.debug("commonTestBeforeMethod: startingPage is defined");
+			logger.debug("coreBeforeMethod: startingPage is defined");
 
 			// If the starting page is not active, navigate to it
 			if (!startingPage.zIsActive()) {
@@ -264,7 +264,7 @@ public class AdminCore {
 	}
 
 	@AfterSuite(groups = { "always" })
-	public void commonTestAfterSuite() throws HarnessException, IOException {
+	public void coreAfterSuite() throws HarnessException, IOException {
 		logger.info("AfterSuite: start");
 
 		if (ConfigProperties.getStringProperty("javascript.errors.report").equals("true")) {
@@ -284,13 +284,13 @@ public class AdminCore {
 	}
 
 	@AfterClass(groups = { "always" })
-	public void commonTestAfterClass() throws HarnessException {
+	public void coreAfterClass() throws HarnessException {
 		logger.info("AfterClass: start");
 		logger.info("AfterClass: finish");
 	}
 
 	@AfterMethod(groups = { "always" })
-	public void commonTestAfterMethod(Method method, ITestResult testResult) throws HarnessException, IOException {
+	public void coreAfterMethod(Method method, ITestResult testResult) throws HarnessException, IOException {
 		logger.info("AfterMethod: start");
 
 		if (ConfigProperties.getStringProperty("javascript.errors.report").equals("true")) {
@@ -450,7 +450,7 @@ public class AdminCore {
 
 		// Get test PASSED/FAILED status
 		if (testResult.getStatus() == ITestResult.FAILURE){
-			app.zPageMain.zRefreshMainUI();
+			ZimbraAdminAccount.ResetAdminAccount();
 		}
 
 		logger.info("AfterMethod: finish");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
@@ -89,7 +89,7 @@ public class AjaxCore {
 	}
 
 	@BeforeSuite(groups = { "always" })
-	public void commonTestBeforeSuite() throws HarnessException, IOException, InterruptedException, SAXException {
+	public void coreBeforeSuite() throws HarnessException, IOException, InterruptedException, SAXException {
 
 		logger.info("BeforeSuite: start");
 		ZimbraAccount.ResetAccountZCS();
@@ -138,13 +138,13 @@ public class AjaxCore {
 	}
 
 	@BeforeClass(groups = { "always" })
-	public void commonTestBeforeClass() throws HarnessException {
+	public void coreBeforeClass() throws HarnessException {
 		logger.info("BeforeClass: start");
 		logger.info("BeforeClass: finish");
 	}
 
 	@BeforeMethod(groups = { "always" })
-	public void commonTestBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
+	public void coreBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
 
 		logger.info("BeforeMethod: start");
 
@@ -257,7 +257,7 @@ public class AjaxCore {
 	}
 
 	@AfterSuite(groups = { "always" })
-	public void commonTestAfterSuite() throws HarnessException, IOException {
+	public void coreAfterSuite() throws HarnessException, IOException {
 		logger.info("AfterSuite: start");
 
 		if (ConfigProperties.getStringProperty("javascript.errors.report").equals("true")) {
@@ -276,7 +276,7 @@ public class AjaxCore {
 	}
 
 	@AfterClass(groups = { "always" })
-	public void commonTestAfterClass() throws HarnessException {
+	public void coreAfterClass() throws HarnessException {
 		logger.info("AfterClass: start");
 
 		ZimbraAccount currentAccount = app.zGetActiveAccount();
@@ -288,7 +288,7 @@ public class AjaxCore {
 	}
 
 	@AfterMethod(groups = { "always" })
-	public void commonTestAfterMethod(Method method, ITestResult testResult) throws HarnessException, IOException {
+	public void coreAfterMethod(Method method, ITestResult testResult) throws HarnessException, IOException {
 		logger.info("AfterMethod: start");
 
 		if (ZimbraURI.needsReload()) {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/QuickCommandSettings.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/QuickCommandSettings.java
@@ -218,7 +218,6 @@ public class QuickCommandSettings extends AjaxCore {
 		// Re-login to pick up the new preferences
 		app.zPageMain.zRefreshMainUI();
 
-		// The AjaxCommonTest.commonTestBeforeMethod() method will log into the client
 		logger.info("addQuickCommands: finish");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/html/core/HtmlCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/html/core/HtmlCore.java
@@ -69,8 +69,8 @@ public class HtmlCore {
 	 * @throws SAXException 
 	 */
 	@BeforeSuite( groups = { "always" } )
-	public void commonTestBeforeSuite() throws HarnessException {
-		logger.info("commonTestBeforeSuite: start");
+	public void coreBeforeSuite() throws HarnessException {
+		logger.info("coreBeforeSuite: start");
 
 
 		ConfigProperties.setAppType(ConfigProperties.AppType.HTML);
@@ -114,27 +114,27 @@ public class HtmlCore {
 		}
 
 
-		logger.info("commonTestBeforeSuite: finish");		
+		logger.info("coreBeforeSuite: finish");		
 	}
 
 	@BeforeClass( groups = { "always" } )
-	public void commonTestBeforeClass() throws HarnessException {
-		logger.info("commonTestBeforeClass: start");
+	public void coreBeforeClass() throws HarnessException {
+		logger.info("coreBeforeClass: start");
 
-		logger.info("commonTestBeforeClass: finish");
+		logger.info("coreBeforeClass: finish");
 
 	}
 
 	@BeforeMethod( groups = { "always" } )
-	public void commonTestBeforeMethod() throws HarnessException {
-		logger.info("commonTestBeforeMethod: start");
+	public void coreBeforeMethod() throws HarnessException {
+		logger.info("coreBeforeMethod: start");
 
 
 		// If test account preferences are defined, then make sure the test account
 		// uses those preferences
 		//
 		if ( (startingAccountPreferences != null) && (!startingAccountPreferences.isEmpty()) ) {
-			logger.debug("commonTestBeforeMethod: startingAccountPreferences are defined");
+			logger.debug("coreBeforeMethod: startingAccountPreferences are defined");
 
 			StringBuilder settings = new StringBuilder();
 			for (Map.Entry<String, String> entry : startingAccountPreferences.entrySet()) {
@@ -155,13 +155,13 @@ public class HtmlCore {
 		// uses those zimlet preferences
 		//
 		if ( (startingAccountZimletPreferences != null) && (!startingAccountZimletPreferences.isEmpty()) ) {
-			logger.debug("commonTestBeforeMethod: startingAccountPreferences are defined");
+			logger.debug("coreBeforeMethod: startingAccountPreferences are defined");
 			ZimbraAccount.AccountZCS().modifyUserZimletPreferences(startingAccountZimletPreferences);
 		}
 
 		// If AccountZCS is not currently logged in, then login now
 		if ( !ZimbraAccount.AccountZCS().equals(app.zGetActiveAccount()) ) {
-			logger.debug("commonTestBeforeMethod: AccountZCS is not currently logged in");
+			logger.debug("coreBeforeMethod: AccountZCS is not currently logged in");
 
 			if ( app.zPageMain.zIsActive() )
 				app.zPageMain.zLogout();
@@ -177,7 +177,7 @@ public class HtmlCore {
 
 		// If a startingPage is defined, then make sure we are on that page
 		if ( startingPage != null ) {
-			logger.debug("commonTestBeforeMethod: startingPage is defined");
+			logger.debug("coreBeforeMethod: startingPage is defined");
 
 			// If the starting page is not active, navigate to it
 			if ( !startingPage.zIsActive() ) {
@@ -191,20 +191,20 @@ public class HtmlCore {
 
 		}
 
-		logger.info("commonTestBeforeMethod: finish");
+		logger.info("coreBeforeMethod: finish");
 
 	}
 
 	@AfterSuite( groups = { "always" } )
-	public void commonTestAfterSuite() throws HarnessException {
-		logger.info("commonTestAfterSuite: start");
+	public void coreAfterSuite() throws HarnessException {
+		logger.info("coreAfterSuite: start");
 		webDriver.quit();
-		logger.info("commonTestAfterSuite: finish");
+		logger.info("coreAfterSuite: finish");
 	}
 
 	@AfterClass( groups = { "always" } )
-	public void commonTestAfterClass() throws HarnessException {
-		logger.info("commonTestAfterClass: start");
+	public void coreAfterClass() throws HarnessException {
+		logger.info("coreAfterClass: start");
 
 		// For Ajax and Html, if account is considered dirty (modified),
 		// then recreate a new account
@@ -217,7 +217,7 @@ public class HtmlCore {
 
 		}
 
-		logger.info("commonTestAfterClass: finish");
+		logger.info("coreAfterClass: finish");
 	}
 
 	/**
@@ -226,10 +226,10 @@ public class HtmlCore {
 	 * @throws HarnessException
 	 */
 	@AfterMethod( groups = { "always" } )
-	public void commonTestAfterMethod() throws HarnessException {
-		logger.info("commonTestAfterMethod: start");
+	public void coreAfterMethod() throws HarnessException {
+		logger.info("coreAfterMethod: start");
 
-		logger.info("commonTestAfterMethod: finish");
+		logger.info("coreAfterMethod: finish");
 	}
 
 }

--- a/src/java/com/zimbra/qa/selenium/projects/mobile/core/MobileCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/mobile/core/MobileCore.java
@@ -73,8 +73,8 @@ public class MobileCore {
 	 * @throws HarnessException
 	 */
 	@BeforeSuite( groups = { "always" } )
-	public void commonTestBeforeSuite() throws HarnessException {
-		logger.info("commonTestBeforeSuite: start");
+	public void coreBeforeSuite() throws HarnessException {
+		logger.info("coreBeforeSuite: start");
 
 
 
@@ -127,7 +127,7 @@ public class MobileCore {
 			throw e;
 		}
 
-		logger.info("commonTestBeforeSuite: finish");		
+		logger.info("coreBeforeSuite: finish");		
 	}
 	
 	/**
@@ -136,24 +136,24 @@ public class MobileCore {
 	 * @throws HarnessException
 	 */
 	@BeforeClass( groups = { "always" } )
-	public void commonTestBeforeClass() throws HarnessException {
-		logger.info("commonTestBeforeClass: start");
+	public void coreBeforeClass() throws HarnessException {
+		logger.info("coreBeforeClass: start");
 
-		logger.info("commonTestBeforeClass: finish");
+		logger.info("coreBeforeClass: finish");
 
 	}
 
 	/**
 	 * Global BeforeMethod
 	 * 
-	 * 1. For all tests, make sure the CommonTest.startingPage is active
+	 * 1. For all tests, make sure the startingPage is active
 	 * 2. For all tests, make sure the logged in user is 
 	 * 
 	 * @throws HarnessException
 	 */
 	@BeforeMethod( groups = { "always" } )
-	public void commonTestBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
-		logger.info("commonTestBeforeMethod: start");
+	public void coreBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
+		logger.info("coreBeforeMethod: start");
 
 		
 		// Get the test description
@@ -177,7 +177,7 @@ public class MobileCore {
 
 	      // If a startinAccount is defined, then make sure we are authenticated as that user
 		if ( startingAccount != null ) {
-			logger.debug("commonTestBeforeMethod: startingAccount is defined");
+			logger.debug("coreBeforeMethod: startingAccount is defined");
 
 			if ( !startingAccount.equals(app.zGetActiveAccount())) {
 
@@ -195,7 +195,7 @@ public class MobileCore {
 
 		// If a startingPage is defined, then make sure we are on that page
 		if ( startingPage != null ) {
-			logger.debug("commonTestBeforeMethod: startingPage is defined");
+			logger.debug("coreBeforeMethod: startingPage is defined");
 			
 			// If the starting page is not active, navigate to it
 			if ( !startingPage.zIsActive() ) {
@@ -210,7 +210,7 @@ public class MobileCore {
 		}
 		
 
-		logger.info("commonTestBeforeMethod: finish");
+		logger.info("coreBeforeMethod: finish");
 
 	}
 
@@ -220,10 +220,10 @@ public class MobileCore {
 	 * @throws HarnessException
 	 */
 	@AfterSuite( groups = { "always" } )
-	public void commonTestAfterSuite() throws HarnessException {	
-		logger.info("commonTestAfterSuite: start");
+	public void coreAfterSuite() throws HarnessException {	
+		logger.info("coreAfterSuite: start");
 		webDriver.quit();
-		logger.info("commonTestAfterSuite: finish");
+		logger.info("coreAfterSuite: finish");
 
 	}
 	
@@ -233,10 +233,10 @@ public class MobileCore {
 	 * @throws HarnessException
 	 */
 	@AfterClass( groups = { "always" } )
-	public void commonTestAfterClass() throws HarnessException {
-		logger.info("commonTestAfterClass: start");
+	public void coreAfterClass() throws HarnessException {
+		logger.info("coreAfterClass: start");
 		
-		logger.info("commonTestAfterClass: finish");
+		logger.info("coreAfterClass: finish");
 	}
 
 	/**
@@ -245,12 +245,12 @@ public class MobileCore {
 	 * @throws HarnessException
 	 */
 	@AfterMethod( groups = { "always" } )
-	public void commonTestAfterMethod(Method method, ITestResult testResult)
+	public void coreAfterMethod(Method method, ITestResult testResult)
 	throws HarnessException {
-		logger.info("commonTestAfterMethod: start");
+		logger.info("coreAfterMethod: start");
 
 
-      logger.info("commonTestAfterMethod: finish");
+      logger.info("coreAfterMethod: finish");
 	}
 
 }

--- a/src/java/com/zimbra/qa/selenium/projects/touch/core/TouchCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/core/TouchCore.java
@@ -62,9 +62,9 @@ public class TouchCore {
 	}
 
 	@BeforeSuite( groups = { "always" } )
-	public void commonTestBeforeSuite()
+	public void coreBeforeSuite()
 	throws HarnessException, IOException, InterruptedException, SAXException {
-		logger.info("commonTestBeforeSuite: start");
+		logger.info("coreBeforeSuite: start");
 		ZimbraAccount.ResetAccountZCS();
 
 		try
@@ -109,7 +109,7 @@ public class TouchCore {
 			logger.warn(e);
 		}
 
-		logger.info("commonTestBeforeSuite: finish");
+		logger.info("coreBeforeSuite: finish");
 	}
 
 	/**
@@ -118,10 +118,10 @@ public class TouchCore {
 	 * @throws HarnessException
 	 */
 	@BeforeClass( groups = { "always" } )
-	public void commonTestBeforeClass() throws HarnessException {
-		logger.info("commonTestBeforeClass: start");
+	public void coreBeforeClass() throws HarnessException {
+		logger.info("coreBeforeClass: start");
 
-		logger.info("commonTestBeforeClass: finish");
+		logger.info("coreBeforeClass: finish");
 
 	}
 
@@ -139,8 +139,8 @@ public class TouchCore {
 	 * @throws HarnessException
 	 */
 	@BeforeMethod( groups = { "always" } )
-	public void commonTestBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
-		logger.info("commonTestBeforeMethod: start");
+	public void coreBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
+		logger.info("coreBeforeMethod: start");
 
 
 		// Get the test description
@@ -166,12 +166,12 @@ public class TouchCore {
 		// uses those preferences
 		//
 		if ( (startingAccountPreferences != null) && (!startingAccountPreferences.isEmpty()) ) {
-			logger.debug("commonTestBeforeMethod: startingAccountPreferences are defined");
+			logger.debug("coreBeforeMethod: startingAccountPreferences are defined");
 
 			// If the current test accounts preferences match, then the account can be used
 			if ( !ZimbraAccount.AccountZCS().compareAccountPreferences(startingAccountPreferences) ) {
 
-				logger.debug("commonTestBeforeMethod: startingAccountPreferences do not match active account");
+				logger.debug("coreBeforeMethod: startingAccountPreferences do not match active account");
 
 				// Reset the account
 				ZimbraAccount.ResetAccountZCS();
@@ -187,7 +187,7 @@ public class TouchCore {
 
 		// If AccountZCS is not currently logged in, then login now
 		if ( !ZimbraAccount.AccountZCS().equals(app.zGetActiveAccount()) ) {
-			logger.debug("commonTestBeforeMethod: AccountZCS is not currently logged in");
+			logger.debug("coreBeforeMethod: AccountZCS is not currently logged in");
 
 			if ( app.zPageMain.zIsActive() )
 				try {
@@ -206,7 +206,7 @@ public class TouchCore {
 
 		// If a startingPage is defined, then make sure we are on that page
 		if ( startingPage != null ) {
-			logger.debug("commonTestBeforeMethod: startingPage is defined");
+			logger.debug("coreBeforeMethod: startingPage is defined");
 
 			// If the starting page is not active, navigate to it
 			if ( !startingPage.zIsActive() ) {
@@ -220,20 +220,20 @@ public class TouchCore {
 
 		}
 
-		logger.info("commonTestBeforeMethod: finish");
+		logger.info("coreBeforeMethod: finish");
 
 	}
 
 	@AfterSuite( groups = { "always" } )
-	public void commonTestAfterSuite() throws HarnessException {
-		logger.info("commonTestAfterSuite: start");
+	public void coreAfterSuite() throws HarnessException {
+		logger.info("coreAfterSuite: start");
 		webDriver.quit();
-		logger.info("commonTestAfterSuite: finish");
+		logger.info("coreAfterSuite: finish");
 	}
 
 	@AfterClass( groups = { "always" } )
-	public void commonTestAfterClass() throws HarnessException {
-		logger.info("commonTestAfterClass: start");
+	public void coreAfterClass() throws HarnessException {
+		logger.info("coreAfterClass: start");
 
 		// For Touch, if account is considered dirty (modified),
 		// then recreate a new account, but for the zimlet
@@ -246,7 +246,7 @@ public class TouchCore {
 
 		}
 
-		logger.info("commonTestAfterClass: finish");
+		logger.info("coreAfterClass: finish");
 	}
 
 	/**
@@ -255,9 +255,9 @@ public class TouchCore {
 	 * @throws HarnessException
 	 */
 	@AfterMethod( groups = { "always" } )
-	public void commonTestAfterMethod(Method method, ITestResult testResult)
+	public void coreAfterMethod(Method method, ITestResult testResult)
 	throws HarnessException {
-		logger.info("commonTestAfterMethod: start");
+		logger.info("coreAfterMethod: start");
 
 
 		// If the active URL does not match the base URL, then
@@ -288,7 +288,7 @@ public class TouchCore {
             //app.zPageLogin.sOpen(ConfigProperties.getBaseURL());
         }
 
-		logger.info("commonTestAfterMethod: finish");
+		logger.info("coreAfterMethod: finish");
 	}
 
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/core/QuickCommandSettings.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/core/QuickCommandSettings.java
@@ -232,7 +232,6 @@ public class QuickCommandSettings extends UniversalCore {
 		// Re-login to pick up the new preferences
 		app.zPageMain.zRefreshMainUI();
 
-		// The UniversalCommonTest.commonTestBeforeMethod() method will log into the client
 		logger.info("addQuickCommands: finish");
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/universal/core/UniversalCore.java
@@ -86,7 +86,7 @@ public class UniversalCore {
 	}
 
 	@BeforeSuite(groups = { "always" })
-	public void commonTestBeforeSuite() throws HarnessException, IOException, InterruptedException, SAXException {
+	public void coreBeforeSuite() throws HarnessException, IOException, InterruptedException, SAXException {
 
 		logger.info("BeforeSuite: start");
 		ZimbraAccount.ResetAccountZCS();
@@ -135,13 +135,13 @@ public class UniversalCore {
 	}
 
 	@BeforeClass(groups = { "always" })
-	public void commonTestBeforeClass() throws HarnessException {
+	public void coreBeforeClass() throws HarnessException {
 		logger.info("BeforeClass: start");
 		logger.info("BeforeClass: finish");
 	}
 
 	@BeforeMethod(groups = { "always" })
-	public void commonTestBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
+	public void coreBeforeMethod(Method method, ITestContext testContext) throws HarnessException {
 
 		logger.info("BeforeMethod: start");
 
@@ -260,7 +260,7 @@ public class UniversalCore {
 	}
 
 	@AfterSuite(groups = { "always" })
-	public void commonTestAfterSuite() throws HarnessException, IOException {
+	public void coreAfterSuite() throws HarnessException, IOException {
 		logger.info("AfterSuite: start");
 
 		if (ConfigProperties.getStringProperty("javascript.errors.report").equals("true")) {
@@ -279,7 +279,7 @@ public class UniversalCore {
 	}
 
 	@AfterClass(groups = { "always" })
-	public void commonTestAfterClass() throws HarnessException {
+	public void coreAfterClass() throws HarnessException {
 		logger.info("AfterClass: start");
 
 		ZimbraAccount currentAccount = app.zGetActiveAccount();
@@ -291,7 +291,7 @@ public class UniversalCore {
 	}
 
 	@AfterMethod(groups = { "always" })
-	public void commonTestAfterMethod(Method method, ITestResult testResult) throws HarnessException, IOException {
+	public void coreAfterMethod(Method method, ITestResult testResult) throws HarnessException, IOException {
 		logger.info("AfterMethod: start");
 
 		if (ZimbraURI.needsReload()) {


### PR DESCRIPTION
ZCS-3608: Resetting admin account when test fails and replaced commontTest to core

One problem needs to be addressed separately - reset-ed admin account is not used in admin console login which is P2 separate issue because starting page fixed due to removal of refresh for now. Also admin console UI is same although account gets reset-ed unlike Ajax client.