### PR TITLE
ZCS-4443: Upgrade selenium server, jar and browser drivers to latest 3.11.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <project xmlns:ivy="antlib:org.apache.ivy.ant" name="zm-selenium" default="selenium-jar" basedir=".">
 
-	<property name="selenium.version" value="3.9.1"/>
+	<property name="selenium.version" value="3.11.0"/>
 
 	<property name="ivy.jar.dir" location="${user.home}/.ant/lib"/>
 	<property name="ivy.install.version" value="2.3.0"/>
@@ -215,7 +215,7 @@
 		<ivy:install organisation="com.google.code.gson" module="gson" revision="2.8.0" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="com.google.guava" module="guava" revision="23.0" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="com.jcraft" module="jsch" revision="0.1.53" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-		<ivy:install organisation="com.squareup.okhttp3" module="okhttp" revision="3.9.1" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+		<ivy:install organisation="com.squareup.okhttp3" module="okhttp" revision="3.10.0" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="com.squareup.okio" module="okio" revision="1.13.0" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="commons-beanutils" module="commons-beanutils" revision="1.7.0" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 		<ivy:install organisation="commons-cli" module="commons-cli" revision="1.2" settingsRef="ivy.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -6,7 +6,7 @@
 		<dependency org="ant-tar-patched" name="ant-tar-patched" rev="1.0"/>
 		<dependency org="com.google.guava" name="guava" rev="23.0"/>
 		<dependency org="com.jcraft" name="jsch" rev="0.1.53"/>
-		<dependency org="com.squareup.okhttp3" name="okhttp" rev="3.9.1"/>
+		<dependency org="com.squareup.okhttp3" name="okhttp" rev="3.10.0"/>
 		<dependency org="com.squareup.okio" name="okio" rev="1.13.0"/>
 		<dependency org="commons-beanutils" name="commons-beanutils" rev="1.7.0"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2"/>
@@ -42,16 +42,16 @@
 		<dependency org="org.testng" name="testng" rev="5.12.1"/>
 		<dependency org="xalan" name="serializer" rev="2.7.2"/>
 		<dependency org="xml-apis" name="xml-apis" rev="2.0.2"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-api" rev="3.9.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-chrome-driver" rev="3.9.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-edge-driver" rev="3.9.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-firefox-driver" rev="3.9.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-ie-driver" rev="3.9.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-java" rev="3.9.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-remote-driver" rev="3.9.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-safari-driver" rev="3.9.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-server" rev="3.9.1"/>
-		<dependency org="org.seleniumhq.selenium" name="selenium-support" rev="3.9.1"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-api" rev="3.11.0"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-chrome-driver" rev="3.11.0"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-edge-driver" rev="3.11.0"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-firefox-driver" rev="3.11.0"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-ie-driver" rev="3.11.0"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-java" rev="3.11.0"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-remote-driver" rev="3.11.0"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-safari-driver" rev="3.11.0"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-server" rev="3.11.0"/>
+		<dependency org="org.seleniumhq.selenium" name="selenium-support" rev="3.11.0"/>
 		<dependency org="zimbra" name="zm-native" rev="latest.integration"/>
         <dependency org="zimbra" name="zm-common" rev="latest.integration"/>
 	</dependencies>

--- a/src/java/com/zimbra/qa/selenium/framework/core/SeleniumService.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/SeleniumService.java
@@ -234,16 +234,15 @@ public class SeleniumService {
 	public SeleniumService() {
 		logger.info("New SeleniumService object");
 
-		String modeProp = ConfigProperties.getStringProperty("seleniumMode", "local").toLowerCase();
+		String modeProp = ConfigProperties.getStringProperty("seleniumMode").toLowerCase();
 		logger.info("New SeleniumService object: "+ modeProp);
 
 		// Set Defaults
 		mode = SeleniumMode.Local;
-		SeleniumServer = ConfigProperties.getStringProperty("serverName", "localhost");
-		SeleniumPort = ConfigProperties.getIntProperty("serverPort", 4444);
-		SeleniumBrowser = ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".browser",	ConfigProperties.getStringProperty("browser"));
-		SeleniumServerHost = ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".server.host",	ConfigProperties.getStringProperty("server.host"));
-		SeleniumBrowserVersion = ConfigProperties.getStringProperty("browserVersion");
+		SeleniumServer = ConfigProperties.getStringProperty("serverName");
+		SeleniumPort = ConfigProperties.getIntProperty("serverPort");
+		SeleniumBrowser = ConfigProperties.getStringProperty("browser");
+		SeleniumServerHost = ConfigProperties.getStringProperty("server.host");
 
 		if (modeProp.equals(SeleniumMode.Local.toString().toLowerCase())) {
 			mode = SeleniumMode.Local;

--- a/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeleniumObject.java
+++ b/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeleniumObject.java
@@ -540,6 +540,7 @@ public abstract class AbsSeleniumObject {
 		return new StringBuilder("(").append(centerWidth).append(",").append(centerHeight).append(")").toString();
 	}
 
+	@SuppressWarnings("deprecation")
 	public void sWaitForPageToLoad() throws HarnessException {
 		String timeout = ConfigProperties.getStringProperty("selenium.maxpageload.msec", "20000");
 		logger.info("waitForPageToLoad(" + timeout + ")");
@@ -1976,6 +1977,7 @@ public abstract class AbsSeleniumObject {
 		return visible;
 	}
 
+	@SuppressWarnings("deprecation")
 	private boolean waitForElementPresent(final String locator, final boolean flag, long timeout) {
 		logger.info("waitForElementPresent(" + locator + ")");
 		Boolean present = false;
@@ -1999,6 +2001,7 @@ public abstract class AbsSeleniumObject {
 		return present;
 	}
 
+	@SuppressWarnings("deprecation")
 	private boolean waitForElementVisible(final String locator, final boolean flag, long timeout) {
 		logger.info("waitForElementVisible(" + locator + ")");
 		Boolean visible = false;
@@ -2142,6 +2145,7 @@ public abstract class AbsSeleniumObject {
 		return waitForWindow(name, true, timeout, handlesSize);
 	}
 
+	@SuppressWarnings("deprecation")
 	private boolean waitForWindow(final String name, final Boolean flag, Long timeout, int... handlesSize) {
 		logger.info("waitForWindow(" + name + ") ");
 


### PR DESCRIPTION
ZCS-4443: Upgrade selenium server, jar and browser drivers to latest 3.11.0.

Sample run after upgrading selenium version:

	===============================================
	AJAX
	Total tests run: 1, Failures: 0, Skips: 0
	===============================================

	*****
	Total Tests:   1
	Total Passed:  1
	Total Failed:  0
	Total Skipped: 0
	Total Retried: 0

	Duration: 1 minutes
	Browser: chrome