### PR TITLE
ZCS-3608: Fixed LimitZimlets testcase which was passing wrongly in the past

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitThemes.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitThemes.java
@@ -36,13 +36,14 @@ public class LimitThemes extends AdminCore {
 	}
 
 
-	@Test (description = "Edit account - Verify option 'Limit Themes available to this user to:'",
+	@Test (description = "Modify account to verify limited themes available",
 			groups = { "smoke", "L1" })
 
 	public void LimitThemes_01() throws HarnessException {
 
 		// Create a new account in the Admin Console using SOAP
-		AccountItem account = new AccountItem("email" + ConfigProperties.getUniqueString(),ConfigProperties.getStringProperty("testdomain"));
+		AccountItem account = new AccountItem("email" + ConfigProperties.getUniqueString(), ConfigProperties.getStringProperty("testdomain"));
+
 		ZimbraAdminAccount.AdminConsoleAdmin().soapSend(
 				"<CreateAccountRequest xmlns='urn:zimbraAdmin'>"
 						+			"<name>" + account.getEmailAddress() + "</name>"
@@ -60,7 +61,7 @@ public class LimitThemes extends AdminCore {
 		// Click on themes tab
 		app.zPageEditAccount.zToolbarPressButton(Button.B_THEMES);
 
-		// Set available skin
+		// Set available theme
 		form.zLimitThemes(theme);
 
 		// Save the changes
@@ -71,8 +72,11 @@ public class LimitThemes extends AdminCore {
 				"<GetAccountRequest xmlns='urn:zimbraAdmin'>"
 						+			"<account by='name'>"+ account.getEmailAddress() +"</account>"
 						+		"</GetAccountRequest>");
-		Element response = ZimbraAdminAccount.AdminConsoleAdmin().soapSelectNode("//admin:GetAccountResponse/admin:account/admin:a[@n='zimbraAvailableSkin']", 1);
+
+		Element response = ZimbraAdminAccount.AdminConsoleAdmin()
+				.soapSelectNode("//admin:GetAccountResponse/admin:account/admin:a[@n='zimbraAvailableSkin']", 1);
+
 		ZAssert.assertNotNull(response, "Verify the account is edited successfully");
-		ZAssert.assertStringContains(response.toString(),"harmony", "Verify mail feature is disabled");
+		ZAssert.assertStringContains(response.toString(),"harmony", "Verify limited ");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitZimlets.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitZimlets.java
@@ -35,7 +35,7 @@ public class LimitZimlets extends AdminCore {
 		super.startingPage = app.zPageManageAccounts;
 	}
 
-	@Test (description = "Edit account - Verify option 'Limit Zimlets available to this user to:'",
+	@Test (description = "Modify account to verify limited Zimlets available",
 			groups = { "smoke", "L1" })
 
 	public void LimitZimlets_01() throws HarnessException {
@@ -48,8 +48,7 @@ public class LimitZimlets extends AdminCore {
 						+			"<password>test123</password>"
 						+		"</CreateAccountRequest>");
 
-		String zimlet="com_zimbra_date";
-		String zimlet_status="!com_zimbra_date";
+		String unavailableZimlet = "com_zimbra_date";
 
 		// Refresh the account list
 		app.zPageMain.zToolbarPressButton(Button.B_REFRESH);
@@ -61,7 +60,7 @@ public class LimitZimlets extends AdminCore {
 		app.zPageEditAccount.zToolbarPressButton(Button.B_ZIMLETS);
 
 		// Limit zimlet
-		form.zLimitZimlets(zimlet);
+		form.zLimitZimlets(unavailableZimlet);
 
 		// Save the changes
 		form.zSave();
@@ -72,16 +71,15 @@ public class LimitZimlets extends AdminCore {
 						+			"<account by='name'>"+ account.getEmailAddress() +"</account>"
 						+		"</GetAccountRequest>");
 
-		Element[] response = ZimbraAdminAccount.GlobalAdmin().soapSelectNodes("//admin:a[@n='zimbraZimletAvailableZimlets']");
+		Element[] response = ZimbraAdminAccount.AdminConsoleAdmin().soapSelectNodes("//admin:a[@n='zimbraZimletAvailableZimlets']");
 
-		// Verify that MTA configuration has changed
-		boolean value = false;
+		boolean actualModifiedZimlets = false;
 		for(Element e : response ) {
-			if (e.getText().contains(zimlet_status)) {
-				value = true;
+			if (e.getText().contains(unavailableZimlet)) {
+				actualModifiedZimlets = true;
 				break;
 			}
 		}
-		ZAssert.assertFalse(value, "Verify zimlet is unavailable for an account!");
+		ZAssert.assertFalse(actualModifiedZimlets, "Verify modified zimlet unavailable for an account");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitZimlets.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitZimlets.java
@@ -41,7 +41,8 @@ public class LimitZimlets extends AdminCore {
 	public void LimitZimlets_01() throws HarnessException {
 
 		// Create a new account in the Admin Console using SOAP
-		AccountItem account = new AccountItem("email" + ConfigProperties.getUniqueString(),ConfigProperties.getStringProperty("testdomain"));
+		AccountItem account = new AccountItem("email" + ConfigProperties.getUniqueString(), ConfigProperties.getStringProperty("testdomain"));
+
 		ZimbraAdminAccount.AdminConsoleAdmin().soapSend(
 				"<CreateAccountRequest xmlns='urn:zimbraAdmin'>"
 						+			"<name>" + account.getEmailAddress() + "</name>"
@@ -56,7 +57,7 @@ public class LimitZimlets extends AdminCore {
 		// Click on Edit button
 		FormEditAccount form = (FormEditAccount) app.zPageManageAccounts.zListItem(Action.A_RIGHTCLICK, Button.O_EDIT, account.getEmailAddress());
 
-		// Click on Features
+		// Click on zimlets
 		app.zPageEditAccount.zToolbarPressButton(Button.B_ZIMLETS);
 
 		// Limit zimlet


### PR DESCRIPTION
ZCS-3608: Fixed LimitZimlets testcase which was passing wrongly in the past.

LimitZimlets_01 testcase was passing wrongly and started failing recently which is correct. Fixed this testcase, SOAP verification should use ZimbraAdminAccount.AdminConsoleAdmin() instead of ZimbraAdminAccount.GlobalAdmin().

```
Selenium Automation Report: 8.8.6_GA_1902.20171122_NETWORK.

Client      :  pnq-zqa001
Server      :  pnq-zqa006 (Single Node)

Suite       :  Full
Pattern     :  projects.admin.tests
Browser     :  Chrome 62
Testware    :  feature
Version     :  8.8.6_GA_1902.20171122_NETWORK (Zimbra version: Release 8.8.6.GA.1902.UBUNTU14.64 UBUNTU14_64 NETWORK edition.)

Total Tests      :  316
Total Passed     :  314
Total Failed     :  2
Total Skipped    :  0

Total Selenium Test Failures  :  1
Total Open Application Bugs  :  1

Failed tests:
com.zimbra.qa.selenium.projects.admin.tests.accounts.LimitZimlets.LimitZimlets_01 [L1, smoke]
```

![limitzimlets_01](https://user-images.githubusercontent.com/21263826/33240934-c32b04c6-d2e4-11e7-9d87-5b8e29359295.png)
