### PR TITLE
ZCS-3970: Add facility to automatically configure Zimbra Drive & Nextcloud settings

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -50,6 +50,9 @@ testdomain=testdomain.com
 webPortal=https://pnq-tms.lab.zimbra.com
 bugTrackingTool=https://bugzilla.zimbra.com
 buildServer=http://zre-matrix.eng.zimbra.com
+driveServer=http://zqa-257.eng.zimbra.com
+
+# Browser drivers
 chromeDriverURL=http://chromedriver.storage.googleapis.com/2.33
 geckoDriverURL=https://github.com/mozilla/geckodriver/releases/download/v0.19.0
 edgeDriverURL=https://download.microsoft.com/download/3/4/2/342316D7-EBE0-4F10-ABA2-AE8E0CDF36DD/MicrosoftWebDriver.exe#15063

--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -80,6 +80,10 @@ public class ExecuteHarnessMain {
 
 	public static String zimbraVersion;
 	public static Boolean isNGEnabled;
+	public static Boolean isDLRightGranted = false;
+	public static Boolean isSmimeOcspDisabled = false;
+	public static Boolean isChatConfigured = false;
+	public static Boolean isDriveConfigured = false;
 
 	public ExecuteHarnessMain() {
 	}
@@ -294,10 +298,10 @@ public class ExecuteHarnessMain {
 			}
 		}
 
-		if (!CommandLineUtility.runCommandOnZimbraServer(storeServers.get(0), "dpkg -l | grep -i 'zimbra-chat'").contains("ii  zimbra-chat")) {
+		if (!CommandLineUtility.runCommandOnZimbraServer(storeServers.get(0), "dpkg -l | grep -i 'zimbra-chat'").toString().contains("ii  zimbra-chat")) {
 			excludeGroups.add("chat");
 		}
-		if (!CommandLineUtility.runCommandOnZimbraServer(storeServers.get(0), "dpkg -l | grep -i 'zimbra-drive'").contains("ii  zimbra-drive")) {
+		if (!CommandLineUtility.runCommandOnZimbraServer(storeServers.get(0), "dpkg -l | grep -i 'zimbra-drive'").toString().contains("ii  zimbra-drive")) {
 			excludeGroups.add("drive");
 		}
 
@@ -1549,20 +1553,6 @@ public class ExecuteHarnessMain {
 
 			// Ajax project settings
 			} else if (project.contains("ajax")) {
-
-				// Grant createDistList right to domain
-				StafIntegration.logInfo = "Grant createDistList right to domain using CLI utility";
-				logger.info(StafIntegration.logInfo);
-				Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo), Charset.forName("UTF-8"), StandardOpenOption.APPEND);
-				CommandLineUtility.runCommandOnZimbraServer(ConfigProperties.getStringProperty("server.host"), "zmprov grr domain " + ConfigProperties.getStringProperty("testdomain")
-								+ " dom " + ConfigProperties.getStringProperty("testdomain") + " createDistList");
-
-				// Disable zimbraSmimeOCSPEnabled attribute for S/MIME
-				StafIntegration.logInfo = "Disable zimbraSmimeOCSPEnabled attribute for S/MIME using CLI utility";
-				logger.info(StafIntegration.logInfo);
-				Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo), Charset.forName("UTF-8"), StandardOpenOption.APPEND);
-				CommandLineUtility.runCommandOnZimbraServer(ConfigProperties.getStringProperty("server.host"), "zmprov mcf zimbraSmimeOCSPEnabled FALSE");
-
 				// Initially disable chat and drive zimlets on COS if they are enabled
 				ArrayList<String> availableZimlets = CommandLineUtility.runCommandOnZimbraServer(
 						ConfigProperties.getStringProperty("server.host"), "zmprov -l gc default zimbraZimletAvailableZimlets | grep zimbraZimletAvailableZimlets | cut -c 32-");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
@@ -216,7 +216,6 @@ public class AjaxCore {
 				app.zPageDrive.sType("css=input[id='zimbra_url']", ExecuteHarnessMain.storeServers.get(0));
 				app.zPageDrive.zKeyboard.zTypeKeyEvent(KeyEvent.VK_TAB);
 				SleepUtil.sleepMedium();
-
 			} finally {
 				app.zPageMain.sOpen(ConfigProperties.getBaseURL());
 			}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/pages/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/pages/PageMain.java
@@ -551,25 +551,14 @@ public class PageMain extends AbsTab {
 				sClickAt(appLocator, "");
 				this.zWaitForBusyOverlay();
 				SleepUtil.sleepMedium();
-				if (!appTab.equals(((AjaxPages) MyApplication).zPagePreferences)) {
+				if (!appTab.equals(((AjaxPages) MyApplication).zPagePreferences)
+						&& !appTab.equals(((AjaxPages) MyApplication).zPageDrive)) {
 					zWaitForElementPresent(commonAppLocator);
 				}
 
 				if (zGetCurrentApp().equals(appTab)) {
 					logger.info("Navigated to " + appTab + " page");
 					break;
-				} else {
-					zRefreshMainUI();
-					appTab.zNavigateTo();
-
-					// Check UI loading
-					if (ConfigProperties.getStringProperty("server.host").contains("zimbra.com")) {
-						zWaitTillElementPresent(appIdentifier);
-					} else {
-						zWaitTillElementPresent(appIdentifier.replace("ZIMLET", "TAG"));
-					}
-					this.zWaitForBusyOverlay();
-					SleepUtil.sleepSmall();
 				}
 			}
 		}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/pages/PageMain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/pages/PageMain.java
@@ -45,7 +45,7 @@ public class PageMain extends AbsTab {
 		public static final String zBriefcaseApp = "css=td[id=zb__App__Briefcase_title]";
 		public static final String zPreferencesTab = "id=zb__App__Options_title";
 		public static final String zDriveApp = "css=td[id=zb__App__ZIMBRA_DRIVE_title]";
-		
+
 		public static final String zSocialTab = "css=div[id^='zb__App__com_zimbra_social_'] td[id$='_title']";
 		public static final String zRefreshButton = "css=div[id='CHECK_MAIL'] td[id='CHECK_MAIL_left_icon']>div";
 	}
@@ -467,7 +467,7 @@ public class PageMain extends AbsTab {
 		briefcaseZimletsPane = PageBriefcase.Locators.zBriefcaseZimletsPane;
 		generalPreferencesOverviewPane = PagePreferences.Locators.zGeneralPreferencesOverviewPane;
 		drivePane = PageDrive.Locators.zDriveFolderPane.toString();
-		
+
 
 		if (sIsVisible(mailZimletsPane)) {
 			return ((AjaxPages) MyApplication).zPageMail;
@@ -559,6 +559,8 @@ public class PageMain extends AbsTab {
 				if (zGetCurrentApp().equals(appTab)) {
 					logger.info("Navigated to " + appTab + " page");
 					break;
+				} else {
+					zRefreshMainUI();
 				}
 			}
 		}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/pages/drive/DialogUploadFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/pages/drive/DialogUploadFile.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.interactions.Actions;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
+import com.zimbra.qa.selenium.framework.util.SleepUtil;
 
 public class DialogUploadFile extends AbsDialog {
 
@@ -78,7 +79,6 @@ public class DialogUploadFile extends AbsDialog {
 				Actions action = new Actions(webDriver());
 				action.moveToElement(el, 1, 1).doubleClick(el).build().perform();
 			} else {
-				//executeScript("arguments[0].click()", el);
 				sClick(locator);
 			}
 			return null;
@@ -90,8 +90,9 @@ public class DialogUploadFile extends AbsDialog {
 			throw new HarnessException("Button " + button + " locator " + locator + " not visible!");
 		}
 
-		this.sClickAt(locator, "0,0");
+		this.sClick(locator);
 		this.zWaitForBusyOverlay();
+		SleepUtil.sleepLong();
 		
 		return (null);
 	}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/pages/drive/PageDrive.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/pages/drive/PageDrive.java
@@ -18,7 +18,6 @@ package com.zimbra.qa.selenium.projects.ajax.pages.drive;
 
 import java.util.Map;
 import org.apache.commons.httpclient.HttpStatus;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import com.zimbra.qa.selenium.framework.items.IItem;
 import com.zimbra.qa.selenium.framework.ui.AbsApplication;
@@ -30,7 +29,6 @@ import com.zimbra.qa.selenium.framework.util.HarnessException;
 import com.zimbra.qa.selenium.framework.util.RestUtil;
 import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
-import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.pages.AjaxPages;
 import com.zimbra.qa.selenium.projects.ajax.pages.drive.DialogUploadFile;
 
@@ -116,14 +114,13 @@ public class PageDrive extends AbsTab {
 		}
 
 		try {
-		((AjaxPages) MyApplication).zPageMain.zCheckAppLoaded(Locators.zDriveFolderPane);
+			((AjaxPages) MyApplication).zPageMain.zCheckAppLoaded(Locators.zDriveFolderPane);
 		} catch (Exception ex) {
 			throw new HarnessException("Try connecting Nextcloud Server first or check zimbra settings. Drive not Connected");
 		}
 	}
 
 	public AbsPage zToolbarPressButton(Button button, IItem fileItem) throws HarnessException{
-		// TODO Auto-generated method stub
 
 		logger.info(myPageName() + " zToolbarPressButton(" + button + ")");
 
@@ -384,7 +381,7 @@ public class PageDrive extends AbsTab {
 		throw new HarnessException("implement me! : pulldown=" + pulldown + " option=" + option);
 	}
 
-	public String getItemNameFromListView(String itemName) throws HarnessException {
+	public String zGetItemNameFromListView(String itemName) throws HarnessException {
 
 		String itemLocator = "css=div[id^='zlif__ZDRIVE_DLV-main']:contains('"+itemName+"')";
 
@@ -393,64 +390,4 @@ public class PageDrive extends AbsTab {
 		else
 			return "";
 	}
-	
-	public Boolean zVerifyImageFilePreviewContents(String locator) throws HarnessException {
-
-		try {
-			webDriver().switchTo().frame(0);
-			we = webDriver().findElement(By.cssSelector(locator.replace("css=", "")));
-			if (we.isDisplayed()) {
-				return true;
-			} else {
-				return false;
-			}
-
-		} finally {
-			webDriver().switchTo().defaultContent();
-		}
-
-	}
-
-	public Boolean zVerifyTextFilePreviewContents(String fileContent) throws HarnessException {
-
-		try {
-			webDriver().switchTo().frame(0);
-			if (fileContent.equals(webDriver().findElement(By.tagName("body")).getText())) {
-				return true;
-			} else {
-				return false;
-			}
-
-		} finally {
-			webDriver().switchTo().defaultContent();
-		}
-	}
-
-	public Boolean zVerifyPdfFilePreviewContents(String fileContent) throws HarnessException {
-
-		if (ConfigProperties.getStringProperty("browser").contains("firefox")) {
-
-			String[] pdfElements = { "//body//div[contains(text(), '" + fileContent + "')]", "//button[@id='zoomIn']",
-					"//button[@id='previous']", "//button[@id='print']" };
-
-			try {
-				webDriver().switchTo().frame(0);
-
-				for (int i = 0; i <= pdfElements.length - 1; i++) {
-					System.out.println("Verify " + pdfElements[i] + " element present in file preview");
-					we = webDriver().findElement(By.xpath(pdfElements[i]));
-					if (!we.isDisplayed()) {
-						throw new HarnessException("Could't find " + pdfElements[i] + " element in file preview");
-					}
-				}
-
-			} finally {
-				webDriver().switchTo().defaultContent();
-			}
-
-		}
-		return true;
-
-	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zextras/chat/AddBuddy.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zextras/chat/AddBuddy.java
@@ -1,0 +1,64 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.qa.selenium.projects.ajax.tests.zextras.chat;
+
+import org.testng.annotations.Test;
+import com.zimbra.qa.selenium.framework.ui.Button;
+import com.zimbra.qa.selenium.framework.util.HarnessException;
+import com.zimbra.qa.selenium.framework.util.ZAssert;
+import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
+import com.zimbra.qa.selenium.projects.ajax.core.AjaxCore;
+import com.zimbra.qa.selenium.projects.ajax.pages.chat.BuddyItem;
+import com.zimbra.qa.selenium.projects.ajax.pages.chat.WizardAddBuddy;
+import com.zimbra.qa.selenium.projects.ajax.pages.chat.PageChatPanel.Userstatus;
+
+public class AddBuddy extends AjaxCore {
+
+	public AddBuddy() {
+		logger.info("New "+ AddBuddy.class.getCanonicalName());
+		super.startingPage = app.zPageChatPanel;
+	}
+
+
+	@Test (description = "Add new buddy",
+			groups = { "sanity", "L0", "chat" })
+
+	public void AddNewBuddy_01() throws HarnessException {
+
+		BuddyItem item = new BuddyItem();
+		item.setEmailAddress(ZimbraAccount.Account1().EmailAddress);
+		app.zPageChatPanel.zNavigateTo();
+
+		WizardAddBuddy wizard = (WizardAddBuddy) app.zPageChatPanel.zEllipsesOption(Button.B_ADD_NEW_BUDDY);
+		wizard.zCompleteWizard(item);
+
+		ZimbraAccount account = app.zGetActiveAccount();
+		ZAssert.assertStringContains(app.zPageChatPanel.zUserStatus(ZimbraAccount.Account1().EmailAddress),
+				Userstatus.invited.getStatus(), "Verify the user status");
+
+		app.zPageLogin.zNavigateTo();
+		app.zPageLogin.zLogin(ZimbraAccount.Account1());
+		app.zPageChatPanel.zNavigateTo();
+
+		ZAssert.assertStringContains(app.zPageChatPanel.zUserStatus(account.EmailAddress),
+				Userstatus.need_response.getStatus(), "Verify the user status");
+		ZAssert.assertStringContains(app.zPageChatPanel.zUserStatus(account.EmailAddress),
+				Userstatus.need_response.getStatus(), "Verify the user status");
+		app.zPageChatPanel.zSelectUser(account.EmailAddress, Userstatus.need_response);
+
+	}
+}

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zextras/chat/ChatWithUser.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zextras/chat/ChatWithUser.java
@@ -1,4 +1,20 @@
-package com.zimbra.qa.selenium.projects.ajax.tests.zextras;
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2011, 2012, 2013, 2014, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.qa.selenium.projects.ajax.tests.zextras.chat;
 
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.Action;
@@ -14,60 +30,30 @@ import com.zimbra.qa.selenium.projects.ajax.pages.chat.PageChatPanel.Userstatus;
 import com.zimbra.qa.selenium.projects.ajax.pages.mail.DisplayMail.Field;
 import com.zimbra.qa.selenium.projects.ajax.pages.mail.DisplayMail;
 
+public class ChatWithUser extends AjaxCore {
 
-public class chat extends AjaxCore {
-
-	public chat() {
-		logger.info("New "+ chat.class.getCanonicalName());
-		super.startingPage=app.zPageChatPanel;
+	public ChatWithUser() {
+		logger.info("New "+ ChatWithUser.class.getCanonicalName());
+		super.startingPage = app.zPageChatPanel;
 	}
 
-	@Test (description = "Add new buddy",
-			groups = { "smoke", "L0", "chat" })
 
-	public void ChatAddNewBuddy_01() throws HarnessException {
+	@Test (description = "Chat with online user after adding buddy",
+			groups = { "sanity", "L0", "chat" })
 
-		BuddyItem item = new BuddyItem();
-		item.setEmailAddress(ZimbraAccount.Account1().EmailAddress);
-		app.zPageChatPanel.zNavigateTo();
-
-		WizardAddBuddy wizard = (WizardAddBuddy)app.zPageChatPanel.zEllipsesOption(Button.B_ADD_NEW_BUDDY);
-
-		wizard.zCompleteWizard(item);
-
-		ZimbraAccount account = app.zGetActiveAccount();
-
-		ZAssert.assertStringContains(app.zPageChatPanel.zUserStatus(ZimbraAccount.Account1().EmailAddress),Userstatus.invited.getStatus(),"Verify the user status");
-
-		app.zPageLogin.zNavigateTo();
-		app.zPageLogin.zLogin(ZimbraAccount.Account1());
-		app.zPageChatPanel.zNavigateTo();
-
-		ZAssert.assertStringContains(app.zPageChatPanel.zUserStatus(account.EmailAddress),Userstatus.need_response.getStatus(),"Verify the user status");ZAssert.assertStringContains(app.zPageChatPanel.zUserStatus(account.EmailAddress),Userstatus.need_response.getStatus(),"Verify the user status");
-
-		app.zPageChatPanel.zSelectUser(account.EmailAddress, Userstatus.need_response);
-
-	}
-
-	@Test (description = "Chat with added new buddy when receiver is Online",
-			groups = { "smoke", "L0", "chat" })
-
-	public void ChatAddNewBuddy_02() throws HarnessException {
+	public void ChatWithOnlineUser_01() throws HarnessException {
 
 		BuddyItem item = new BuddyItem();
 		item.setEmailAddress(ZimbraAccount.Account2().EmailAddress);
 		app.zPageChatPanel.zNavigateTo();
 
 		WizardAddBuddy wizard = (WizardAddBuddy)app.zPageChatPanel.zEllipsesOption(Button.B_ADD_NEW_BUDDY);
-
 		wizard.zCompleteWizard(item);
 
 		ZimbraAccount account = app.zGetActiveAccount();
-
 		app.zPageLogin.zNavigateTo();
 		app.zPageLogin.zLogin(ZimbraAccount.Account2());
 		app.zPageChatPanel.zNavigateTo();
-
 		app.zPageChatPanel.zSelectUser(account.EmailAddress, Userstatus.need_response);
 
 		account.soapSend(
@@ -81,17 +67,16 @@ public class chat extends AjaxCore {
 						+ "</ZxChatRequest>");
 
 		app.zPageChatPanel.zSelectUser(account.EmailAddress, Userstatus.offline);
-
-		ZAssert.assertStringContains(app.zPageChatPanel.zGetMsg(), "Test", "verify the chat message");
+		ZAssert.assertStringContains(app.zPageChatPanel.zGetMsg(), "Test", "Verify the chat message");
 	}
 
 
-	@Test (description = "Chat with added new buddy when receiver is Offline",
-			groups = { "smoke", "L0", "chat" })
+	@Test (description = "Chat with offline user after adding buddy",
+			groups = { "smoke", "L1", "chat" })
 
-	public void ChatAddNewBuddy_03() throws HarnessException {
+	public void ChatWithOfflineUser_02() throws HarnessException {
 
-		String message = "Chat"+ConfigProperties.getUniqueString();
+		String message = "Chat" + ConfigProperties.getUniqueString();
 		BuddyItem item = new BuddyItem();
 		item.setEmailAddress(ZimbraAccount.Account3().EmailAddress);
 		app.zPageChatPanel.zNavigateTo();
@@ -106,18 +91,16 @@ public class chat extends AjaxCore {
 		app.zPageChatPanel.zNavigateTo();
 
 		app.zPageChatPanel.zSelectUser(account.EmailAddress, Userstatus.need_response);
-
 		app.zPageChatPanel.zSelectUser(account.EmailAddress, Userstatus.offline);
 		app.zPageChatPanel.zSendMsg(message);
 
 		app.zPageLogin.zNavigateTo();
 		app.zPageLogin.zLogin(account);
 		app.zPageChatPanel.zNavigateTo();
-
 		ZAssert.assertTrue(app.zPageChatPanel.zVerifyChatFolder(),"Verify the chat folder");
 
-		DisplayMail actual = (DisplayMail) app.zPageMail.zListItem(Action.A_LEFTCLICK, "OpenChat - "+ZimbraAccount.Account3().EmailAddress);
-
+		DisplayMail actual = (DisplayMail) app.zPageMail.zListItem(Action.A_LEFTCLICK,
+				"OpenChat - " + ZimbraAccount.Account3().EmailAddress);
 		ZAssert.assertStringContains(actual.zGetMailProperty(Field.Body),message,"Verify the Open Mail existence");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zextras/drive/UploadFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zextras/drive/UploadFile.java
@@ -26,16 +26,14 @@ import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.projects.ajax.core.AjaxCore;
 import com.zimbra.qa.selenium.projects.ajax.pages.drive.DialogUploadFile;;
 
-public class UploadFile extends AjaxCore{
+public class UploadFile extends AjaxCore {
 
 	public UploadFile() throws HarnessException {
 		logger.info("New " + UploadFile.class.getCanonicalName());
-		super.startingPage = app.zPageDrive;
-		super.startingAccountPreferences.put("zimbraPrefShowSelectionCheckbox","TRUE");
 	}
 
 	@Test (description = "Upload file through UI and verify it",
-			groups = { "sanity", "L0", "upload", "drive" })
+			groups = { "sanity", "L0", "upload", "non-msedge" } )
 
 	public void UploadFile_01() throws HarnessException {
 
@@ -45,6 +43,9 @@ public class UploadFile extends AjaxCore{
 			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
 			FileItem fileItem = new FileItem(filePath);
 
+			// Navigate to drive app
+			app.zPageDrive.zNavigateTo();
+
 			// Click on Upload File button in the Toolbar
 			DialogUploadFile dlg = (DialogUploadFile) app.zPageDrive.zToolbarPressButton(Button.B_UPLOAD_FILE, fileItem);
 			dlg.zPressButton(Button.B_BROWSE);
@@ -52,7 +53,7 @@ public class UploadFile extends AjaxCore{
 			dlg.zPressButton(Button.B_OK);
 
 			// Verify file is uploaded
-			String name = app.zPageDrive.getItemNameFromListView(fileName);
+			String name = app.zPageDrive.zGetItemNameFromListView(fileName);
 			ZAssert.assertStringContains(name, fileName, "Verify file name through GUI");
 
 		} finally {


### PR DESCRIPTION
ZCS-3970: Add facility to automatically configure Zimbra Drive & Nextcloud settings.

- Added code to automatically configure drive and nextcloud settings
- Added code to configure chat, drive, smime and dl settings in before class
- Removed respective smime and dl code from execute harness main to boost the initial speed
- Fixed group for chat and drive and re-organized tests
- Fixed infinite loop issue in refresh ui code
- Removed un-necessary code