### PR TITLE
ZCS-4429: Skipping context menu issues with MS Edge to move ahead

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/quickadd/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/quickadd/CreateAppointment.java
@@ -152,7 +152,7 @@ public class CreateAppointment extends AjaxCore {
 
 
 	@Test (description = "Create basic appointment using quick add dialog and add date and time using date/time picker",
-			groups = { "smoke", "L0" } )
+			groups = { "smoke", "L0", "non-msedge" } )
 
 	public void CreateAppointment_04() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
@@ -191,7 +191,7 @@ public class CreateMeeting extends AjaxCore {
 
 
 	@Test (description = "Create basic meeting invite by selecting date from date picker and time from dropdown",
-			groups = { "sanity", "L0" })
+			groups = { "sanity", "L0", "non-msedge" })
 
 	public void CreateMeeting_04() throws HarnessException {
 


### PR DESCRIPTION
ZCS-4429: Skipping context menu issues with MS Edge to move ahead..

com.zimbra.qa.selenium.projects.ajax.tests.calendar.appointments.quickadd.CreateAppointment.CreateAppointment_04()

com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.organizer.singleday.create.CreateMeeting.CreateMeeting_04()

This tests blocks entire suite due to issue with few Ajax context menu in MS Edge. Currently we are focusing on adding MS Edge support for L0, this issue can be looked in future if major problem but we just have ~2% failure in MS Edge which is absolutely fine for L0. We already have full support for Chrome & Firefox, MS Edge - L0 is an additional support for our fort-night releases.