### PR TITLE
ZCS-4218: Exclude Zextras related testcases if not applicable to execute in build

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -287,15 +287,13 @@ public class ExecuteHarnessMain {
 			excludeGroups.add("non-msedge");
 		}
 
-		for (String sIsNGEnabled : CommandLineUtility.runCommandOnZimbraServer(storeServers.get(0),
-				"zmprov gs `zmhostname` zimbraNetworkModulesNGEnabled | grep -i 'zimbraNetworkModulesNGEnabled' | cut -d : -f 2 | tr -d '[:blank:]'")) {
-			if (sIsNGEnabled.equals("FALSE")) {
-				excludeGroups.add("ng-module");
-				isNGEnabled = false;
-			} else {
-				excludeGroups.add("non-ngmodule");
-				isNGEnabled = true;
-			}
+		if (CommandLineUtility.runCommandOnZimbraServer(storeServers.get(0),
+				"zmprov gs `zmhostname` zimbraNetworkModulesNGEnabled | grep -i 'zimbraNetworkModulesNGEnabled' | cut -d : -f 2 | tr -d '[:blank:]'").toString().contains("TRUE")) {
+			excludeGroups.add("non-ngmodule");
+			isNGEnabled = true;
+		} else {
+			excludeGroups.add("ng-module");
+			isNGEnabled = false;
 		}
 
 		if (!CommandLineUtility.runCommandOnZimbraServer(storeServers.get(0), "dpkg -l | grep -i 'zimbra-chat'").toString().contains("ii  zimbra-chat")) {


### PR DESCRIPTION
ZCS-4218: Exclude Zextras related testcases if not applicable to execute in build.

	8.7.11 patch build:
	zimbra@pnq-zqa007:~$ zmprov gs `zmhostname` zimbraNetworkModulesNGEnabled | grep -i 'zimbraNetworkModulesNGEnabled' | cut -d : -f 2 | tr -d '[:blank:]'
	zimbra@pnq-zqa007:~$

	8.8.5 build without zextras:
	zimbra@pnq-zqa010:~$ zmprov gs `zmhostname` zimbraNetworkModulesNGEnabled | grep -i 'zimbraNetworkModulesNGEnabled' | cut -d : -f 2 | tr -d '[:blank:]'
	FALSE
	zimbra@pnq-zqa010:~$

	8.8.5 build with zextras:
	zimbra@zqa-206:~$ zmprov gs `zmhostname` zimbraNetworkModulesNGEnabled | grep -i 'zimbraNetworkModulesNGEnabled' | cut -d : -f 2 | tr -d '[:blank:]'
	TRUE
	zimbra@zqa-206:~$