### PR TITLE
ZCS-4677: Add test to verify the working of zimbraFileUploadMaxSize attribute while uploading a file to briefcase

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/pages/briefcase/DialogUploadFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/pages/briefcase/DialogUploadFile.java
@@ -19,8 +19,13 @@ package com.zimbra.qa.selenium.projects.ajax.pages.briefcase;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.interactions.Actions;
-import com.zimbra.qa.selenium.framework.ui.*;
+import com.zimbra.qa.selenium.framework.ui.AbsApplication;
+import com.zimbra.qa.selenium.framework.ui.AbsDialog;
+import com.zimbra.qa.selenium.framework.ui.AbsPage;
+import com.zimbra.qa.selenium.framework.ui.AbsTab;
+import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
+import com.zimbra.qa.selenium.framework.util.SleepUtil;
 
 public class DialogUploadFile extends AbsDialog {
 
@@ -28,6 +33,7 @@ public class DialogUploadFile extends AbsDialog {
 		public static final String zDialogClass = "css=div.ZmUploadDialog";
 		public static final String zTitleCLass = "DwtDialogTitle";
 		public static final String zDialogButtonsClass = "DwtDialogButtonBar";
+		public static final String zUploadStatusMessage = "css=div.ZmUploadDialog td[id$='_msg']";
 	}
 
 	public DialogUploadFile(AbsApplication application, AbsTab page) {
@@ -91,6 +97,9 @@ public class DialogUploadFile extends AbsDialog {
 		}
 
 		this.sClickAt(locator, "0,0");
+		if(button == Button.B_OK) {
+			SleepUtil.sleepLongMedium();
+		}
 		this.zWaitForBusyOverlay();
 
 		return (null);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/pages/briefcase/PageBriefcase.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/pages/briefcase/PageBriefcase.java
@@ -1246,6 +1246,9 @@ public class PageBriefcase extends AbsTab {
 		logger.info(myPageName() + " zToolbarPressButton(" + button + ")");
 
 		tracer.trace("Press the " + button + " button");
+		
+		String locator = null;
+		AbsPage page = null;
 
 		if (button == null)
 			throw new HarnessException("Button cannot be null!");
@@ -1254,8 +1257,19 @@ public class PageBriefcase extends AbsTab {
 
 			return (((AjaxPages) this.MyApplication).zPageMain.zToolbarPressButton(Button.B_REFRESH));
 
+		} else if (button == Button.B_UPLOAD_FILE) {
+			
+			locator = Locators.zUploadFileTitleBtn.locator;
+
+			page = new DialogUploadFile(MyApplication, this);
 		}
-		return (null);
+		
+		this.sClickAt(locator, "0,0");
+		SleepUtil.sleepMedium();
+
+		zWaitForBusyOverlay();
+
+		return (page);
 
 	}
 


### PR DESCRIPTION
Added automation test to verify the working of zimbraFileUploadMaxSize attribute while uploading a file to briefcase

Bug 81323 - zimbraFileUploadMaxSize does not restrict to upload attachment exceeding the value