### PR TITLE
ZCS-4442: Configure AWS public/private key for CLI and use possible API to run selenium tests AWS/CI server

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/core/ClientSession.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ClientSession.java
@@ -67,7 +67,7 @@ import java.util.zip.GZIPInputStream;
  * {@link ClientSession}.
  * <p>
  *
- * @author Matt Rhoades
+ * @author Matt Rhoades, Jitesh Sojitra
  *
  */
 
@@ -187,7 +187,7 @@ public class ClientSession {
 				System.setProperty("webdriver.gecko.driver", driverFilePath);
 				options.setCapability(CapabilityType.LOGGING_PREFS, logs);
 				webDriver = new FirefoxDriver(options);
-				
+
 				Dimension dimension = new Dimension(500, 500);
 				webDriver.manage().window().setSize(dimension);
 				webDriver.manage().window().maximize();
@@ -256,6 +256,7 @@ public class ClientSession {
 				options.setExperimentalOption("prefs", preferences);
 				options.addArguments("disable-infobars");
 				options.addArguments("start-maximized");
+				options.addArguments("--no-sandbox");
 
 		        System.setProperty("webdriver.chrome.driver", driverFilePath);
 		        options.setCapability("chrome.switches", Arrays.asList("--disable-extensions"));

--- a/src/java/com/zimbra/qa/selenium/framework/util/ConfigProperties.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ConfigProperties.java
@@ -237,22 +237,26 @@ public class ConfigProperties {
 	}
 
 	public static String zimbraGetVersionString() throws HarnessException {
+
 		// Get zimbra server version
-		logger.info("Getting zimbra server version...");
+		if (ExecuteHarnessMain.zimbraVersion == null || ExecuteHarnessMain.zimbraVersion == "") {
+			logger.info("Get zimbra server version...");
 
-		String buildType;
-		for (String zimbraVersion : CommandLineUtility.runCommandOnZimbraServer(ConfigProperties.getStringProperty("server.host"), "zmcontrol -v")) {
-			if (zimbraVersion.toLowerCase().contains("network")) {
-				buildType = "NETWORK";
-			} else {
-				buildType = "FOSS";
+			String buildType;
+			for (String zimbraVersion : CommandLineUtility
+					.runCommandOnZimbraServer(ConfigProperties.getStringProperty("server.host"), "zmcontrol -v")) {
+				if (zimbraVersion.toLowerCase().contains("network")) {
+					buildType = "NETWORK";
+				} else {
+					buildType = "FOSS";
+				}
+
+				Date date = new Date();
+				SimpleDateFormat dateTimeFormat = new SimpleDateFormat("hh.mm");
+
+				ExecuteHarnessMain.zimbraVersion = zimbraVersion.replace("Release ", "").split(" ")[0] + "_" + buildType
+						+ "-" + dateTimeFormat.format(date);
 			}
-
-			Date date = new Date();
-			SimpleDateFormat dateTimeFormat = new SimpleDateFormat("hh.mm");
-
-			ExecuteHarnessMain.zimbraVersion = zimbraVersion.replace("Release ", "").split(" ")[0] + "_" + buildType
-					+ "-" + dateTimeFormat.format(date);
 		}
 		return ExecuteHarnessMain.zimbraVersion;
 	}

--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
@@ -96,23 +96,21 @@ public class ZimbraAccount {
 
 	/*
 	 * Create an account with the email address <name>@<domain> The password is set
-	 * to config property "adminPwd"
+	 * to config property "adminPassword"
 	 */
 	public ZimbraAccount(String email, String password) {
 
 		if (email == null) {
 			DisplayName = ConfigProperties.getStringProperty("locale").toLowerCase().replace("_", "")
 					+ ConfigProperties.getUniqueString();
-			email = DisplayName + "@" + ConfigProperties.getStringProperty("testdomain", "testdomain.com");
+			email = DisplayName + "@" + ConfigProperties.getStringProperty("testdomain");
 		} else {
 			DisplayName = email.split("@")[0];
 		}
-
 		EmailAddress = email;
 
 		if (password == null) {
-			// password = ConfigProperties.getStringProperty("adminPwd", "test123");
-			password = "test123";
+			password = ConfigProperties.getStringProperty("adminPassword");
 		}
 		Password = password;
 	}
@@ -404,7 +402,7 @@ public class ZimbraAccount {
 		try {
 
 			if (exists()) {
-				logger.info(EmailAddress + " already exists.  Not provisioning again.");
+				logger.info(EmailAddress + " already exists. Not provisioning again.");
 				return (this);
 			}
 
@@ -1073,8 +1071,7 @@ public class ZimbraAccount {
 
 			setTransport(request);
 
-			// Remember the context, request, envelope and response for logging
-			// purposes
+			// Remember the context, request, envelope and response for logging purposes
 			requestBody = request;
 			requestEnvelope = mSoapProto.soapEnvelope(requestBody, context);
 

--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAdminAccount.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAdminAccount.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.log4j.*;
 import com.zimbra.common.soap.Element;
+import com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain;
 import com.zimbra.qa.selenium.projects.admin.items.AccountItem;
 
 public class ZimbraAdminAccount extends ZimbraAccount {
@@ -250,8 +251,8 @@ public class ZimbraAdminAccount extends ZimbraAccount {
 	public static synchronized ZimbraAdminAccount AdminConsoleAdmin() {
 		if (_AdminConsoleAdmin == null) {
 			try {
-				String name = "globaladmin" + ConfigProperties.getUniqueString();
-				String domain = ConfigProperties.getStringProperty("server.host", "zqa-062.eng.zimbra.com");
+				String name = ConfigProperties.getStringProperty("adminUser") + ConfigProperties.getUniqueString();
+				String domain = ExecuteHarnessMain.proxyServers.get(0);
 				_AdminConsoleAdmin = new ZimbraAdminAccount(name + "@" + domain);
 				_AdminConsoleAdmin.provision();
 				_AdminConsoleAdmin.authenticate();
@@ -283,16 +284,14 @@ public class ZimbraAdminAccount extends ZimbraAccount {
 
 	/**
 	 * Get the global admin account This account is defined in config.properties as
-	 * <adminName>@<server>
-	 * 
+	 * <adminUser>@<server>
+	 *
 	 * @return The global admin account
 	 */
 	public static synchronized ZimbraAdminAccount GlobalAdmin() {
 		if (_GlobalAdmin == null) {
-			// String name = "globaladmin@" + ConfigProperties.getStringProperty("");
-			String name = "globaladmin@"
-					+ ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".server.host",
-							ConfigProperties.getStringProperty("server.host"));
+			String name = ConfigProperties.getStringProperty("adminUser") + "@"
+					+ ExecuteHarnessMain.proxyServers.get(0);
 			_GlobalAdmin = new ZimbraAdminAccount(name);
 			_GlobalAdmin.authenticate();
 		}
@@ -312,7 +311,7 @@ public class ZimbraAdminAccount extends ZimbraAccount {
 			throw new HarnessException("GetVersionInfoRequest did not return GetVersionInfoResponse");
 
 		// Create a new global admin account
-		String domain = ConfigProperties.getStringProperty("server.host", "zqa-062.eng.zimbra.com");
+		String domain = ConfigProperties.getStringProperty("server.host");
 		ZimbraAdminAccount admin = new ZimbraAdminAccount("admin" + System.currentTimeMillis() + "@" + domain);
 		admin.provision(); // Create the account (CreateAccountRequest)
 		admin.authenticate(); // Authenticate the account (AuthRequest)


### PR DESCRIPTION
ZCS-4442: Configure AWS public/private key for CLI and use possible API to run selenium tests AWS/CI server

- options.addArguments("--no-sandbox"); is required for UBUNTU OS otherwise launching chrome fails
- Using admin user from configuration in case of public AWS server
- Using public/private key combinations which is added in AWS server