### PR TITLE
ZCS-3706: Added capablity to include-exclude ng-module testcases & chat-drive zimlet

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -287,7 +287,7 @@ public class ExecuteHarnessMain {
 			if (isNGEnabled.equals("FALSE")) {
 				excludeGroups.add("ng-module");
 			} else {
-				excludeGroups.add("non-ng");
+				excludeGroups.add("non-ngmodule");
 			}
 		}
 
@@ -1554,17 +1554,17 @@ public class ExecuteHarnessMain {
 				Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo), Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 				CommandLineUtility.runCommandOnZimbraServer("zmprov mcf zimbraSmimeOCSPEnabled FALSE");
 
-				// Disable chat and drive zimlets on COS if they are enabled
-				ArrayList<String> zimletList= CommandLineUtility.runCommandOnZimbraServer("zmprov -l gc default zimbraZimletAvailableZimlets | grep zimbraZimletAvailableZimlets | cut -c 32-");
+				// Initially disable chat and drive zimlets on COS if they are enabled
+				ArrayList<String> zimletList = CommandLineUtility.runCommandOnZimbraServer("zmprov -l gc default zimbraZimletAvailableZimlets | grep zimbraZimletAvailableZimlets | cut -c 32-");
 				if (zimletList.contains("com_zextras_chat_open")) {
-					StafIntegration.logInfo = "Disable com_zextras_chat_open zimlets on COS";
+					StafIntegration.logInfo = "Initially disable zimbra chat zimlet on COS";
 					logger.info(StafIntegration.logInfo);
 					Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo),Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 					CommandLineUtility.runCommandOnZimbraServer("zmprov mc default -zimbraZimletAvailableZimlets '+com_zextras_chat_open'");
-					CommandLineUtility.runCommandOnZimbraServer("zmprov fc -a all");
+					CommandLineUtility.runCommandOnZimbraServer("zmsprov fc -a all");
 				}
 				if (zimletList.contains("com_zextras_drive_open")){
-					StafIntegration.logInfo = "Disable com_zextras_drive_open zimlets on COS";
+					StafIntegration.logInfo = "Initially disable zimbra drive zimlet on COS";
 					logger.info(StafIntegration.logInfo);
 					Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo),Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 					CommandLineUtility.runCommandOnZimbraServer("zmprov mc default -zimbraZimletAvailableZimlets '+com_zextras_drive_open'");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
@@ -142,20 +142,21 @@ public class AjaxCore {
 	public void coreBeforeClass() throws HarnessException, IOException {
 		logger.info("BeforeClass: start");
 		logger.info("Class name: " + this.getClass());
+
 		ArrayList<String> zimletList= null;
-		if (this.getClass().getName().contains("com.zimbra.qa.selenium.projects.ajax.tests.network.chat")) {
-			zimletList=CommandLineUtility.runCommandOnZimbraServer("zmprov -l gc default zimbraZimletAvailableZimlets | grep zimbraZimletAvailableZimlets | cut -c 32-");
+		if (this.getClass().getName().contains("com.zimbra.qa.selenium.projects.ajax.tests.zextras.chat")) {
+			zimletList = CommandLineUtility.runCommandOnZimbraServer("zmprov -l gc default zimbraZimletAvailableZimlets | grep zimbraZimletAvailableZimlets | cut -c 32-");
 			if (!zimletList.contains("com_zextras_chat_open")) {
-				logger.info("Enable com_zextras_chat_open zimlets on default COS");
+				logger.info("Enable zimbra chat zimlet on default COS");
 				Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo),Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 				CommandLineUtility.runCommandOnZimbraServer("zmprov mc default +zimbraZimletAvailableZimlets '+com_zextras_chat_open'");
 				CommandLineUtility.runCommandOnZimbraServer("zmprov fc -a all");
 			}
 		}
-		if (this.getClass().getName().contains("com.zimbra.qa.selenium.projects.ajax.tests.network.drive")) {
-			zimletList=CommandLineUtility.runCommandOnZimbraServer("zmprov -l gc default zimbraZimletAvailableZimlets | grep zimbraZimletAvailableZimlets | cut -c 32-");
+		if (this.getClass().getName().contains("com.zimbra.qa.selenium.projects.ajax.tests.zextras.drive")) {
+			zimletList = CommandLineUtility.runCommandOnZimbraServer("zmprov -l gc default zimbraZimletAvailableZimlets | grep zimbraZimletAvailableZimlets | cut -c 32-");
 			if (!zimletList.contains("com_zextras_drive_open")) {
-				logger.info("Enable com_zextras_drive_open zimlets on default COS");
+				logger.info("Enable zimbra drive zimlet on default COS");
 				Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo),Charset.forName("UTF-8"), StandardOpenOption.APPEND);
 				CommandLineUtility.runCommandOnZimbraServer("zmprov mc default +zimbraZimletAvailableZimlets '+com_zextras_drive_open'");
 				CommandLineUtility.runCommandOnZimbraServer("zmprov fc -a all");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
@@ -55,6 +55,7 @@ import com.zimbra.qa.selenium.projects.ajax.pages.mail.FormMailNew;
 import com.zimbra.qa.selenium.projects.ajax.pages.mail.SeparateWindowDisplayMail;
 import com.zimbra.qa.selenium.projects.ajax.pages.mail.SeparateWindowFormMailNew;
 import com.zimbra.qa.selenium.projects.ajax.pages.tasks.FormTaskNew;
+import com.zimbra.qa.selenium.staf.StafIntegration;
 import com.zimbra.qa.selenium.projects.ajax.pages.calendar.FormApptNew;
 import com.zimbra.qa.selenium.projects.ajax.pages.contacts.FormContactDistributionListNew;
 import com.zimbra.qa.selenium.projects.ajax.pages.contacts.FormContactGroupNew;
@@ -138,8 +139,28 @@ public class AjaxCore {
 	}
 
 	@BeforeClass(groups = { "always" })
-	public void coreBeforeClass() throws HarnessException {
+	public void coreBeforeClass() throws HarnessException, IOException {
 		logger.info("BeforeClass: start");
+		logger.info("Class name: " + this.getClass());
+		ArrayList<String> zimletList= null;
+		if (this.getClass().getName().contains("com.zimbra.qa.selenium.projects.ajax.tests.network.chat")) {
+			zimletList=CommandLineUtility.runCommandOnZimbraServer("zmprov -l gc default zimbraZimletAvailableZimlets | grep zimbraZimletAvailableZimlets | cut -c 32-");
+			if (!zimletList.contains("com_zextras_chat_open")) {
+				logger.info("Enable com_zextras_chat_open zimlets on default COS");
+				Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo),Charset.forName("UTF-8"), StandardOpenOption.APPEND);
+				CommandLineUtility.runCommandOnZimbraServer("zmprov mc default +zimbraZimletAvailableZimlets '+com_zextras_chat_open'");
+				CommandLineUtility.runCommandOnZimbraServer("zmprov fc -a all");
+			}
+		}
+		if (this.getClass().getName().contains("com.zimbra.qa.selenium.projects.ajax.tests.network.drive")) {
+			zimletList=CommandLineUtility.runCommandOnZimbraServer("zmprov -l gc default zimbraZimletAvailableZimlets | grep zimbraZimletAvailableZimlets | cut -c 32-");
+			if (!zimletList.contains("com_zextras_drive_open")) {
+				logger.info("Enable com_zextras_drive_open zimlets on default COS");
+				Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo),Charset.forName("UTF-8"), StandardOpenOption.APPEND);
+				CommandLineUtility.runCommandOnZimbraServer("zmprov mc default +zimbraZimletAvailableZimlets '+com_zextras_drive_open'");
+				CommandLineUtility.runCommandOnZimbraServer("zmprov fc -a all");
+			}
+		}
 		logger.info("BeforeClass: finish");
 	}
 


### PR DESCRIPTION
1. if zimbraNetworkModulesNGEnabled is FALSE -> excludeGroups.add("ng-module")
2. if zimbraNetworkModulesNGEnabled is TRUE -> excludeGroups.add("non-ng")[to be added in legacy testcases of backup,DelegatedAdmin,ActiveSync and HSM ]
3. if zimbra-chat is not present -> excludeGroups.add("chat")
4. if zimbra-drive is not present -> excludeGroups.add("drive")

5. ExecuteHarnessMain : Disable chat-drive zimlet on COS level initially for all TCs

6. @BeforeClass : Enable chat-drive zimlet on COS level if test case if of Chat or Drive