### PR TITLE
ZCS-4436: Replaced lmtpInject utility with SOAP AddMsgRequest

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
@@ -779,7 +779,7 @@ public class ZimbraAccount {
 	 * @return the attachment id, to be used with SaveDocumentRequest, for example
 	 * @throws HarnessException
 	 */
-	public String uploadFile(String filename) throws HarnessException {
+	public String uploadFileUsingRestUtil(String filename) throws HarnessException {
 		RestUtil util = new RestUtil();
 		util.setAuthentication(this);
 		util.setPath("/service/upload");

--- a/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCore.java
@@ -460,11 +460,6 @@ public class AdminCore {
 			}
 		}
 
-		// Get test PASSED/FAILED status
-		if (testResult.getStatus() == ITestResult.FAILURE){
-			//ZimbraAdminAccount.ResetAdminAccount();
-		}
-
 		logger.info("AfterMethod: finish");
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
@@ -836,11 +836,11 @@ public class AjaxCore {
 		}
 	}
 
-	// Inject message using SOAP AddMsgRequest
+	// Inject message using REST upload & SOAP AddMsgRequest
 	public void injectMessage (ZimbraAccount account, String filePath) throws HarnessException {
 		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
-		// Send the message from AccountA to the ZCS user
+		// Add message in selected account
 		try {
 			app.zGetActiveAccount().soapSend(
 				"<AddMsgRequest xmlns='urn:zimbraMail'>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
@@ -323,7 +323,7 @@ public class AjaxCore {
 
 	public File fGetJavaScriptErrorsHtmlFile() throws HarnessException {
 		String sJavaScriptErrorsFolderPath = ExecuteHarnessMain.testoutputfoldername
-				+ "\\debug\\projects\\javascript-errors";
+				+ "/debug/projects/javascript-errors";
 		String sJavaScriptErrorsHtmlFilePath = sJavaScriptErrorsFolderPath + "/" + sJavaScriptErrorsHtmlFileName;
 		File fJavaScriptErrorsHtmlFile = new File(sJavaScriptErrorsHtmlFilePath);
 		return fJavaScriptErrorsHtmlFile;
@@ -834,6 +834,20 @@ public class AjaxCore {
 		} catch (HarnessException e) {
 			logger.error("Unable to navigate to app.", e);
 		}
+	}
 
+	// Inject message using SOAP AddMsgRequest
+	public void injectMessage (ZimbraAccount account, String filePath) throws HarnessException {
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
+
+		// Send the message from AccountA to the ZCS user
+		try {
+			app.zGetActiveAccount().soapSend(
+				"<AddMsgRequest xmlns='urn:zimbraMail'>" +
+					"<m l='Inbox' f='u' aid='"+ attachmentId + "'></m>" +
+				"</AddMsgRequest>");
+		} catch (HarnessException e) {
+			throw new HarnessException("Unable to inject message: " + e);
+		}
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/CheckInFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/CheckInFile.java
@@ -55,7 +55,7 @@ public class CheckInFile extends EnableBriefcaseFeature {
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
@@ -118,7 +118,7 @@ public class CheckInFile extends EnableBriefcaseFeature {
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DeleteFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DeleteFile.java
@@ -58,7 +58,7 @@ public class DeleteFile extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"
@@ -106,7 +106,7 @@ public class DeleteFile extends EnableBriefcaseFeature {
 		Shortcut shortcut = Shortcut.S_DELETE;
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'><doc l='"
@@ -163,7 +163,7 @@ public class DeleteFile extends EnableBriefcaseFeature {
 		Shortcut shortcut = Shortcut.S_BACKSPACE;
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'><doc l='"
@@ -216,7 +216,7 @@ public class DeleteFile extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'><doc l='"
@@ -260,7 +260,7 @@ public class DeleteFile extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"
@@ -283,7 +283,7 @@ public class DeleteFile extends EnableBriefcaseFeature {
 				"Verify document was deleted through GUI");
 
 		// Re-Upload file to server through RestUtil
-		String attachId = account.uploadFile(filePath);
+		String attachId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DisplayFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DisplayFile.java
@@ -55,7 +55,7 @@ public class DisplayFile extends EnableBriefcaseFeature {
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
@@ -86,7 +86,7 @@ public class DisplayFile extends EnableBriefcaseFeature {
 		String subject = "test???test.txt";
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/EditFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/EditFile.java
@@ -59,7 +59,7 @@ public class EditFile extends EnableBriefcaseFeature {
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
@@ -115,7 +115,7 @@ public class EditFile extends EnableBriefcaseFeature {
 		IItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"
@@ -150,7 +150,7 @@ public class EditFile extends EnableBriefcaseFeature {
 		IItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId() + "'>"
@@ -192,8 +192,8 @@ public class EditFile extends EnableBriefcaseFeature {
 		String locator = "css=tr[id^='zlif__BDLV-main__'] div[id^='zlif__BDLV-main__']:contains('#1:')";
 
 		// Upload file to server through RestUtil
-		String attachment1Id = account.uploadFile(file1Path);
-		String attachment2Id = account.uploadFile(file1Path);
+		String attachment1Id = account.uploadFileUsingRestUtil(file1Path);
+		String attachment2Id = account.uploadFileUsingRestUtil(file1Path);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc desc='" + notesV1 + "' l='"
@@ -249,8 +249,8 @@ public class EditFile extends EnableBriefcaseFeature {
 		String locator = "css=tr[id^='zlif__BDLV-main__'] div[id^='zlif__BDLV-main__']:contains('#2:')";
 
 		// Upload file to server through RestUtil
-		String attachment1Id = account.uploadFile(file1Path);
-		String attachment2Id = account.uploadFile(file1Path);
+		String attachment1Id = account.uploadFileUsingRestUtil(file1Path);
+		String attachment2Id = account.uploadFileUsingRestUtil(file1Path);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/MoveFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/MoveFile.java
@@ -72,7 +72,7 @@ public class MoveFile extends EnableBriefcaseFeature {
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + folderItem.getId() + "'>"
@@ -137,7 +137,7 @@ public class MoveFile extends EnableBriefcaseFeature {
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + subFolders[0].getId() + "'>"
@@ -205,7 +205,7 @@ public class MoveFile extends EnableBriefcaseFeature {
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/OpenFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/OpenFile.java
@@ -58,7 +58,7 @@ public class OpenFile extends EnableBriefcaseFeature {
 		final String fileText = "test";
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/PreviewFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/PreviewFile.java
@@ -50,7 +50,7 @@ public class PreviewFile extends EnableBriefcaseFeature {
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
@@ -86,7 +86,7 @@ public class PreviewFile extends EnableBriefcaseFeature {
 		String fileContent = "test text file content";
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
@@ -121,7 +121,7 @@ public class PreviewFile extends EnableBriefcaseFeature {
 		String fileContent = "PDF Test File";
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/SendFileAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/SendFileAttachment.java
@@ -58,7 +58,7 @@ public class SendFileAttachment extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
@@ -112,7 +112,7 @@ public class SendFileAttachment extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/SendFileLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/SendFileLink.java
@@ -59,7 +59,7 @@ public class SendFileLink extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
@@ -119,7 +119,7 @@ public class SendFileLink extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/TagFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/TagFile.java
@@ -54,7 +54,7 @@ public class TagFile extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
@@ -121,7 +121,7 @@ public class TagFile extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()
@@ -177,7 +177,7 @@ public class TagFile extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UnTagFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UnTagFile.java
@@ -47,7 +47,7 @@ public class UnTagFile extends EnableBriefcaseFeature {
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>" + "<doc l='" + briefcaseFolder.getId()

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UploadFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UploadFile.java
@@ -56,7 +56,7 @@ public class UploadFile extends EnableBriefcaseFeature {
 		String fileName = fileItem.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"
@@ -131,7 +131,7 @@ public class UploadFile extends EnableBriefcaseFeature {
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/admin/SendFileLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/admin/SendFileLink.java
@@ -56,7 +56,7 @@ public class SendFileLink extends EnableBriefcaseFeature {
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = ZimbraAccount.AccountA().uploadFile(filePath);
+		String attachmentId = ZimbraAccount.AccountA().uploadFileUsingRestUtil(filePath);
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(ZimbraAccount.AccountA(), SystemFolder.Briefcase);
 
 		// Create a folder to share

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/manager/SendFileLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/manager/SendFileLink.java
@@ -56,7 +56,7 @@ public class SendFileLink extends EnableBriefcaseFeature {
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = ZimbraAccount.AccountA().uploadFile(filePath);
+		String attachmentId = ZimbraAccount.AccountA().uploadFileUsingRestUtil(filePath);
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(ZimbraAccount.AccountA(), SystemFolder.Briefcase);
 
 		// Create a folder to share

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/viewer/SendFileLink.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/mountpoints/viewer/SendFileLink.java
@@ -56,7 +56,7 @@ public class SendFileLink extends EnableBriefcaseFeature {
 		FileItem fileItem = new FileItem(filePath);
 
 		// Upload file to server through RestUtil
-		String attachmentId = ZimbraAccount.AccountA().uploadFile(filePath);
+		String attachmentId = ZimbraAccount.AccountA().uploadFileUsingRestUtil(filePath);
 		FolderItem briefcaseFolder = FolderItem.importFromSOAP(ZimbraAccount.AccountA(), SystemFolder.Briefcase);
 
 		// Create a folder to share

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/Forward.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/actions/Forward.java
@@ -219,7 +219,8 @@ public class Forward extends AjaxCore {
 		final String apptSubject = "Schedule for Generic Training";
 		final String apptContent = "<div>";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(apptSubject), "Verify message displayed in current view");
@@ -266,7 +267,8 @@ public class Forward extends AjaxCore {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug106342/bug106342.txt";
 		final String apptSubject = "Group photo with Steve";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(apptSubject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/viewappt/VerifyAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/attendee/singleday/viewappt/VerifyAttachment.java
@@ -43,7 +43,7 @@ public class VerifyAttachment extends AjaxCore {
 		//upload file to server
 		String filename = "BasicExcel2007.xlsx";
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/Files/Basic01/"+ filename;
-		String dAttachmentId  = account.uploadFile(filePath);
+		String dAttachmentId  = account.uploadFileUsingRestUtil(filePath);
 		// Create date object
 		String tz = ZTimeZone.getLocalTimeZone().getID();
 		Calendar now = Calendar.getInstance();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingUsingMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeetingUsingMessage.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.organizer.singleday.create;
 
-import java.io.File;
 import java.util.Calendar;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
@@ -58,7 +57,8 @@ public class CreateMeetingUsingMessage extends AjaxCore {
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 8, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -119,7 +119,8 @@ public class CreateMeetingUsingMessage extends AjaxCore {
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 9, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -179,7 +180,8 @@ public class CreateMeetingUsingMessage extends AjaxCore {
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 10, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -239,7 +241,8 @@ public class CreateMeetingUsingMessage extends AjaxCore {
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 11, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -298,7 +301,8 @@ public class CreateMeetingUsingMessage extends AjaxCore {
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 12, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -357,7 +361,8 @@ public class CreateMeetingUsingMessage extends AjaxCore {
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 13, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -417,7 +422,8 @@ public class CreateMeetingUsingMessage extends AjaxCore {
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 14, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 15, 0, 0);
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -478,7 +484,8 @@ public class CreateMeetingUsingMessage extends AjaxCore {
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 15, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 16, 0, 0);
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -537,7 +544,8 @@ public class CreateMeetingUsingMessage extends AjaxCore {
 		ZDate startUTC = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 16, 0, 0);
 		ZDate endUTC   = new ZDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH), 17, 0, 0);
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verify mail exists
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWhichContainsAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWhichContainsAttachment.java
@@ -41,10 +41,11 @@ public class ViewInviteWhichContainsAttachment extends AjaxCore {
 		ZimbraAccount account = app.zGetActiveAccount();
 		String apptSubject = ConfigProperties.getUniqueString();
 
-		//upload file to server
+		// Upload file to server
 		String filename = "BasicExcel2007.xlsx";
-		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/Files/Basic01/"+ filename;
-		String dAttachmentId  = account.uploadFile(filePath);
+		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/Files/Basic01/" + filename;
+		String dAttachmentId  = account.uploadFileUsingRestUtil(filePath);
+
 		// Create date object
 		String tz = ZTimeZone.getLocalTimeZone().getID();
 		Calendar now = Calendar.getInstance();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWithDisplayMailPreference.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/viewinvite/ViewInviteWithDisplayMailPreference.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.calendar.meetings.organizer.singleday.viewinvite;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -148,11 +147,11 @@ public class ViewInviteWithDisplayMailPreference extends AjaxCore {
 		String value = app.zGetActiveAccount().soapSelectValue("//acct:pref[@name='zimbraPrefMessageViewHtmlPreferred']", null);
 		ZAssert.assertEquals(value, "FALSE", "Verify zimbraPrefMessageViewHtmlPreferred preference changed to Text");
 
-		String filename = ConfigProperties.getBaseDirectory() + "/data/public/mime/email20/CalendarHTMLBody.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email20/CalendarHTMLBody.txt";
 		String subject = "multiline HTML body";
 
 		if (!app.zPageMail.zVerifyMailExists(subject)) {
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(filename));
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 		}
 
@@ -293,7 +292,7 @@ public class ViewInviteWithDisplayMailPreference extends AjaxCore {
 		final String subject = "multiline plain text body";
 
 		if (!app.zPageMail.zVerifyMailExists(subject)) {
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 		}
 		// Select the message so that it shows in the reading pane

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToBriefcase.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToBriefcase.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attachments;
 
-import java.io.File;
 import java.util.List;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -55,8 +54,8 @@ public class AddToBriefcase extends SetGroupMailByMessagePreference {
 
 		FolderItem folder = FolderItem.importFromSOAP(account, FolderItem.SystemFolder.Briefcase);
 
-		// Inject the message
-		LmtpInject.injectFile(account, new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Double check that there is an attachment
 		account.soapSend(
@@ -122,8 +121,8 @@ public class AddToBriefcase extends SetGroupMailByMessagePreference {
 
  		FolderItem folder = FolderItem.importFromSOAP(account, FolderItem.SystemFolder.Briefcase);
 
- 		// Inject the message
- 		LmtpInject.injectFile(account, new File(mimeFile));
+ 		// Inject the sample mime
+ 		injectMessage(app.zGetActiveAccount(), mimeFile);
 
  		// Double check that there is an attachment
  		account.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToCalendar.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attachments;
 
-import java.io.File;
 import java.util.List;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -56,7 +55,7 @@ public class AddToCalendar extends SetGroupMailByMessagePreference {
 		FolderItem folder = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Calendar);
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Double check that there is an attachment
 		account.soapSend(
@@ -124,7 +123,7 @@ public class AddToCalendar extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email08/mime03.txt";
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 
 		// Select the message so that it shows in the reading pane
@@ -192,10 +191,9 @@ public class AddToCalendar extends SetGroupMailByMessagePreference {
 		String foldername = "folder" + ConfigProperties.getUniqueString();
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email08/mime06.txt";
 
-		// Inject the message
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
-		SleepUtil.sleepMedium();
 
 		// Select the message so that it shows in the reading pane
 		DisplayMail display = (DisplayMail) app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
@@ -273,7 +271,7 @@ public class AddToCalendar extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email08/mime04.txt";
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 		SleepUtil.sleepMedium();
 
@@ -357,7 +355,7 @@ public class AddToCalendar extends SetGroupMailByMessagePreference {
 		String mountfolderid = app.zGetActiveAccount().soapSelectValue("//mail:link[@name='"+ mountpointname +"']", "id");
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Double check that there is an attachment
 		app.zGetActiveAccount().soapSend(
@@ -423,7 +421,7 @@ public class AddToCalendar extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email08/mime02.txt";
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 
 		// Adding additional code to go to Cal tab and click explicitly on Calendar header, so that new folder will create in upper level.

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AttachmentIcons.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AttachmentIcons.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attachments;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.AttachmentItem;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -40,7 +39,8 @@ public class AttachmentIcons extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email05/mime01.txt";
 		final String subject = "subject151615738";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -69,7 +69,8 @@ public class AttachmentIcons extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email05/mime03.txt";
 		final String subject = "subject13330659993903";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/CheckErrorAfterRemovingAttachement.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/CheckErrorAfterRemovingAttachement.java
@@ -1,4 +1,3 @@
-
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
@@ -17,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attachments;
 
-import java.io.File;
 import java.util.List;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -49,7 +47,7 @@ public class CheckErrorAfterRemovingAttachement extends SetGroupMailByMessagePre
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Verification for attachment
 		account.soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/GetAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/GetAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attachments;
 
-import java.io.File;
 import java.util.List;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -26,7 +25,6 @@ import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -49,7 +47,8 @@ public class GetAttachment extends SetGroupMailByMessagePreference {
 		final String subject = "subject151615738";
 		final String attachmentname = "file.txt";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -82,7 +81,8 @@ public class GetAttachment extends SetGroupMailByMessagePreference {
 		final String attachmentname2 = "file02.txt";
 		final String attachmentname3 = "file03.txt";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -127,7 +127,8 @@ public class GetAttachment extends SetGroupMailByMessagePreference {
 		final String subject = "FW: Christian cartoons [SEC=UNCLASSIFIED]";
 		final String fileName = "image001.gif";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -153,8 +154,8 @@ public class GetAttachment extends SetGroupMailByMessagePreference {
 		Element[] nodes = app.zGetActiveAccount().soapSelectNodes("//mail:mp[@filename='" + fileName + "']");
 		ZAssert.assertEquals(nodes.length, 1, "Verify attachment exist in the forwarded mail");
 	}
-	
-	
+
+
 	@Bugs (ids = "83052")
 	@Test (description = "Verify the presence of attachment in mail on the second attempt of Show Conversation",
 			groups = { "functional", "L3" })
@@ -167,7 +168,7 @@ public class GetAttachment extends SetGroupMailByMessagePreference {
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		// Inject a message with an attachment
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Double check that there is an attachment
 		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>" + "<query>subject:(" + subject
@@ -180,7 +181,7 @@ public class GetAttachment extends SetGroupMailByMessagePreference {
 
 		// Refresh current view and check the presence of mail
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
-		
+
 		// Switch to message view
 		app.zPageMail.zToolbarPressButton(Button.B_MAIL_VIEW_BY_MESSAGE);
 
@@ -200,10 +201,10 @@ public class GetAttachment extends SetGroupMailByMessagePreference {
 			}
 		}
 		ZAssert.assertNotNull(item, "No attachment is in the message");
-		
+
 		// Close the show conversation tab
 		app.zPageMail.zToolbarPressButton(Button.B_CLOSE_CONVERSATION);
-		
+
 		// Open the Show conversation view again and check the presence of attachment: Bug:83052
 		app.zPageMail.zToolbarPressPulldown(Button.B_ACTIONS, Button.O_SHOW_CONVERSATION);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/HoverOverAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/HoverOverAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attachments;
 
-import java.io.*;
 import java.util.*;
 import org.testng.annotations.*;
 import com.zimbra.qa.selenium.framework.core.*;
@@ -52,7 +51,9 @@ public class HoverOverAttachment extends SetGroupMailByMessagePreference {
 	public void HoverOverAttachment_01(String subject, String path) throws HarnessException {
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + path;
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Click on Get Mail to refresh the folder list
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/OpenAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/OpenAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attachments;
 
-import java.io.File;
 import java.util.List;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.AttachmentItem;
@@ -43,7 +42,8 @@ public class OpenAttachment extends SetGroupMailByMessagePreference {
 		final String attachmentname = "file.txt";
 		final String attachmentcontent = "Text Attachment Content";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/OpenAttachmentFromEMLAttachedInMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/OpenAttachmentFromEMLAttachedInMessage.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attachments;
 
-import java.io.File;
 import java.io.IOException;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -41,7 +40,8 @@ public class OpenAttachmentFromEMLAttachedInMessage extends SetGroupMailByMessag
 		final String subject = "Print2PDF Error";
 		final String subjecteml = "File conversion #27331";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/RemoveAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/RemoveAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attachments;
 
-import java.io.File;
 import java.util.List;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -46,7 +45,7 @@ public class RemoveAttachment extends SetGroupMailByMessagePreference {
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Double check that there is an attachment
 		account.soapSend(
@@ -122,7 +121,7 @@ public class RemoveAttachment extends SetGroupMailByMessagePreference {
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Double check that there is an attachment
 		account.soapSend(
@@ -191,7 +190,7 @@ public class RemoveAttachment extends SetGroupMailByMessagePreference {
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Double check that there is an attachment
 		account.soapSend(
@@ -268,7 +267,7 @@ public class RemoveAttachment extends SetGroupMailByMessagePreference {
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Double check that there is an attachment
 		account.soapSend(
@@ -336,7 +335,7 @@ public class RemoveAttachment extends SetGroupMailByMessagePreference {
 		ZimbraAccount account = app.zGetActiveAccount();
 
 		// Inject the message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Double check that there is an attachment
 		account.soapSend("<SearchRequest xmlns='urn:zimbraMail' types='message'>" + "<query>subject:(" + subject

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attributes/ZimbraAttachmentsViewInHtmlOnlyTrue.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attributes/ZimbraAttachmentsViewInHtmlOnlyTrue.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.attributes;
 
-import java.io.*;
 import java.util.*;
 import org.testng.annotations.*;
 import com.zimbra.qa.selenium.framework.items.*;
@@ -41,7 +40,8 @@ public class ZimbraAttachmentsViewInHtmlOnlyTrue extends SetGroupMailByMessagePr
 		final String subject = "subject151615738";
 		final String attachmentname = "file.txt";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/Forward.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/Forward.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.attachments;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.MailItem;
@@ -24,7 +23,6 @@ import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.projects.ajax.core.SetGroupMailByMessagePreference;
@@ -49,7 +47,7 @@ public class Forward extends SetGroupMailByMessagePreference {
 		final String mimeAttachmentName = "screenshot.JPG";
 
 		// Send the message to the test account
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -80,8 +78,8 @@ public class Forward extends SetGroupMailByMessagePreference {
 		String filename = ZimbraAccount.AccountB().soapSelectValue("//mail:mp[@cd='attachment']", "filename");
 		ZAssert.assertEquals(filename, mimeAttachmentName, "Verify the attachment exists in the forwarded mail");
 	}
-	
-	
+
+
 	@Test (description = "Forward a mail after removing the attachemnt",
 			groups = { "smoke", "L1" })
 
@@ -92,7 +90,7 @@ public class Forward extends SetGroupMailByMessagePreference {
 		final String attachmentName = "remove.txt";
 
 		// Send the message to the test account
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -102,10 +100,10 @@ public class Forward extends SetGroupMailByMessagePreference {
 
 		// Forward the item
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_FORWARD);
-		
+
 		// Remove the attachment
 		mailform.zRemoveAttachment(attachmentName);
-		
+
 		// Fill out the form with the data
 		mailform.zFillField(Field.To, ZimbraAccount.Account1().EmailAddress);
 
@@ -125,8 +123,8 @@ public class Forward extends SetGroupMailByMessagePreference {
 		String fileName = ZimbraAccount.Account1().soapSelectValue("//mail:mp[@cd='attachment']", "filename");
 		ZAssert.assertNull(fileName, "Verify the attachment is not present in the forwarded mail");
 	}
-	
-	
+
+
 	@Bugs(ids = "76776")
 	@Test (description = "Forward a mail having two attachments --> Remove one attachement and Cancel --> "
 								+ "Forward Again - Verify the number of attachement attachments",
@@ -140,7 +138,7 @@ public class Forward extends SetGroupMailByMessagePreference {
 		final String attachmentName2 = "2.png";
 
 		// Send the message to the test account
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -150,19 +148,19 @@ public class Forward extends SetGroupMailByMessagePreference {
 
 		// Forward the item
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_FORWARD);
-		
+
 		// Remove one of the attachments
 		mailform.zRemoveAttachment(attachmentName1);
-		
+
 		// Cancel the forward compose
 		mailform.zToolbarPressButton(Button.B_CANCEL);
-		
+
 		mailform = (FormMailNew) app.zPageMail.zToolbarPressButton(Button.B_FORWARD);
-		
+
 		// Check the presence of attachments
 		ZAssert.assertTrue(mailform.zHasAttachment(attachmentName1),"Verify attachment '" + attachmentName1 + "' is present");
 		ZAssert.assertTrue(mailform.zHasAttachment(attachmentName2),"Verify attachment '" + attachmentName2 + "' is present");
-		
+
 		// Fill out the form with the data
 		mailform.zFillField(Field.To, ZimbraAccount.AccountB().EmailAddress);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ForwardMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ForwardMailWithAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.attachments;
 
-import java.io.File;
 import org.openqa.selenium.Keys;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -44,13 +43,13 @@ public class ForwardMailWithAttachment extends SetGroupMailByMessagePreference {
 		try {
 
 			final String subject = "subjectAttachment";
-			final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email17/mime.txt";
+			final String mimeFile = ConfigProperties.getBaseDirectory() + "\\data\\public\\mime\\email17\\mime.txt";
 			final String mimeAttachmentName = "samplejpg.jpg";
 
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
 
 			// Send the message to the test account
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 
 			// Refresh current view
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -65,7 +64,7 @@ public class ForwardMailWithAttachment extends SetGroupMailByMessagePreference {
 			mailform.zFillField(Field.To, ZimbraAccount.AccountA().EmailAddress);
 
 			final String fileName = "testtextfile.txt";
-			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/" + fileName;
 
 			app.zPageMail.zPressButton(Button.B_ATTACH);
 			zUpload(filePath);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/Reply.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/Reply.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.attachments;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
 import com.zimbra.qa.selenium.framework.items.MailItem;
@@ -42,7 +41,8 @@ public class Reply extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email09/mime.txt";
 		final String subject = "subject13625192398933";
 
-		LmtpInject.injectFile(ZimbraAccount.AccountA(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem original = MailItem.importFromSOAP(ZimbraAccount.AccountA(), "subject:("+ mimeSubject +")");
 		ZAssert.assertNotNull(original, "Verify the message is received correctly");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyAll.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyAll.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.attachments;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
 import com.zimbra.qa.selenium.framework.items.MailItem;
@@ -40,10 +39,10 @@ public class ReplyAll extends SetGroupMailByMessagePreference {
 
 		final String mimeSubject = "subject1397778577518254677";
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email15/mime.txt";
-
 		final String subject = "subject13625192398933";
 
-		LmtpInject.injectFile(ZimbraAccount.AccountA(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem original = MailItem.importFromSOAP(ZimbraAccount.AccountA(), "subject:("+ mimeSubject +")");
 		ZAssert.assertNotNull(original, "Verify the message is received correctly");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyAllMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyAllMailWithAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.attachments;
 
-import java.io.File;
 import org.openqa.selenium.Keys;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -44,11 +43,12 @@ public class ReplyAllMailWithAttachment extends SetGroupMailByMessagePreference 
 		try {
 
 			final String mimeSubject = "subjectAttachment";
-			final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email17/mime.txt";
+			final String mimeFile = ConfigProperties.getBaseDirectory() + "\\data\\public\\mime\\email17\\mime.txt";
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
 			final String mimeAttachmentName = "samplejpg.jpg";
 
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			// Inject the sample mime
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 
 			MailItem original = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ mimeSubject +")");
 			ZAssert.assertNotNull(original, "Verify the message is received correctly");
@@ -66,7 +66,7 @@ public class ReplyAllMailWithAttachment extends SetGroupMailByMessagePreference 
 			mailform.zFillField(Field.To, ZimbraAccount.AccountB().EmailAddress);
 
 			final String fileName = "structure.jpg";
-			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/" + fileName;
 
 			app.zPageMail.zPressButton(Button.B_ATTACH);
 			zUpload(filePath);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/ReplyMailWithAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.attachments;
 
-import java.io.File;
 import org.openqa.selenium.Keys;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -44,11 +43,12 @@ public class ReplyMailWithAttachment extends SetGroupMailByMessagePreference {
 		try {
 
 			final String mimeSubject = "subjectAttachment";
-			final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email17/mime.txt";
+			final String mimeFile = ConfigProperties.getBaseDirectory() + "\\data\\public\\mime\\email17\\mime.txt";
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
 			final String mimeAttachmentName = "samplejpg.jpg";
 
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			// Inject the sample mime
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 
 			MailItem original = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ mimeSubject +")");
 			ZAssert.assertNotNull(original, "Verify the message is received correctly");
@@ -65,7 +65,7 @@ public class ReplyMailWithAttachment extends SetGroupMailByMessagePreference {
 			mailform.zFillField(Field.To, ZimbraAccount.AccountA().EmailAddress);
 
 			final String fileName = "structure.jpg";
-			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/" + fileName;
 
 			app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
 			app.zPageMail.zPressButton(Button.B_MY_COMPUTER);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendAs.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/delegates/SendAs.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.delegates;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
 import com.zimbra.qa.selenium.framework.core.Bugs;
@@ -123,7 +122,7 @@ public class SendAs extends SetGroupMailByMessagePreference {
 		final String mimeAttachmentName = "screenshot.JPG";
 
 		// Send the message to the test account
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/ReplyingMessageDoesntCreateDraft.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/ReplyingMessageDoesntCreateDraft.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.drafts;
 
-import java.io.*;
 import org.testng.annotations.*;
 import com.zimbra.common.soap.*;
 import com.zimbra.qa.selenium.framework.core.*;
@@ -41,9 +40,10 @@ public class ReplyingMessageDoesntCreateDraft extends SetGroupMailByMessagePrefe
 	public void ReplyingMessageDoesntCreateDraft_01() throws HarnessException {
 
 		String subject = "subject13690880312762";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug67686/mime01.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug67686";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/attachments/SaveDraftMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/attachments/SaveDraftMailWithAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.drafts.attachments;
 
-import java.io.File;
 import org.openqa.selenium.Keys;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -114,13 +113,14 @@ public class SaveDraftMailWithAttachment extends SetGroupMailByMessagePreference
 
 			// Create file item
 			final String mimeSubject = "subjectAttachment";
-			final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email17/mime.txt";
+			final String mimeFile = ConfigProperties.getBaseDirectory() + "\\data\\public\\mime\\email17\\mime.txt";
 			final String mimeAttachmentName = "samplejpg.jpg";
 
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
 			FolderItem drafts = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Drafts);
 
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			// Inject the sample mime
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 
 			// Refresh current view
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(mimeSubject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/attachments/SaveDraftMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/drafts/attachments/SaveDraftMailWithInlineImageAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.drafts.attachments;
 
-import java.io.File;
 import org.openqa.selenium.Keys;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -117,13 +116,14 @@ public class SaveDraftMailWithInlineImageAttachment extends SetGroupMailByMessag
 
 			// Create file item
 			final String mimeSubject = "subjectAttachment";
-			final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email17/mime.txt";
+			final String mimeFile = ConfigProperties.getBaseDirectory() + "\\data\\public\\mime\\email17\\mime.txt";
 			final String mimeAttachmentName = "samplejpg.jpg";
 
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
 			FolderItem drafts = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Drafts);
 
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			// Inject the sample mime
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 
 			// Refresh current view
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(mimeSubject), "Verify message displayed in current view");
@@ -147,7 +147,7 @@ public class SaveDraftMailWithInlineImageAttachment extends SetGroupMailByMessag
 			mailform.zFillField(Field.To, ZimbraAccount.AccountA().EmailAddress);
 
 			final String anotherFileName = "structure.jpg";
-			final String anotherFilePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + anotherFileName;
+			final String anotherFilePath = ConfigProperties.getBaseDirectory() + "/data/public/other/" + anotherFileName;
 
 			app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
 			app.zPageMail.zPressButton(Button.B_ATTACH_INLINE);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/formatting/ForwardMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/formatting/ForwardMail.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.formatting;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
 import com.zimbra.qa.selenium.framework.items.MailItem;
@@ -43,7 +42,8 @@ public class ForwardMail extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory()	+ "/data/public/mime/Excel_Data_Formatting_Mime.txt";
 		final String subject = "Test Excel Data Formatting";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/formatting/ReplyMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/formatting/ReplyMail.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.formatting;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
 import com.zimbra.qa.selenium.framework.items.MailItem;
@@ -42,7 +41,8 @@ public class ReplyMail extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Excel_Data_Formatting_Mime.txt";
 		final String subject = "Test Excel Data Formatting";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/formatting/ViewMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/formatting/ViewMail.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.formatting;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
@@ -39,7 +38,8 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Excel_Data_Formatting_Mime.txt";
 		final String subject = "Test Excel Data Formatting";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ForwardMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ForwardMailWithInlineImageAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.inlineimage;
 
-import java.io.File;
 import org.openqa.selenium.Keys;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -45,10 +44,11 @@ public class ForwardMailWithInlineImageAttachment extends SetGroupMailByMessageP
 		try {
 
 			final String mimeSubject = "subjectAttachment";
-			final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email17/mime.txt";
+			final String mimeFile = ConfigProperties.getBaseDirectory() + "\\data\\public\\mime\\email17\\mime.txt";
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
 
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			// Inject the sample mime
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 
 			MailItem original = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ mimeSubject +")");
 			ZAssert.assertNotNull(original, "Verify the message is received correctly");
@@ -65,7 +65,7 @@ public class ForwardMailWithInlineImageAttachment extends SetGroupMailByMessageP
 			mailform.zFillField(Field.To, ZimbraAccount.AccountA().EmailAddress);
 
 			final String fileName = "samplejpg.jpg";
-			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/" + fileName;
 
 			app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
 			app.zPageMail.zPressButton(Button.B_ATTACH_INLINE);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ReplyMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/ReplyMailWithInlineImageAttachment.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.compose.inlineimage;
 
-import java.io.File;
 import org.openqa.selenium.Keys;
 import org.testng.annotations.Test;
 import com.zimbra.common.soap.Element;
@@ -45,10 +44,11 @@ public class ReplyMailWithInlineImageAttachment extends SetGroupMailByMessagePre
 		try {
 
 			final String mimeSubject = "subjectAttachment";
-			final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email17/mime.txt";
+			final String mimeFile = ConfigProperties.getBaseDirectory() + "\\data\\public\\mime\\email17\\mime.txt";
 			FolderItem sent = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Sent);
 
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			// Inject the sample mime
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 
 			MailItem original = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:("+ mimeSubject +")");
 			ZAssert.assertNotNull(original, "Verify the message is received correctly");
@@ -65,7 +65,7 @@ public class ReplyMailWithInlineImageAttachment extends SetGroupMailByMessagePre
 			mailform.zFillField(Field.To, ZimbraAccount.AccountA().EmailAddress);
 
 			final String fileName = "samplejpg.jpg";
-			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory() + "/data/public/other/" + fileName;
 
 			app.zPageMail.zPressButton(Button.O_ATTACH_DROPDOWN);
 			app.zPageMail.zPressButton(Button.B_ATTACH_INLINE);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/attachments/GetAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/attachments/GetAttachment.java
@@ -16,13 +16,11 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.conversation.attachments;
 
-import java.io.File;
 import java.util.List;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.AttachmentItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.*;
@@ -44,7 +42,8 @@ public class GetAttachment extends SetGroupMailByConversationPreference {
 		final String subject = "subject151615738";
 		final String attachmentname = "file.txt";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -82,7 +81,8 @@ public class GetAttachment extends SetGroupMailByConversationPreference {
 		final String attachmentname2 = "file02.txt";
 		final String attachmentname3 = "file03.txt";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/conversations/CheckFromHeaderInConversationView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/conversations/CheckFromHeaderInConversationView.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.conversation.conversations;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import org.testng.annotations.Test;
@@ -26,9 +25,7 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
-import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.AjaxCore;
 
@@ -54,9 +51,10 @@ public class CheckFromHeaderInConversationView extends AjaxCore {
 
 		String subject = "Encoding test";
 		String to = "ljk20k00k1je";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug16213/bug16213att4501.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug16213";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Click on folder in the tree
 		FolderItem inbox = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Inbox);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/conversations/ReadMore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/conversations/ReadMore.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.conversation.conversations;
 
-import java.io.*;
 import org.testng.annotations.*;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
@@ -35,9 +34,10 @@ public class ReadMore extends SetGroupMailByConversationPreference {
 	public void ReadMore_01() throws HarnessException {
 
 		final String subject = "ReadMore13674340693103";
-		final String mimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/email11";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email11/mime01.txt";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmConv.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmConv.java
@@ -16,13 +16,11 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.conversation.performance;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.util.performance.*;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.*;
@@ -46,10 +44,11 @@ public class ZmConv extends AjaxCore {
 
 	public void ZmMailItem_01() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/conversation02";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/conversation02";
 		String subject = "Conversation13155016716714";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/performance/ZmMailApp.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.conversation.performance;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.util.*;
@@ -64,8 +63,10 @@ public class ZmMailApp extends AjaxCore {
 
 	public void ZmMailApp_02() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Fill out the login page
 		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
@@ -87,8 +88,10 @@ public class ZmMailApp extends AjaxCore {
 
 	public void ZmMailApp_03() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Fill out the login page
 		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/feeds/CheckFeedGeneratedMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/feeds/CheckFeedGeneratedMessage.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.feeds;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -41,9 +40,10 @@ public class CheckFeedGeneratedMessage extends SetGroupMailByMessagePreference {
 
 		String subject = "\"Wear-with-all\"";
 		String bodytext = "Barbara's suggestion:";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug52121/bug52121.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug52121";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckAcceptDeclineButtonsForInvite.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckAcceptDeclineButtonsForInvite.java
@@ -16,15 +16,12 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
-import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.SetGroupMailByMessagePreference;
 import com.zimbra.qa.selenium.projects.ajax.pages.mail.DisplayMail;
@@ -43,9 +40,10 @@ public class CheckAcceptDeclineButtonsForInvite extends SetGroupMailByMessagePre
 	public void CheckAcceptDeclineButtonsForInvite_01 () throws HarnessException {
 
 		String subject = "all-hands";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21013/bug21013att6662.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21013";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckMailContentForSpecificMimes.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckMailContentForSpecificMimes.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -41,9 +40,10 @@ public class CheckMailContentForSpecificMimes extends SetGroupMailByMessagePrefe
 		String subject = "subject13010064065623";
 		String bodyBeforeImage = "K\u00e6re alle";
 		String bodyAfterImage = "Problemet best\u00E5r";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug13911/bug13911att3713.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug13911";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -67,9 +67,10 @@ public class CheckMailContentForSpecificMimes extends SetGroupMailByMessagePrefe
 		String subject = "subject12998858731253";
 		String beginningContent = "Uso Interno";
 		String endingContent = "Esta mensagem";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21415/bug21415att10438.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21415";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -95,9 +96,10 @@ public class CheckMailContentForSpecificMimes extends SetGroupMailByMessagePrefe
 		String subject = "subject12998912514374";
 		String beginningContent = "Change 77406";
 		String endingContent = "SkinResources.java";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21415/bug21415att8124.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug21415";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -121,9 +123,10 @@ public class CheckMailContentForSpecificMimes extends SetGroupMailByMessagePrefe
 	public void CheckMailContentForSpecificMime_04() throws HarnessException {
 
 		String subject = "subject13001430504373";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug25624/bug25624att9322.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug25624";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -143,10 +146,10 @@ public class CheckMailContentForSpecificMimes extends SetGroupMailByMessagePrefe
 	public void CheckMailContentForSpecificMime_05() throws HarnessException {
 
 		String subject = "subject13001430504374";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug27796/bug27796att10515.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug27796";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
-
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -168,9 +171,10 @@ public class CheckMailContentForSpecificMimes extends SetGroupMailByMessagePrefe
 	public void CheckMailContentForSpecificMime_06() throws HarnessException {
 
 		String subject = "subject13002239738283";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug31535/bug34401att14395.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug31535";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -192,9 +196,10 @@ public class CheckMailContentForSpecificMimes extends SetGroupMailByMessagePrefe
 
 		String subject = "Fwd: test bug66192";
 		String bodytext = "Kind regards,";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/bug66192.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug66192";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckViewEntireMessageFunctionality.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/CheckViewEntireMessageFunctionality.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -39,10 +38,10 @@ public class CheckViewEntireMessageFunctionality extends SetGroupMailByMessagePr
 	public void CheckViewEntireMessageFunctionality_01() throws HarnessException  {
 
 		final String subject = "Bug39246";
-		final String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/viewEntireMessage_Bug39246.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/viewEntireMessage_Bug39246.txt";
 
-		// Inject the example message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Get Mail
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DisplayExternalImages.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DisplayExternalImages.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
@@ -24,13 +23,12 @@ import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.projects.ajax.core.SetGroupMailByMessagePreference;
 import com.zimbra.qa.selenium.projects.ajax.pages.mail.PageMail.Locators;
 
 public class DisplayExternalImages extends SetGroupMailByMessagePreference {
-	
+
 	public DisplayExternalImages() throws HarnessException {
 		logger.info("New "+ DisplayExternalImages.class.getCanonicalName());
 	}
@@ -44,8 +42,9 @@ public class DisplayExternalImages extends SetGroupMailByMessagePreference {
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/externalImage01/externalimage01.txt";
 		final String subject = "externalimage01";
-	
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -55,17 +54,17 @@ public class DisplayExternalImages extends SetGroupMailByMessagePreference {
 
 		// Verify warning info bar with other links
 		ZAssert.assertTrue(app.zPageMail.zHasWDDLinks(), "Verify display images link");
-		
+
 		// Click on 'Always display images sent from' email link to always display the external image
 		app.zPageMail.sClick(Locators.zMsgViewEmailLink);
-		
+
 		// Verify warning info bar with other links
 		ZAssert.assertFalse(app.zPageMail.sIsVisible(Locators.zMsgViewInfoBar), "Verify that info bar with links is not appearing now.");
-		
+
 		// Select the body frame and verify the external image is displayed
 		app.zPageMail.sSelectFrame("iframe[name$='__body__iframe']");
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zMsgExternalImage), "Verify the external is displayed");
-		
+
 		// Refresh the inbox folder and open the message again to check if the external image warning info bar is displayed
 		FolderItem inbox = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Inbox);
 		app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, inbox);
@@ -79,8 +78,8 @@ public class DisplayExternalImages extends SetGroupMailByMessagePreference {
 		app.zPageMail.sSelectFrame("iframe[name$='__body__iframe']");
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zMsgExternalImage), "Verify the external is displayed");
 	}
-	
-	
+
+
 	@Bugs (ids = "70600" )
 	@Test (description = "View the display of external images when user clicks on 'Always display images sent from' domain link",
 			groups = { "functional", "L3" })
@@ -89,9 +88,9 @@ public class DisplayExternalImages extends SetGroupMailByMessagePreference {
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/externalImage01/externalimage02.txt";
 		final String subject = "external image test";
-		
+
 		// Add the message to mailbox
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -101,17 +100,17 @@ public class DisplayExternalImages extends SetGroupMailByMessagePreference {
 
 		// Verify warning info bar with other links
 		ZAssert.assertTrue(app.zPageMail.zHasWDDLinks(), "Verify display images link");
-		
+
 		// Click on 'Always display images sent from' email link to always display the external image
 		app.zPageMail.sClick(Locators.zMsgViewDomainLink);
-		
+
 		// Verify warning info bar with other links
 		ZAssert.assertFalse(app.zPageMail.sIsVisible(Locators.zMsgViewInfoBar), "Verify that info bar with links is not appearing now.");
-		
+
 		// Select the body frame and verify the external image is displayed
 		app.zPageMail.sSelectFrame("iframe[name$='__body__iframe']");
 		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zMsgExternalImage), "Verify the external is displayed");
-		
+
 		// Refresh the inbox folder and open the message again to check if the external image warning info bar is displayed
 		FolderItem inbox = FolderItem.importFromSOAP(app.zGetActiveAccount(), FolderItem.SystemFolder.Inbox);
 		app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, inbox);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DisplayMailContent.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DisplayMailContent.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
@@ -56,7 +55,8 @@ public class DisplayMailContent extends SetGroupMailByMessagePreference {
 		final String colorBackgroundContent ="<span style=\"background-color: rgb(51, 153, 102);\">Green background</span></div>";
 		final String numberedListContent ="<ol><li>point one</li><li>point two</li><li>point three</li></ol>";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -110,7 +110,7 @@ public class DisplayMailContent extends SetGroupMailByMessagePreference {
 		final String subject = "subject13214016725788";
 
 		if (!app.zPageMail.zVerifyMailExists(subject)) {
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 		}
 
@@ -163,7 +163,8 @@ public class DisplayMailContent extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email19/multilineTextcontent.txt";
 		final String subject = "subject13214016777777";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -220,7 +221,7 @@ public class DisplayMailContent extends SetGroupMailByMessagePreference {
 
 		// If mail already exist from previous testcases then don't inject
 		if (!app.zPageMail.zVerifyMailExists(subject)) {
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+			injectMessage(app.zGetActiveAccount(), mimeFile);
 			ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 		}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/MessageDisplayShowsFromAsUnknown.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/MessageDisplayShowsFromAsUnknown.java
@@ -16,16 +16,13 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
-import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.AjaxCore;
 
@@ -51,14 +48,17 @@ public class MessageDisplayShowsFromAsUnknown extends AjaxCore {
 
 		String subject = "Encoding test";
 		String from = "Unknown";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug16213/bug16213att4501.txt";
 
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug16213";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(MimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
 
 		app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
-		ZAssert.assertEquals(app.zPageMail.sGetText("css=div[id='zv__TV-main'] div[id='zl__TV-main'] ul[id='zl__TV-main__rows'] div[class^='TopRow'] div span").trim(), from, "Verify the default string for 'From' is 'Unknown'");
+		ZAssert.assertEquals(app.zPageMail.sGetText(
+				"css=div[id='zv__TV-main'] div[id='zl__TV-main'] ul[id='zl__TV-main__rows'] div[class^='TopRow'] div span")
+				.trim(), from, "Verify the default string for 'From' is 'Unknown'");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/ReadMore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/ReadMore.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.*;
 import org.testng.annotations.*;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
@@ -35,9 +34,10 @@ public class ReadMore extends SetGroupMailByMessagePreference {
 	public void ViewMail_01() throws HarnessException {
 
 		final String subject = "ReadMore13674340693102";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/mime00.txt";
 
-		final String mimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/email11";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/SendMailWithSpecialCharacter.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/SendMailWithSpecialCharacter.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.*;
 import org.testng.annotations.*;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.*;
@@ -69,7 +68,9 @@ public class SendMailWithSpecialCharacter extends SetGroupMailByMessagePreferenc
 		String subject = "13680547408344 & 13680547408345";
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug82073/mime1.txt";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
+
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
 	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/ViewMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/ViewMail.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.File;
 import org.openqa.selenium.WebElement;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
@@ -30,9 +29,6 @@ import com.zimbra.qa.selenium.projects.ajax.pages.mail.PageMail.Locators;
 
 @SuppressWarnings("unused")
 public class ViewMail extends SetGroupMailByMessagePreference {
-
-	boolean injected = false;
-	final String mimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/email00";
 
 	public ViewMail() throws HarnessException {
 		logger.info("New "+ ViewMail.class.getCanonicalName());
@@ -48,11 +44,10 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String subject = "subject12996131112962";
 		final String from = "from12996131112962@example.com";
 		final String sender = "sender12996131112962@example.com";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email00/mime_wSender.txt";
 
-		if ( !injected ) {
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
-			injected = true;
-		}
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), subject);
 		ZAssert.assertNotNull(mail, "Verify message is received");
@@ -82,11 +77,10 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String subject = "subject13016959916873";
 		final String from = "from13016959916873@example.com";
 		final String replyto = "replyto13016959916873@example.com";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email00/mime_wReplyTo.txt";
 
-		if ( !injected ) {
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
-			injected = true;
-		}
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), subject);
 		ZAssert.assertNotNull(mail, "Verify message is received");
@@ -117,11 +111,10 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String subject = "subject13147509564213";
 		final String from = "from13011239916873@example.com";
 		final String resentfrom = "resentfrom13016943216873@example.com";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email00/mime_wResentFrom.txt";
 
-		if ( !injected ) {
-			LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
-			injected = true;
-		}
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), subject);
 		ZAssert.assertNotNull(mail, "Verify message is received");
@@ -148,12 +141,13 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 
 	public void ViewMail_04() throws HarnessException {
 
-		final String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug64444";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug64444/bug64444.txt";
 		final String subject = "subject13150123168433";
 		final String from = "from13160123168433@testdomain.com";
 		final String to = "to3163210168433@testdomain.com";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject +")");
 		ZAssert.assertNotNull(mail, "Verify message is received");
@@ -176,11 +170,12 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 
 	public void ViewMail_05() throws HarnessException {
 
-		final String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug66565";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug66565/mime01.txt";
 		final String subject = "subject13197565510464";
 		final String subjectText = "<u><i> subject13197565510464 </i></u>";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), "subject:(" + subject +")");
 		ZAssert.assertNotNull(mail, "Verify message is received");
@@ -206,11 +201,12 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 
 	public void ViewMail_06() throws HarnessException {
 
-		// Inject the sample mime
 		String subject = "subject13188948451403";
 		String content = "Welcome to the NetWorker Listserv list";
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug65933";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(MimeFolder));
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug65933/Bug65933.txt";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh the inbox
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -229,11 +225,12 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 
 	public void ViewMail_07() throws HarnessException {
 
-		// Inject the sample mime
 		String subject = "subject13189485723753";
 		String content = "Enrico Medici";
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug65623";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(MimeFolder));
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug65623.txt";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh the inbox
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -252,11 +249,12 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 
 	public void ViewMail_08() throws HarnessException {
 
-		// Inject the sample mime
 		String subject = "subject13189993282183";
 		String content = "Incident Title";
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug65079";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(MimeFolder));
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug65079/Bug65079.txt";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh the inbox
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -278,7 +276,8 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String subject = "subject13214016725788";
 		final String content = "The Ming Dynasty";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -300,7 +299,8 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String subject = "subject13214016672655";
 		final String content = "Bold";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -322,7 +322,8 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String subject = "subject13214016621403";
 		final String content = "Bold";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -341,11 +342,12 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 
 	public void ViewMail_12() throws HarnessException {
 
-		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug67854";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug67854/mime01.txt";
 		final String subject = "subject13218526621403";
 		final String content = "The message has no text content.";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -370,11 +372,12 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 
 	public void ViewMail_13() throws HarnessException {
 
-		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug72248";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug72248/mime.txt";
 		final String subject = "subject13217218621403";
 		final String content = "content1328844621403";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -395,11 +398,12 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 
 	public void ViewMail_14() throws HarnessException {
 
-		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug72233";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug72233/mime.txt";
 		final String subject = "bug72233";
 		final String htmlcontent = "html1328844621404";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -423,7 +427,8 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/externalImage01/externalimage01.txt";
 		final String subject = "externalimage01";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -446,7 +451,8 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String subject = "Very large message";
 		final String testString = "Entire message is displayed";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/ViewMailAsText.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/ViewMailAsText.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -26,9 +25,6 @@ import com.zimbra.qa.selenium.projects.ajax.pages.mail.DisplayMail;
 import com.zimbra.qa.selenium.projects.ajax.pages.mail.DisplayMail.Field;
 
 public class ViewMailAsText extends AjaxCore {
-
-	boolean injected = false;
-	final String mimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/email00";
 
 	public ViewMailAsText() throws HarnessException {
 		logger.info("New "+ ViewMailAsText.class.getCanonicalName());
@@ -51,7 +47,8 @@ public class ViewMailAsText extends AjaxCore {
 		final String subject = "subject13214016725788";
 		final String content = "The Ming Dynasty";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -73,7 +70,8 @@ public class ViewMailAsText extends AjaxCore {
 		final String subject = "subject13214016672655";
 		final String content = "Bold";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -95,7 +93,8 @@ public class ViewMailAsText extends AjaxCore {
 		final String subject = "subject13214016621403";
 		final String content = "The Ming Dynasty";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/CreateMailWithAnInlineImg.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/inlineimage/CreateMailWithAnInlineImg.java
@@ -52,7 +52,7 @@ public class CreateMailWithAnInlineImg extends SetGroupMailByMessagePreference {
 
 			// Create file item
 			final String fileName = "samplejpg.jpg";
-			final String filePath = ConfigProperties.getBaseDirectory()	+ "\\data\\public\\other\\" + fileName;
+			final String filePath = ConfigProperties.getBaseDirectory() + "\\data\\public\\other\\" + fileName;
 			SeparateWindowFormMailNew window = null;
 			String windowTitle = "Zimbra: Compose";
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/mail/ViewMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/newwindow/mail/ViewMail.java
@@ -16,14 +16,12 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.newwindow.mail;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.SetGroupMailByMessagePreference;
@@ -48,7 +46,7 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String from = "from12996131112962@example.com";
 		final String sender = "sender12996131112962@example.com";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder + "/mime_wSender.txt"));
+		injectMessage(app.zGetActiveAccount(), mimeFolder + "/mime_wSender.txt");
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), subject);
 		ZAssert.assertNotNull(mail, "Verify message is received");
@@ -95,7 +93,7 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String from = "from13016959916873@example.com";
 		final String replyto = "replyto13016959916873@example.com";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder + "/mime_wReplyTo.txt"));
+		injectMessage(app.zGetActiveAccount(), mimeFolder + "/mime_wReplyTo.txt");
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), subject);
 		ZAssert.assertNotNull(mail, "Verify message is received");
@@ -142,7 +140,7 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String from = "from13011239916873@example.com";
 		final String resentfrom = "resentfrom13016943216873@example.com";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder + "/mime_wResentFrom.txt"));
+		injectMessage(app.zGetActiveAccount(), mimeFolder + "/mime_wResentFrom.txt");
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(), subject);
 		ZAssert.assertNotNull(mail, "Verify message is received");
@@ -187,7 +185,8 @@ public class ViewMail extends SetGroupMailByMessagePreference {
 		final String subject = "bug72233";
 		final String htmlcontent = "html1328844621404";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailApp.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailApp.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.performance;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.util.*;
@@ -63,8 +62,10 @@ public class ZmMailApp extends AjaxCore {
 
 	public void ZmMailApp_02() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Fill out the login page
 		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);
@@ -86,8 +87,10 @@ public class ZmMailApp extends AjaxCore {
 
 	public void ZmMailApp_03() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";
-		LmtpInject.injectFile(ZimbraAccount.AccountZCS(), new File(mime));
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email03";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Fill out the login page
 		app.zPageLogin.zSetLoginName(ZimbraAccount.AccountZCS().EmailAddress);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailItem.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailItem.java
@@ -16,13 +16,11 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.performance;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.performance.*;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.*;
@@ -46,10 +44,11 @@ public class ZmMailItem extends AjaxCore {
 
 	public void ZmMailItem_01() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
 		String subject = "Subject13155016716713";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -65,10 +64,11 @@ public class ZmMailItem extends AjaxCore {
 
 	public void ZmMailItem_02() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
 		String subject = "Subject13155016716713";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -86,7 +86,9 @@ public class ZmMailItem extends AjaxCore {
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email05/mime01.txt";
 		final String subject = "subject151615738";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -104,7 +106,9 @@ public class ZmMailItem extends AjaxCore {
 
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email05/mime02.txt";
 		final String subject = "subject151111738";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailItemHTML.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/ZmMailItemHTML.java
@@ -16,13 +16,11 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.performance;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.performance.*;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.*;
@@ -46,10 +44,11 @@ public class ZmMailItemHTML extends AjaxCore {
 
 	public void ZmMailItem_01() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
 		String subject = "Subject13155016716713";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -65,10 +64,11 @@ public class ZmMailItemHTML extends AjaxCore {
 
 	public void ZmMailItem_02() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
 		String subject = "Subject13155016716713";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppFwdCompose.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppFwdCompose.java
@@ -16,13 +16,11 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.performance.compose;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.framework.util.performance.PerfKey;
@@ -49,11 +47,11 @@ public class ZmMailAppFwdCompose extends AjaxCore {
 
 	public void ZmMailAppFwdCompose_01() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
 		String subject = "Subject13155016716713";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
-
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -75,10 +73,11 @@ public class ZmMailAppFwdCompose extends AjaxCore {
 
 	public void ZmMailAppFwdCompose_02() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/largeconversation_mime.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/largeconversation_mime.txt";
 		String subject = "RESOLVED BUGS";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppReplyCompose.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/performance/compose/ZmMailAppReplyCompose.java
@@ -16,13 +16,11 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.performance.compose;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.framework.util.performance.PerfKey;
@@ -51,10 +49,11 @@ public class ZmMailAppReplyCompose extends AjaxCore {
 
 	public void ZmMailAppReplyCompose_01() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email02/mime01.txt";
 		String subject = "Subject13155016716713";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -75,10 +74,11 @@ public class ZmMailAppReplyCompose extends AjaxCore {
 
 	public void ZmMailAppReplyCompose_02() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/largeconversation_mime.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/largeconversation_mime.txt";
 		String subject = "RESOLVED BUGS";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -100,10 +100,11 @@ public class ZmMailAppReplyCompose extends AjaxCore {
 
 	public void ZmMailAppReplyCompose_03() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/Invite_Message.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Invite_Message.txt";
 		String subject = "Test Edit Reply";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
@@ -126,10 +127,11 @@ public class ZmMailAppReplyCompose extends AjaxCore {
 
 	public void ZmMailAppReplyCompose_04() throws HarnessException {
 
-		String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/inviteMessageWith7MBAttachment.txt";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/inviteMessageWith7MBAttachment.txt";
 		String subject = "Invite Message with 7 MB attachment";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/displayingmessages/ZimbraPrefDisplayExternalImages.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/displayingmessages/ZimbraPrefDisplayExternalImages.java
@@ -16,19 +16,16 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.preferences.mail.displayingmessages;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.AjaxCore;
 import com.zimbra.qa.selenium.projects.ajax.pages.mail.PageMail.Locators;
 import com.zimbra.qa.selenium.projects.ajax.pages.preferences.PagePreferences;
 import com.zimbra.qa.selenium.projects.ajax.pages.preferences.TreePreferences.TreeItem;
-
 
 public class ZimbraPrefDisplayExternalImages extends AjaxCore {
 
@@ -46,7 +43,8 @@ public class ZimbraPrefDisplayExternalImages extends AjaxCore {
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email18/AutomaticExternalImageDisplayMime.txt";
 		final String subject = "Display external image preference check";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyToMessageWithSignatureContainsImage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/mail/signatures/ReplyToMessageWithSignatureContainsImage.java
@@ -59,7 +59,7 @@ public class ReplyToMessageWithSignatureContainsImage extends AjaxCore {
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		// Save uploaded file to briefcase through SOAP
 		account.soapSend("<SaveDocumentRequest xmlns='urn:zimbraMail'>"

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainConversationView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainConversationView.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.preferences.trustedaddresses;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.FolderItem;
@@ -25,7 +24,6 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -63,7 +61,7 @@ public class TrustedDomainConversationView extends AjaxCore {
 		final String subject = "TestTrustedAddress";
 		final String from = "admintest@testdoamin.com";
 		final String to = "admin@testdoamin.com";
-		final String mimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
 		FolderItem inboxFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(),SystemFolder.Inbox);
 
 		// Verify domain through soap- GetPrefsRequest
@@ -71,7 +69,7 @@ public class TrustedDomainConversationView extends AjaxCore {
 		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdoamin.com"), "Verify doamin is present /Pref/TrustedAddr");
 
 		// Inject the external image message(s)
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(),subject);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainMessageView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainMessageView.java
@@ -16,14 +16,12 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.preferences.trustedaddresses;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -60,14 +58,14 @@ public class TrustedDomainMessageView extends AjaxCore {
 		final String subject = "TestTrustedAddress";
 		final String from = "admintest@testdoamin.com";
 		final String to = "admin@testdoamin.com";
-		final String mimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
 
 		// Verify domain through soap- GetPrefsRequest
 		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference("zimbraPrefMailTrustedSenderList");
 		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdoamin.com"), "Verify doamin is present /Pref/TrustedAddr");
 
 		// Inject the external image message(s)
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(),subject);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedEmailAddressMessageView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedEmailAddressMessageView.java
@@ -16,14 +16,12 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.preferences.trustedaddresses;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -60,14 +58,14 @@ public class TrustedEmailAddressMessageView extends AjaxCore {
 		final String subject = "TestTrustedAddress";
 		final String from = "admintest@testdoamin.com";
 		final String to = "admin@testdoamin.com";
-		final String mimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
 
 		// Verify Email id through soap GetPrefsRequest
 		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference("zimbraPrefMailTrustedSenderList");
 		ZAssert.assertTrue(PrefMailTrustedAddr.equals("admintest@testdoamin.com"), "Verify Email address is present /Pref/TrustedAddr");
 
 		// Inject the external image message(s)
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(),subject);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/UnTrustedDomainConversationView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/UnTrustedDomainConversationView.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.preferences.trustedaddresses;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
@@ -26,7 +25,6 @@ import com.zimbra.qa.selenium.framework.items.FolderItem.SystemFolder;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.projects.ajax.core.AjaxCore;
@@ -61,11 +59,11 @@ public class UnTrustedDomainConversationView extends AjaxCore {
 		final String subject = "TestTrustedAddress";
 		final String from = "admintest@testdoamin.com";
 		final String to = "admin@testdoamin.com";
-		final String mimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
 		FolderItem inboxFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(),SystemFolder.Inbox);
 
 		// Inject the external image message(s)
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(),subject);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/UnTrustedDomainMessageView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/UnTrustedDomainMessageView.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.preferences.trustedaddresses;
 
-import java.io.File;
 import java.util.HashMap;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
@@ -24,7 +23,6 @@ import com.zimbra.qa.selenium.framework.items.MailItem;
 import com.zimbra.qa.selenium.framework.ui.Action;
 import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.LmtpInject;
 import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
@@ -60,10 +58,10 @@ public class UnTrustedDomainMessageView extends AjaxCore {
 		final String subject = "TestTrustedAddress";
 		final String from = "admintest@testdoamin.com";
 		final String to = "admin@testdoamin.com";
-		final String mimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/ExternalImg.txt";
 
 		// Inject the external image message(s)
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFolder));
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		MailItem mail = MailItem.importFromSOAP(app.zGetActiveAccount(),subject);
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/CreateHtmlTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/CreateHtmlTask.java
@@ -230,7 +230,7 @@ public class CreateHtmlTask extends AjaxCore {
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/Files/Basic01/BasicExcel2007.xlsx";
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		app.zGetActiveAccount().soapSend(
 				"<CreateTaskRequest xmlns='urn:zimbraMail'>" +
@@ -282,7 +282,7 @@ public class CreateHtmlTask extends AjaxCore {
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		app.zGetActiveAccount().soapSend(
 				"<CreateTaskRequest xmlns='urn:zimbraMail'>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/CreateTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/CreateTask.java
@@ -221,7 +221,7 @@ public class CreateTask extends AjaxCore {
 		// Create file item
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/Files/Basic01/BasicExcel2007.xlsx";
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		app.zGetActiveAccount().soapSend(
 				"<CreateTaskRequest xmlns='urn:zimbraMail'>" +
@@ -268,7 +268,7 @@ public class CreateTask extends AjaxCore {
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		app.zGetActiveAccount().soapSend(
 				"<CreateTaskRequest xmlns='urn:zimbraMail'>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/EditTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/EditTask.java
@@ -275,7 +275,7 @@ public class EditTask extends AjaxCore{
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/Files/Basic01/BasicExcel2007.xlsx";
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		app.zGetActiveAccount().soapSend(
 				"<CreateTaskRequest xmlns='urn:zimbraMail'>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/attachments/OpenTaskContainsAttachmentMultipleTimes.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/attachments/OpenTaskContainsAttachmentMultipleTimes.java
@@ -64,7 +64,7 @@ public class OpenTaskContainsAttachmentMultipleTimes extends AjaxCore {
 		String fileName = file.getName();
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 
 		app.zGetActiveAccount().soapSend(

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/EditTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/EditTask.java
@@ -60,7 +60,7 @@ public class EditTask extends AjaxCore{
 		String filePath = ConfigProperties.getBaseDirectory() + "/data/public/Files/Basic01/BasicExcel2007.xlsx";
 
 		// Upload file to server through RestUtil
-		String attachmentId = account.uploadFile(filePath);
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
 		app.zGetActiveAccount().soapSend(
 				"<CreateTaskRequest xmlns='urn:zimbraMail'>" +

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/date/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/date/GetMessage.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.zimlets.date;
 
-import java.io.File;
 import java.util.*;
 import java.util.regex.Pattern;
 import org.testng.annotations.*;
@@ -125,10 +124,10 @@ public class GetMessage extends AjaxCore {
 	public void GetMessage_03() throws HarnessException {
 
 		final String subject = "subject12912323015009";
-		final String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/date01/en_us_valid_dates.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/date01/en_us_valid_dates.txt";
 
-		// Inject the example message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -162,10 +161,10 @@ public class GetMessage extends AjaxCore {
 	public void GetMessage_04() throws HarnessException {
 
 		final String subject = "subject1293323025009";
-		final String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/date01/en_us_invalid_dates.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/date01/en_us_invalid_dates.txt";
 
-		// Inject the example message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/phone/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/phone/GetMessage.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.zimlets.phone;
 
-import java.io.File;
 import java.util.*;
 import org.testng.annotations.*;
 import com.zimbra.qa.selenium.framework.core.Bugs;
@@ -133,10 +132,10 @@ public class GetMessage extends AjaxCore {
 	public void GetMessage_03() throws HarnessException {
 
 		final String subject = "subject12977323015009";
-		final String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email01/en_us_valid_phone.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email01/en_us_valid_phone.txt";
 
-		// Inject the example message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -186,10 +185,10 @@ public class GetMessage extends AjaxCore {
 	public void GetMessage_04() throws HarnessException {
 
 		final String subject = "subject12977323025009";
-		final String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/email01/en_us_invalid_phone.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email01/en_us_invalid_phone.txt";
 
-		// Inject the example message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/GetMessage.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.zimlets.url;
 
-import java.io.File;
 import java.util.*;
 import org.testng.annotations.*;
 import com.zimbra.qa.selenium.framework.core.Bugs;
@@ -133,12 +132,12 @@ public class GetMessage extends AjaxCore {
 	public void GetMessage_03() throws HarnessException {
 
 		final String subject = "subject12955323015009";
-		final String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/url01/valid_url.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/url01/valid_url.txt";
 		final String url1 = "http://www.zimbra.com";
 		final String url2 = "https://www.zimbra.com";
 
-		// Inject the example message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");
@@ -169,10 +168,10 @@ public class GetMessage extends AjaxCore {
 	public void GetMessage_04() throws HarnessException {
 
 		final String subject = "subject12976223025009";
-		final String mime = ConfigProperties.getBaseDirectory() + "/data/public/mime/url01/invalid_url.txt";
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/url01/invalid_url.txt";
 
-		// Inject the example message
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mime));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/HoverOverURL.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/HoverOverURL.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.zimlets.url;
 
-import java.io.*;
 import java.util.*;
 import org.testng.annotations.*;
 import com.zimbra.qa.selenium.framework.core.*;
@@ -127,7 +126,9 @@ public class HoverOverURL extends AjaxCore {
 		// Create the message data to be sent
 		String subject = "bug82303";
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/Bugs/Bug82303/mime.txt";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/videolive/GetMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/url/videolive/GetMessage.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.ajax.tests.zimlets.url.videolive;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.ui.*;
 import com.zimbra.qa.selenium.framework.util.*;
@@ -34,11 +33,11 @@ public class GetMessage extends AjaxCore {
 
 	public void GetMail_01() throws HarnessException {
 
-		// Inject the sample message
 		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email07/mime.txt";
 		final String subject = "subject135232705018411";
 
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(mimeFile));
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
 
 		// Refresh current view
 		ZAssert.assertTrue(app.zPageMail.zVerifyMailExists(subject), "Verify message displayed in current view");

--- a/src/java/com/zimbra/qa/selenium/projects/touch/core/TouchCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/core/TouchCore.java
@@ -338,11 +338,11 @@ public class TouchCore {
 		return elementPresent;
 	}
 
-	// Inject message using SOAP AddMsgRequest
+	// Inject message using REST upload & SOAP AddMsgRequest
 	public void injectMessage (ZimbraAccount account, String filePath) throws HarnessException {
 		String attachmentId = account.uploadFileUsingRestUtil(filePath);
 
-		// Send the message from AccountA to the ZCS user
+		// Add message in selected account
 		try {
 			app.zGetActiveAccount().soapSend(
 				"<AddMsgRequest xmlns='urn:zimbraMail'>" +

--- a/src/java/com/zimbra/qa/selenium/projects/touch/core/TouchCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/core/TouchCore.java
@@ -337,4 +337,19 @@ public class TouchCore {
 		}
 		return elementPresent;
 	}
+
+	// Inject message using SOAP AddMsgRequest
+	public void injectMessage (ZimbraAccount account, String filePath) throws HarnessException {
+		String attachmentId = account.uploadFileUsingRestUtil(filePath);
+
+		// Send the message from AccountA to the ZCS user
+		try {
+			app.zGetActiveAccount().soapSend(
+				"<AddMsgRequest xmlns='urn:zimbraMail'>" +
+					"<m l='Inbox' f='u' aid='"+ attachmentId + "'></m>" +
+				"</AddMsgRequest>");
+		} catch (HarnessException e) {
+			throw new HarnessException("Unable to inject message: " + e);
+		}
+	}
 }

--- a/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/views/conversation/ForwardImageMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/touch/tests/mail/views/conversation/ForwardImageMail.java
@@ -16,7 +16,6 @@
  */
 package com.zimbra.qa.selenium.projects.touch.tests.mail.views.conversation;
 
-import java.io.File;
 import org.testng.annotations.Test;
 import com.zimbra.qa.selenium.framework.core.Bugs;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -30,52 +29,56 @@ public class ForwardImageMail extends SetGroupMailByConversationPreference {
 	public ForwardImageMail() {
 		logger.info("New "+ ForwardImageMail.class.getCanonicalName());
 	}
-	
+
 	@Bugs (ids = "81331")
 	@Test (description = "Verify inline image present after hitting Forward from the mail",
 			groups = { "smoke" })
-			
+
 	public void ForwardInlineImageMail_01() throws HarnessException {
-		
-		String subject = "inline image testing";		
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/email13/inline image.txt";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(MimeFolder));
-		
+
+		String subject = "inline image testing";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email13/inline image.txt";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
+
 		// Select the mail from inbox
 		app.zPageMail.zToolbarPressButton(Button.B_FOLDER_TREE);
 		app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, "Inbox");
 		app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
-		
+
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressPulldown(Button.B_REPLY, Button.O_FORWARD);
 		ZAssert.assertTrue(app.zPageMail.zVerifyBodyContent(), "Verify the content of the mail");
 		ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageInReadingPane(), "Verify inline image showing in the reading pane");
 		mailform.zToolbarPressButton(Button.B_CANCEL);
-		
+
 	}
-	
+
 	@Bugs (ids = "81331")
 	@Test (description = "Forward a mail which contains inline image and verify it at the receipient side",
 			groups = { "functional" })
-			
+
 	public void ForwardInlineImageMail_02() throws HarnessException {
-		
+
 		String subject = "inline image testing";
 		String startTextOfBody = "body of the inline image starts..";
 		String endTextOfBody = "body of the inline image ends..";;
 		String imgSrc = "cid:c44b200d9264f34d048f41c1280beee5b1e7dd38@zimbra";
 		String modifiedContent = "modified body" + ConfigProperties.getUniqueString();
-		
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/email13/inline image.txt";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(MimeFolder));
-		
+
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email13/inline image.txt";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
+
 		// Select the mail from inbox
 		app.zPageMail.zToolbarPressButton(Button.B_FOLDER_TREE);
 		app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, "Inbox");
 		app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
-		
+
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressPulldown(Button.B_REPLY, Button.O_FORWARD);
 		ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageInComposedMessage(), "Verify image tag in the composed mail");
-		
+
 		mailform.zFillField(Field.To, ZimbraAccount.AccountB().EmailAddress);
 		mailform.zFillField(Field.Body, modifiedContent);
 		mailform.zSubmit();
@@ -86,7 +89,7 @@ public class ForwardImageMail extends SetGroupMailByConversationPreference {
 						+ "<query>" + "subject:(" + subject + ")</query>"
 						+ "</SearchRequest>");
 		String toid = ZimbraAccount.AccountB().soapSelectValue("//mail:m", "id");
-		
+
 		ZimbraAccount.AccountB().soapSend(
 				"<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + toid
 						+ "' html='1'/>" + "</GetMsgRequest>");
@@ -97,56 +100,58 @@ public class ForwardImageMail extends SetGroupMailByConversationPreference {
 		ZAssert.assertStringContains(tobody, modifiedContent, "Verify the modified content");
 		ZAssert.assertStringContains(tobody, imgSrc, "Verify the image tag");
 		ZAssert.assertTrue(app.zPageMail.zVerifyBodyContent(), "Verify image tag in the composed mail");
-		
+
 	}
-	
+
 	@Bugs (ids = "81069")
 	@Test (description = "Verify external image present after hitting Forward from the mail",
 			groups = { "functional" })
-			
+
 	public void ForwardExternalImageMail_03() throws HarnessException {
-		
-		String subject = "external image testing";		
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/email13/external image.txt";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(MimeFolder));
-		
+
+		String subject = "external image testing";
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email13/external image.txt";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
+
 		// Select the mail from inbox
 		app.zPageMail.zToolbarPressButton(Button.B_FOLDER_TREE);
 		app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, "Inbox");
 		app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
 		app.zPageMail.zToolbarPressButton(Button.B_LOAD_IMAGES);
-		
+
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressPulldown(Button.B_REPLY, Button.O_FORWARD);
 		//ZAssert.assertTrue(app.zPageMail.zVerifyBodyContent(), "Verify the content of the mail");
 		ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageInReadingPane(), "Verify inline image in the reading pane");
 		mailform.zToolbarPressButton(Button.B_CANCEL);
-		
+
 	}
-	
+
 	@Bugs (ids = "81069")
 	@Test (description = "Forward a mail which contains external image and verify it at the receipient side",
 			groups = { "functional" })
-			
+
 	public void ForwardExternalImageMail_04() throws HarnessException {
-		
+
 		String subject = "external image testing";
 		String startTextOfBody = "body of the image starts..";
 		String endTextOfBody = "body of the image ends..";
 		String imgSrc = "http://fileswwwzimbracom.s3.amazonaws.com/_res/images/try/Try-Page-Collab-8-5.png";
 		String modifiedContent = "modified body" + ConfigProperties.getUniqueString();
-		
-		String MimeFolder = ConfigProperties.getBaseDirectory() + "/data/public/mime/email13/external image.txt";
-		LmtpInject.injectFile(app.zGetActiveAccount(), new File(MimeFolder));
-		
+
+		String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/email13/external image.txt";
+		injectMessage (app.zGetActiveAccount(), mimeFile);
+
 		// Select the mail from inbox
 		app.zPageMail.zToolbarPressButton(Button.B_FOLDER_TREE);
 		app.zTreeMail.zTreeItem(Action.A_LEFTCLICK, "Inbox");
 		app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
 		//app.zPageMail.zToolbarPressButton(Button.B_LOAD_IMAGES); not required because previous test takes care of it
-		
+
 		FormMailNew mailform = (FormMailNew) app.zPageMail.zToolbarPressPulldown(Button.B_REPLY, Button.O_FORWARD);
 		ZAssert.assertTrue(app.zPageMail.zVerifyInlineImageInComposedMessage(), "Verify image tag in the composed mail");
-		
+
 		mailform.zFillField(Field.To, ZimbraAccount.AccountB().EmailAddress);
 		mailform.zFillField(Field.Body, modifiedContent);
 		mailform.zSubmit();
@@ -157,7 +162,7 @@ public class ForwardImageMail extends SetGroupMailByConversationPreference {
 						+ "<query>subject:(" + subject + ")</query>"
 						+ "</SearchRequest>");
 		String toid = ZimbraAccount.AccountB().soapSelectValue("//mail:m", "id");
-		
+
 		ZimbraAccount.AccountB().soapSend(
 				"<GetMsgRequest xmlns='urn:zimbraMail'>" + "<m id='" + toid
 						+ "' html='1'/>" + "</GetMsgRequest>");
@@ -168,7 +173,7 @@ public class ForwardImageMail extends SetGroupMailByConversationPreference {
 		ZAssert.assertStringContains(tobody, modifiedContent, "Verify the modified content");
 		ZAssert.assertStringContains(tobody, imgSrc, "Verify the image tag");
 		ZAssert.assertTrue(app.zPageMail.zVerifyBodyContent(), "Verify image tag in the composed mail");
-		
+
 	}
-	
+
 }


### PR DESCRIPTION
ZCS-4436: Replaced lmtpInject utility with SOAP AddMsgRequest

- Replaced uploadFile to uploadFileUsingRestUtil
- Replaced lmtpInject utility with SOAP AddMsgRequest
- Fixed all the mimeFolder to use mimeFile with specific conventions
- Added new method to inject message using AddMsgRequest in AjaxCore

	// Inject message using REST upload & SOAP AddMsgRequest
	public void injectMessage (ZimbraAccount account, String filePath) throws HarnessException {
		String attachmentId = account.uploadFileUsingRestUtil(filePath);

		// Add message in selected account
		try {
			app.zGetActiveAccount().soapSend(
				"<AddMsgRequest xmlns='urn:zimbraMail'>" +
					"<m l='Inbox' f='u' aid='"+ attachmentId + "'></m>" +
				"</AddMsgRequest>");
		} catch (HarnessException e) {
			throw new HarnessException("Unable to inject message: " + e);
		}
	}