### PR TITLE
ZCS-4219: Upgrade selenium server, jar and browser drivers to latest 3.9.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <project xmlns:ivy="antlib:org.apache.ivy.ant" name="zm-selenium" default="selenium-jar" basedir=".">
 
-	<property name="selenium.version" value="3.7.1"/>
+	<property name="selenium.version" value="3.9.1"/>
 
 	<property name="ivy.jar.dir" location="${user.home}/.ant/lib"/>
 	<property name="ivy.install.version" value="2.3.0"/>
@@ -215,6 +215,7 @@
 		<ivy:install organisation="com.google.code.gson" module="gson" revision="2.8.0" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="com.google.guava" module="guava" revision="23.0" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="com.jcraft" module="jsch" revision="0.1.53" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+		<ivy:install organisation="com.squareup.okhttp3" module="okhttp" revision="3.9.1" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="commons-beanutils" module="commons-beanutils" revision="1.7.0" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="commons-cli" module="commons-cli" revision="1.2" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="commons-codec" module="commons-codec" revision="1.7" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>

--- a/conf/config.properties
+++ b/conf/config.properties
@@ -53,9 +53,9 @@ buildServer=http://zre-matrix.eng.zimbra.com
 driveServer=http://zqa-257.eng.zimbra.com
 
 # Browser drivers
-chromeDriverURL=http://chromedriver.storage.googleapis.com/2.33
-geckoDriverURL=https://github.com/mozilla/geckodriver/releases/download/v0.19.0
-edgeDriverURL=https://download.microsoft.com/download/3/4/2/342316D7-EBE0-4F10-ABA2-AE8E0CDF36DD/MicrosoftWebDriver.exe#15063
+chromeDriverURL=http://chromedriver.storage.googleapis.com/2.35
+geckoDriverURL=https://github.com/mozilla/geckodriver/releases/download/v0.19.1
+edgeDriverURL=https://download.microsoft.com/download/D/4/1/D417998A-58EE-4EFE-A7CC-39EF9E020768/MicrosoftWebDriver.exe#16299
 
 # POP/IMAP settings on a default Zimbra server
 server.imap.port=993

--- a/ivy.xml
+++ b/ivy.xml
@@ -6,6 +6,7 @@
 		<dependency org="ant-tar-patched" name="ant-tar-patched" rev="1.0"/>
 		<dependency org="com.google.guava" name="guava" rev="23.0"/>
 		<dependency org="com.jcraft" name="jsch" rev="0.1.53"/>
+		<dependency org="com.squareup.okhttp3" name="okhttp" rev="3.9.1"/>
 		<dependency org="commons-beanutils" name="commons-beanutils" rev="1.7.0"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2"/>
 		<dependency org="commons-codec" name="commons-codec" rev="1.7"/>
@@ -40,16 +41,16 @@
 		<dependency org="org.testng" name="testng" rev="5.12.1"/>
 		<dependency org="xalan" name="serializer" rev="2.7.2"/>
 		<dependency org="xml-apis" name="xml-apis" rev="2.0.2"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-api" rev="3.7.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-chrome-driver" rev="3.7.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-edge-driver" rev="3.7.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-firefox-driver" rev="3.7.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-ie-driver" rev="3.7.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-java" rev="3.7.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-remote-driver" rev="3.7.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-safari-driver" rev="3.7.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-server" rev="3.7.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-support" rev="3.7.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-api" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-chrome-driver" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-edge-driver" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-firefox-driver" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-ie-driver" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-java" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-remote-driver" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-safari-driver" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-server" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-support" rev="3.9.1"/>
 		<dependency org="zimbra" name="zm-native" rev="latest.integration"/>
         <dependency org="zimbra" name="zm-common" rev="latest.integration"/>
 	</dependencies>


### PR DESCRIPTION
ZCS-4219: Upgrade selenium server, jar and browser drivers to latest 3.9.1

- Upgraded selenium server from 3.7.1 to 3.9.1
- Added required `<dependency org="com.squareup.okhttp3" name="okhttp" rev="3.9.1"/>` for latest selenium server
- Drivers:
   Chrome 2.33 to 2.35
   Firefox 0.19.0 to 0.19.1
   MS Edge 15063 to 16299

Tested the changes locally and it works fine for me.