### PR TITLE
ZCS-3782: Fix month-view tests which fail when executed on last/first day of month

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/pages/calendar/PageCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/pages/calendar/PageCalendar.java
@@ -3111,7 +3111,7 @@ public class PageCalendar extends AbsTab {
 		boolean b = false;
 		for (int i = 1; i <= noOfAppts; i++) {
 
-			if (month < Integer.parseInt(date.toMM_DD_YYYY().split("/")[0])) { // handling the appointments displayed in
+			if (month != Integer.parseInt(date.toMM_DD_YYYY().split("/")[0])) { // handling the appointments displayed in
 																				// next month
 				zToolbarPressButton(Button.B_NEXT_PAGE);
 				SleepUtil.sleepSmall();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/recurring/RecurringWeekly.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/recurring/RecurringWeekly.java
@@ -62,7 +62,7 @@ public class RecurringWeekly extends AjaxCore {
 		// Make sure that appointment is not created on the first day of month as the date cell has month number mentioned in it.
 		for(int i=1; i <= noOfApptInSeries; i++) {
 			if(temp.toDD().equals("01")) {
-				startUTC.addDays(1);
+				startUTC = startUTC.addDays(1);
 				break;
 			}
 			temp = temp.addDays(7);  //Incrementing date by a week

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/singleday/SingleDayAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/singleday/SingleDayAppointment.java
@@ -50,7 +50,12 @@ public class SingleDayAppointment extends AjaxCore {
 		// Appointment data
 		String subject = "Appointment"+ ConfigProperties.getUniqueString();
 		ZDate startDate = new ZDate(Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, Calendar.getInstance().get(Calendar.DAY_OF_MONTH), 10, 0, 0);
-
+		
+		// Making sure that appointment doesn't get created on 1st day of month
+		if(startDate.toDD().equals("01")) {
+			startDate = startDate.addDays(1);
+		}
+		
 		// Create an appointment of duration 120 mins on next day
 		AppointmentItem.createAppointmentSingleDay(
 				app.zGetActiveAccount(),


### PR DESCRIPTION
1. com.zimbra.qa.selenium.projects.ajax.tests.calendar.appointments.views.month.recurring.RecurringWeekly.RecurringWeekly_01 [functional, L2]

The above test failed because month changed from 12 to 1 (Dec-Jan)
The logic to go to next page was only when the next month is greater than the current month.
Changed it to go to next page when there is a change in the month

2. com.zimbra.qa.selenium.projects.ajax.tests.calendar.appointments.views.month.singleday.SingleDayAppointment.SingleDayAppointment_01 [sanity, L1]

The above test failed because the appointment was getting created on the 1st day of the month.
Fixed it to avoid creating the appointment on the 1st day of the month 


  