### PR TITLE
ZCS-3982: Drive group was missed, test runs when drive package is not installed due to this

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/admin/pages/PageZextrasAdmin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/pages/PageZextrasAdmin.java
@@ -62,7 +62,6 @@ public class PageZextrasAdmin extends AbsTab{
 		zWaitForWorkInProgressDialogInVisible();
 		sClickAt(Locators.Admin, "");
 		zWaitForWorkInProgressDialogInVisible();
-
 	}
 
 	@Override
@@ -157,80 +156,75 @@ public class PageZextrasAdmin extends AbsTab{
 		return (this.getClass().getName());
 	}
 
-	public void SelectAccountRow(String email) throws HarnessException {
+	public void zSelectAccountRow(String email) throws HarnessException {
+		SleepUtil.sleepSmall();
 		sClick("xpath=//tr/descendant::div[@title='"+email+"']");
 	}
 
-	public Boolean IsAccountPresentonUI(String email) throws HarnessException {
+	public Boolean zIsAccountPresentonUI(String email) throws HarnessException {
 		return sIsElementPresent("xpath=//tr/descendant::div[@title='"+email+"']");
 	}
 
-	public String GetDomainfromUI(String email) throws HarnessException{
+	public String zGetDomainfromUI(String email) throws HarnessException{
 		return sGetText("xpath=//tr/descendant::div[@title='"+email+"']//parent::td/following-sibling::td[1]/div");
 	}
 
-	public String GetDelegateAuthfromUI(String email) throws HarnessException{
+	public String zGetDelegateAuthfromUI(String email) throws HarnessException{
 		return sGetText("xpath=//tr/descendant::div[@title='"+email+"']//parent::td/following-sibling::td[2]/div");
 	}
 
-	public String GetEditFeaturesfromUI(String email) throws HarnessException{
+	public String zGetEditFeaturesfromUI(String email) throws HarnessException{
 		return sGetText("xpath=//tr/descendant::div[@title='"+email+"']//parent::td/following-sibling::td[3]/div");
 	}
 
-	public String GetGrantLimitfromUI(String email) throws HarnessException{
+	public String zGetGrantLimitfromUI(String email) throws HarnessException{
 		return sGetText("xpath=//tr/descendant::div[@title='"+email+"']//parent::td/following-sibling::td[4]/div");
 	}
 
-	public void SelectDomainRow(String domain) throws HarnessException {
+	public void zSelectDomainRow(String domain) throws HarnessException {
 		sClick("css=table[id='ztabv__ZxAdmin_domainSettings_table'] div[title='"+domain+"']");
 	}
 
-	public Boolean IsDomainPresentonUI(String domain) throws HarnessException {
+	public Boolean zIsDomainPresentonUI(String domain) throws HarnessException {
 		return sIsElementPresent("xpath=//table[@id='ztabv__ZxAdmin_domainSettings_table']//tr/descendant::div[@title='" + domain + "']");
 	}
 
-	public String GetGlobalLimitfromUI(String domain) throws HarnessException {
+	public String zGetGlobalLimitfromUI(String domain) throws HarnessException {
 		return sGetText("xpath=//table[@id='ztabv__ZxAdmin_domainSettings_table']//tr/descendant::div[@title='" + domain + "']//parent::td/following-sibling::td[2]/div");
 	}
 
-	public String GetDomainQuotafromUI(String domain) throws HarnessException {
+	public String zGetDomainQuotafromUI(String domain) throws HarnessException {
 		return sGetText("xpath=//table[@id='ztabv__ZxAdmin_domainSettings_table']//tr/descendant::div[@title='" + domain + "']//parent::td/following-sibling::td[3]/div");
 	}
 
-	public String GetCosNumberfromUI(String domain) throws HarnessException {
+	public String zGetCosNumberfromUI(String domain) throws HarnessException {
 		return sGetText("xpath=//table[@id='ztabv__ZxAdmin_domainSettings_table']//tr/descendant::div[@title='" + domain + "']//parent::td/following-sibling::td[1]/div");
 	}
 
 
 	@Override
 	public AbsPage zListItem(Action action, String item) throws HarnessException {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public AbsPage zListItem(Action action, Button option, String item) throws HarnessException {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public AbsPage zListItem(Action action, Button option, Button subOption, String item) throws HarnessException {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 
 	@Override
 	public AbsPage zToolbarPressButton(Button button) throws HarnessException {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public AbsPage zToolbarPressPulldown(Button pulldown, Button option) throws HarnessException {
-		// TODO Auto-generated method stub
 		return null;
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/admin/pages/PageZextrasBackup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/pages/PageZextrasBackup.java
@@ -91,7 +91,6 @@ public class PageZextrasBackup extends AbsTab {
 
 	@Override
 	public AbsPage zListItem(Action action, String accountEmailAddress) throws HarnessException {
-
 		return null;
 	}
 
@@ -121,7 +120,7 @@ public class PageZextrasBackup extends AbsTab {
 		return false;
 	}
 
-	public void enterBackupPath(String backupPath) throws HarnessException {
+	public void zEnterBackupPath(String backupPath) throws HarnessException {
 		SleepUtil.sleepSmall();
 		zType(Locators.BACKUP_PATH, backupPath);
 	}
@@ -132,7 +131,7 @@ public class PageZextrasBackup extends AbsTab {
 		SleepUtil.sleepLong();
 	}
 
-	public AbsPage initializeBackup() throws HarnessException {
+	public AbsPage zInitializeBackup() throws HarnessException {
 		AbsPage page = null;
 		SleepUtil.sleepVerySmall();
 		page = new DialogRunSmartScanConfirmation(MyApplication, null);
@@ -140,7 +139,7 @@ public class PageZextrasBackup extends AbsTab {
 		return (page);
 	}
 
-	public AbsPage RestoreDeletedAccount() throws HarnessException {
+	public AbsPage zRestoreDeletedAccount() throws HarnessException {
 		AbsPage page = null;
 		SleepUtil.sleepMedium();
 		page = new WizardRestoreDeletedAccount(this);

--- a/src/java/com/zimbra/qa/selenium/projects/admin/pages/PageZextrasGeneral.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/pages/PageZextrasGeneral.java
@@ -97,7 +97,6 @@ public class PageZextrasGeneral extends AbsTab {
 
 	@Override
 	public AbsPage zListItem(Action action, String accountEmailAddress) throws HarnessException {
-
 		return null;
 	}
 
@@ -179,5 +178,4 @@ public class PageZextrasGeneral extends AbsTab {
 		WebElement we = getElement(locator);
 		return we.getText().contains("The " + module + " module is not running.");
 	}
-
 }

--- a/src/java/com/zimbra/qa/selenium/projects/admin/pages/PageZextrasHSM.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/pages/PageZextrasHSM.java
@@ -128,7 +128,7 @@ public class PageZextrasHSM extends AbsTab {
 		SleepUtil.sleepLong();
 	}
 
-	public AbsPage addSecondaryVolume() throws HarnessException {
+	public AbsPage zAddSecondaryVolume() throws HarnessException {
 		AbsPage page = null;
 		SleepUtil.sleepVerySmall();
 		page = new WizardAddNewVolume(this);
@@ -136,35 +136,35 @@ public class PageZextrasHSM extends AbsTab {
 		return (page);
 	}
 
-	public AbsPage editSecondaryVolume(String volumeName) throws HarnessException {
+	public AbsPage zEditSecondaryVolume(String volumeName) throws HarnessException {
 		AbsPage page = null;
-		SleepUtil.sleepVerySmall();
+		SleepUtil.sleepSmall();
 		this.sClickAt(Locators.SECONDARY_VOLUME + ":contains('" + volumeName + "')", "");
 		page = new WizardEditHSMVolume(this);
 		this.sClickAt(Locators.SECONDARY_VOLUME_EDIT_BUTTON, "");
 		return (page);
 	}
 
-	public AbsPage addHSMPolicy() throws HarnessException {
+	public AbsPage zAddHSMPolicy() throws HarnessException {
 		AbsPage page = null;
-		SleepUtil.sleepVerySmall();
+		SleepUtil.sleepSmall();
 		page = new WizardHSMPolicy(this);
 		this.sClickAt(Locators.HSM_POLICY_ADD_BUTTON, "");
 		SleepUtil.sleepVerySmall();
 		return (page);
 	}
 
-	public AbsPage editHSMPolicy(String hsmPolicy) throws HarnessException {
+	public AbsPage zEditHSMPolicy(String hsmPolicy) throws HarnessException {
 		AbsPage page = null;
-		SleepUtil.sleepVerySmall();
+		SleepUtil.sleepSmall();
 		this.sClickAt(Locators.HSM_POLICY + ":contains('" + hsmPolicy + "')", "");
 		page = new WizardHSMPolicy(this);
 		this.sClickAt(Locators.HSM_POLICY_EDIT_BUTTON, "");
-		SleepUtil.sleepVerySmall();
+		SleepUtil.sleepSmall();
 		return (page);
 	}
 
-	public AbsPage ApplyHSMPolicy() throws HarnessException {
+	public AbsPage zApplyHSMPolicy() throws HarnessException {
 		DialogForZextrasOperationID operationIdDialog = new DialogForZextrasOperationID(MyApplication,null);
 		this.sClickAt(Locators.APPLY_HSM_POLICY_NOW_BUTTON, "");
 		if(zWaitForElementPresent(Locators.APPLY_HSM_POLICY_NOW_DIALOG)) {
@@ -180,18 +180,18 @@ public class PageZextrasHSM extends AbsTab {
 		return null;
 	}
 
-	public Boolean IsSecondaryVolumeExists(String volumeName) throws HarnessException {
+	public Boolean zIsSecondaryVolumeExists(String volumeName) throws HarnessException {
 		SleepUtil.sleepSmall();
 		return (this.sIsElementPresent("css=div.secondaryVolumes div.DwtListView-Rows div:contains('"+ volumeName +"')"));
 	}
 
-	public Boolean IsCurrentVolume(String volumeName) throws HarnessException {
+	public Boolean zIsCurrentVolume(String volumeName) throws HarnessException {
 		SleepUtil.sleepSmall();
 		return (this.sIsElementPresent("xpath=//div[contains(text(),'Secondary Volumes')]/parent::div//td[contains(text(),'"
 						+ volumeName + "')]/preceding-sibling::td[2]/div[@class='ImgCheck']"));
 	}
 
-	public String GetLastHSMPolicyInList() throws HarnessException {
+	public String zGetLastHSMPolicyInList() throws HarnessException {
 		return (sGetText(Locators.lastPolicyInList));
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zextras/drive/UploadFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zextras/drive/UploadFile.java
@@ -33,7 +33,7 @@ public class UploadFile extends AjaxCore {
 	}
 
 	@Test (description = "Upload file through UI and verify it",
-			groups = { "sanity", "L0", "upload", "non-msedge" } )
+			groups = { "sanity", "L0", "upload", "non-msedge", "drive" } )
 
 	public void UploadFile_01() throws HarnessException {
 


### PR DESCRIPTION
ZCS-3970: Drive group was missed, test runs when drive package is not installed due to this.

It will fix group count to 0 if drive package is not installed.

	Selenium Automation Report: 8.8.6_GA_1906.20171130_NETWORK.

	Client      :  pnq-zqa001
	Server      :  pnq-zqa006 (Single Node)

	Suite       :  Full
	Pattern     :  projects.ajax.tests.zextras
	Browser     :  Chrome 63
	Testware    :  develop
	Version     :  8.8.6_GA_1906.20171130_NETWORK (Server version: Release 8.8.6.GA.1906.UBUNTU14.64 UBUNTU14_64 NETWORK edition.)

	Total Tests      :  1
	Total Passed     :  0
	Total Failed     :  1
	Total Skipped    :  0

	Failed tests:
	com.zimbra.qa.selenium.projects.ajax.tests.zextras.drive.UploadFile.UploadFile_01 [L0, upload, sanity, non-msedge]