### PR TITLE
ZCS-4679: Added test to verify that email addresses containing '-', '_' etc. are displayed in bubbles in message header

### DIFF
--- a/data/public/mime/unrecognizedEmailAddress.txt
+++ b/data/public/mime/unrecognizedEmailAddress.txt
@@ -1,0 +1,356 @@
+Delivered-To: testmail@gmail.com
+Received: by 10.231.15.129 with SMTP id k1cs40560iba;
+        Mon, 14 Mar 2011 03:05:31 -0700 (PDT)
+Received: from mr.google.com ([10.231.181.20])
+        by 10.231.181.20 with SMTP id bw20mr12479207ibb.101.1300097131040 (num_hops = 1);
+        Mon, 14 Mar 2011 03:05:31 -0700 (PDT)
+Received: by 10.231.181.20 with SMTP id bw20mr9575747ibb.101.1300097131023;
+        Mon, 14 Mar 2011 03:05:31 -0700 (PDT)
+X-Forwarded-To: testmail@gmail.com
+X-Forwarded-For: testmail@gmail.com testmail@gmail.com
+Delivered-To: testmail@gmail.com
+Received: by 10.231.31.10 with SMTP id w10cs93537ibc;
+        Mon, 14 Mar 2011 03:05:30 -0700 (PDT)
+Received: by 10.42.117.68 with SMTP id s4mr1138352icq.348.1300097129833;
+        Mon, 14 Mar 2011 03:05:29 -0700 (PDT)
+Return-Path: <killroy35.5@hotmail.com>
+Received: from blu0-omc1-s12.blu0.hotmail.com (blu0-omc1-s12.blu0.hotmail.com [65.55.116.23])
+        by mx.google.com with ESMTP id xf6si18994529icb.86.2011.03.14.03.05.27;
+        Mon, 14 Mar 2011 03:05:29 -0700 (PDT)
+Received-SPF: pass (google.com: domain of killroy35.5@hotmail.com designates 65.55.116.23 as permitted sender) client-ip=65.55.116.23;
+Authentication-Results: mx.google.com; spf=pass (google.com: domain of killroy35.5@hotmail.com designates 65.55.116.23 as permitted sender) smtp.mail=killroy35.5@hotmail.com
+Received: from BLU154-W56 ([65.55.116.8]) by blu0-omc1-s12.blu0.hotmail.com with Microsoft SMTPSVC(6.0.3790.4675);
+	 Mon, 14 Mar 2011 03:05:27 -0700
+Return-Path: killroy35.5@hotmail.com
+Content-Type: multipart/alternative;
+	boundary="_5c38a7c9-bf62-4cff-b65a-a31e5eb3e9c8_"
+X-Originating-IP: [88.243.143.150]
+From: =?windows-1254?B?bXV6YWZmZXIgdGH+5/0=?= <killroy35.5@hotmail.com>
+To: <ay__@msn.com>, <godoxs_@hotmail.com>, <cenkkaya@residencehotel.com.tr>, <cettia@cettia.com>,
+	<cilgin.kiz.35@hotmail.com>, <cizgi1963@hotmail.com>, <deniz-sirtikkizil@hotmail.com>
+Subject: Email address bubble check
+Date: Mon, 14 Mar 2011 12:05:26 +0200
+Importance: Normal
+In-Reply-To: <BLU156-w62A9FAF76AA07CC456A0BED6C90@phx.gbl>
+References:
+ <007e01cbda50$e0f7dbd0$a2e79370$@com>,<AANLkTimHx6OdEF6q59hV9m2N=1sPV3RTYe4WxbGEWt7_@mail.gmail.com>,<BLU156-w62A9FAF76AA07CC456A0BED6C90@phx.gbl>
+MIME-Version: 1.0
+X-OriginalArrivalTime: 14 Mar 2011 10:05:27.0234 (UTC) FILETIME=[57AAC220:01CBE22F]
+
+--_5c38a7c9-bf62-4cff-b65a-a31e5eb3e9c8_
+Content-Type: text/plain; charset="windows-1254"
+Content-Transfer-Encoding: 8bit
+
+
+
+
+From: tdidem84@hotmail.com
+To: benidemadan@hotmail.com; camur85@gmail.com; camurun_erki@hotmail.com; can_850@hotmail.com; dnzknclr@hotmail.com; deniz-sirtikkizil@hotmail.com; elcin_durukan@hotmail.com; ezelokcu@hotmail.com; nemesisnewa@hotmail.com; gamzedogan2011@hotmail.com; hvurmaz@hotmail.com; killroy35.5@hotmail.com; midwife_nirse@hotmail.com; umitdogan78@hotmail.com
+Subject: FW: Ben �zel insanlara g�nderdim::)))
+Date: Wed, 9 Mar 2011 11:36:55 +0200
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+Date: Fri, 4 Mar 2011 12:26:31 +0200
+Subject: Ben �zel insanlara g�nderdim::)))
+From: hvurmaz@gmail.com
+
+
+
+
+
+
+
+ 
+
+
+
+
+
+ 
+
+
+
+
+
+
+
+
+ 
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+
+
+
+Bakal�m geri yollar m�s�n?
+
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+ 
+
+Kar�ncaya sormu�lar; '' nereye gidiyorsun?'', '' dostuma'', demi�. ''Bu bacaklarla zor''  demi�ler. Kar�nca; '' olsun, varamasam da yolunda �l�r�m'' demi�.. Yolunda �l�necek dostlara...
+
+
+
+
+
+ 
+
+
+Fark�nda olmayabilirsin ama %100 do�ru: 
+ 
+1. Bu d�nyada u�runda �lebilece�in en az iki ki�i vard�r. 
+2. En az�ndan 15 ki�i �yle ya da b�yle seni seviyordur. 
+3. Herhangi birinin senden nefret edebilmesinin tek sebebi, asl�nda sadece senin gibi olmak istemesidir. 
+4. Senden gelecek bir g�l�mseme baz�lar�na mutluluk getirebilir, o senden ho�lanmasa bile. 
+5. Her gece, birisi uykuya dalmadan �nce seni d���n�yor. 
+6. Birisi i�in d�nyalara bedelsin. 
+7. �ok �zel ve teksin d���ncesinde ki arkada�lar�n� unutma 
+8. Varl���n� bile bilmedi�in biri seni seviyor.  
+9. Hayat�ndaki en b�y�k hatay� yapt���n zamanda bile, ondan hay�rl� bir�ey ��kar. 
+10. Ne zaman d�nya sana s�rt�n� d�nm�� gibi hissedersen, d�n ve bir daha bak. SANMA K� DERT SADECE SENDE VAR..
+11. Her zaman ald���n iltifatlar� hat�rla. Kaba s�zlerin hepsini unut. 
+  
+E�er sevgi dolu bir arkada�san bunu herkese g�nder, sana g�nderen de dahil.
+
+E�er geri al�rsan demek ki ger�ekten seviliyorsun. .
+
+Ve hep hat�rla.... 
+
+�yi arkada�lar y�ld�zlar gibidir, onlar� her zaman g�remeyebilirsin ama orada olduklar�n� bilirsin.
+
+'Bir dosttan tek bir g�l ve g�zel bir s�z� ben onunlayken almay�,
+
+�ld�kten sonraki bir kamyon dolusu �i�e�e tercih ederim.'
+
+HER ZAMAN YANIMDA OLMASINI �STED���M �NSANLARA...
+
+.
+  		 	   		  
+--_5c38a7c9-bf62-4cff-b65a-a31e5eb3e9c8_
+Content-Type: text/html; charset="windows-1254"
+Content-Transfer-Encoding: 8bit
+
+<html>
+<head>
+<style><!--
+.hmmessage P
+{
+margin:0px;
+padding:0px
+}
+body.hmmessage
+{
+font-size: 10pt;
+font-family:Tahoma
+}
+--></style>
+</head>
+<body class='hmmessage'>
+<br><br><hr id="stopSpelling">From: tdidem84@hotmail.com<br>To: benidemadan@hotmail.com; camur85@gmail.com; camurun_erki@hotmail.com; can_850@hotmail.com; dnzknclr@hotmail.com; deniz-sirtikkizil@hotmail.com; elcin_durukan@hotmail.com; ezelokcu@hotmail.com; nemesisnewa@hotmail.com; gamzedogan2011@hotmail.com; hvurmaz@hotmail.com; killroy35.5@hotmail.com; midwife_nirse@hotmail.com; umitdogan78@hotmail.com<br>Subject: FW: Ben �zel insanlara g�nderdim::)))<br>Date: Wed, 9 Mar 2011 11:36:55 +0200<br><br>
+
+<meta http-equiv="Content-Type" content="text/html; charset=unicode">
+<meta name="Generator" content="Microsoft SafeHTML">
+<style>
+.ExternalClass .ecxhmmessage P
+{padding:0px;}
+.ExternalClass body.ecxhmmessage
+{font-size:10pt;font-family:Tahoma;}
+
+</style>
+
+
+<br>&nbsp;<br>
+
+<hr id="ecxstopSpelling">
+Date: Fri, 4 Mar 2011 12:26:31 +0200<br>Subject: Ben �zel insanlara g�nderdim::)))<br>From: hvurmaz@gmail.com<br><br><br>
+<div class="ecxgmail_quote">
+<div lang="TR">
+<div>
+<p class="ecxMsoNormal"><span style="font-size:10pt"><br>&nbsp;</span></p>
+<div style="text-align:center" class="ecxMsoNormal" align="center"><span style="font-size:10pt">
+<hr align="center" size="2" width="100%">
+</span></div>
+<p class="ecxMsoNormal"><span style="font-size:10pt"><br><br>&nbsp;</span></p>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<p class="ecxMsoNormal"><b><span style="font-size:10pt">&nbsp;</span></b></p>
+<p class="ecxMsoNormal"><b><span style="font-size:10pt">&nbsp;</span></b></p>
+<div>
+<div>
+<div>
+<blockquote style="border-bottom:medium none;border-left:black 1.5pt solid;padding-bottom:0cm;padding-left:4pt;padding-right:0cm;margin-bottom:5pt;margin-left:3.75pt;border-top:medium none;border-right:medium none;padding-top:0cm">
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<div>
+<table style="margin-left:10.5pt" border="0" cellspacing="0" cellpadding="0">
+<tbody>
+<tr>
+<td style="padding-bottom:0cm;padding-left:0cm;padding-right:0cm;padding-top:0cm" valign="top">
+<blockquote style="margin-bottom:5pt">
+<div>
+<div>
+<table border="0" cellspacing="0" cellpadding="0">
+<tbody>
+<tr>
+<td style="padding-bottom:0cm;padding-left:0cm;padding-right:0cm;padding-top:0cm" valign="top">
+<blockquote style="margin-bottom:5pt">
+<div>
+<div>
+<div>
+<p class="ecxMsoNormal">&nbsp;</p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tbody>
+<tr>
+<td style="padding-bottom:0cm;padding-left:0cm;padding-right:0cm;padding-top:0cm" valign="top">
+<blockquote style="margin-bottom:5pt">
+<div>
+<div>
+<p style="margin-bottom:12pt" class="ecxMsoNormal"><b><span style="background:white;color:red">Bakal�m geri yollar m�s�n?</span></b></p></div>
+<div>
+<blockquote style="margin-bottom:5pt">
+<div>
+<blockquote style="margin-bottom:5pt">
+<div>
+<div>
+<p style="background:whitesmoke" class="ecxMsoNormal">&nbsp;</p></div>
+<div>
+<p style="background:whitesmoke" class="ecxMsoNormal">&nbsp;</p></div>
+<div>
+<p style="background:whitesmoke" class="ecxMsoNormal">&nbsp;</p></div>
+<div>
+<p style="background:whitesmoke" class="ecxMsoNormal">&nbsp;</p></div>
+<div>
+<p style="background:whitesmoke" class="ecxMsoNormal">&nbsp;</p></div>
+<div>
+<p style="margin-bottom:12pt;background:whitesmoke" class="ecxMsoNormal"><b><span style="font-size:16pt">Kar�ncaya sormu�lar; ''&nbsp;nereye gidiyorsun?'', ''&nbsp;dostuma'', demi�. ''Bu bacaklarla zor'' &nbsp;demi�ler. Kar�nca; ''&nbsp;olsun, varamasam da yolunda �l�r�m'' demi�.. Yolunda �l�necek dostlara...</span></b></p></div>
+<div>
+<div style="text-align:center;background:whitesmoke" class="ecxMsoNormal" align="center"><span style="font-size:10pt">
+<hr align="center" size="2" width="100%">
+</span></div></div>
+<div>
+<p style="margin-bottom:12pt;background:whitesmoke" class="ecxMsoNormal">&nbsp;</p></div></div>
+<div>
+<div>
+<p class="ecxMsoNormal"><b><i><u><span style="font-size:18pt">Fark�nda&nbsp;olmayabilirsin&nbsp;ama&nbsp;%100&nbsp;do�ru:&nbsp;</span></u></i></b><span style="color:black;font-size:10pt"><br></span><b><i><u><span style="color:purple;font-size:18pt">&nbsp;</span></u></i></b><b><span style="color:purple;font-size:18pt"><br></span></b><b><span style="color:fuchsia;font-size:18pt">1.&nbsp;</span></b><b><span style="color:black;font-size:18pt">Bu d�nyada u�runda �lebilece�in en az iki ki�i vard�r.&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:fuchsia;font-size:18pt">2.</span></b><b><span style="color:black;font-size:18pt">&nbsp;En az�ndan 15 ki�i �yle ya da b�yle seni seviyordur.&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:fuchsia;font-size:18pt">3.</span></b><b><span style="color:black;font-size:18pt">&nbsp;Herhangi birinin senden nefret edebilmesinin tek sebebi, asl�nda sadece senin gibi olmak istemesidir.&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:red;font-size:18pt">4.</span></b><b><span style="color:black;font-size:18pt">&nbsp;Senden gelecek bir g�l�mseme baz�lar�na mutluluk getirebilir, o senden ho�lanmasa bile.&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:fuchsia;font-size:18pt">5.</span></b><b><span style="color:black;font-size:18pt">&nbsp;Her gece, birisi uykuya dalmadan �nce seni d���n�yor.&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:red;font-size:18pt">6.</span></b><b><span style="color:black;font-size:18pt">&nbsp;Birisi i�in d�nyalara bedelsin.&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:red;font-size:18pt">7.&nbsp;</span></b><b><span style="color:black;font-size:18pt">�ok �zel ve teksin&nbsp;d���ncesinde ki arkada�lar�n� unutma&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:fuchsia;font-size:18pt">8.</span></b><b><span style="color:black;font-size:18pt">&nbsp;Varl���n� bile bilmedi�in biri seni seviyor.&nbsp;&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:fuchsia;font-size:18pt">9.&nbsp;</span></b><b><span style="color:black;font-size:18pt">Hayat�ndaki en b�y�k hatay� yapt���n zamanda bile, ondan hay�rl� bir�ey ��kar.&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:red;font-size:18pt">10.</span></b><b><span style="color:black;font-size:18pt">&nbsp;Ne zaman d�nya sana s�rt�n� d�nm�� gibi hissedersen, d�n ve bir daha bak.&nbsp;SANMA K� DERT SADECE SENDE VAR..</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:red;font-size:18pt">11.</span></b><b><span style="color:black;font-size:18pt">&nbsp;Her zaman ald���n iltifatlar� hat�rla. Kaba s�zlerin hepsini unut.&nbsp;</span></b><span style="color:black;font-size:10pt"><br></span><b><span style="color:black;font-size:18pt">&nbsp;&nbsp;<br></span></b><b><span style="color:green;font-size:18pt">E�er sevgi dolu bir arkada�san bunu herkese g�nder,&nbsp;</span></b><b><span style="color:red;font-size:18pt">sana g�nderen de dahil.</span></b></p></div>
+<div>
+<p class="ecxMsoNormal"><b><u><span style="color:fuchsia;font-size:18pt">E�er geri al�rsan demek ki ger�ekten seviliyorsun.&nbsp;</span></u></b><b><span style="color:green;font-size:18pt">.</span></b></p></div>
+<div>
+<p class="ecxMsoNormal"><b><span style="color:green;font-size:18pt">Ve hep hat�rla....&nbsp;</span></b></p></div>
+<div>
+<p class="ecxMsoNormal"><b><span style="color:green;font-size:18pt">�yi arkada�lar y�ld�zlar gibidir, onlar� her zaman g�remeyebilirsin ama orada olduklar�n� bilirsin.</span></b></p></div>
+<div>
+<p class="ecxMsoNormal"><b><span style="color:green;font-size:18pt">'Bir dosttan tek bir g�l ve g�zel bir s�z� ben onunlayken almay�,</span></b></p></div>
+<div>
+<p class="ecxMsoNormal"><b><span style="color:green;font-size:18pt">�ld�kten sonraki bir kamyon dolusu �i�e�e tercih ederim.'<br></span></b><b><span style="font-size:18pt"><br><span style="color:red">HER ZAMAN YANIMDA OLMASINI �STED���M �NSANLARA...</span></span></b></p></div></div></blockquote></div></blockquote></div></div></blockquote></td></tr></tbody></table></div></div></div></blockquote></td></tr></tbody></table></div></div></blockquote></td></tr></tbody></table>
+<p style="background:white" class="ecxMsoNormal"><b><span style="font-size:10pt"><br>.</span></b></p></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div>
+<p style="background:white" class="ecxMsoNormal"><b><span style="font-size:10pt">&nbsp;</span></b></p></div></div></div></div></div></div></div></div></div></div></div></div></div></blockquote></div></div></div></div></div></div></div></div></div></div></div></div></div></div> 		 	   		  </body>
+</html>
+--_5c38a7c9-bf62-4cff-b65a-a31e5eb3e9c8_--

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/pages/mail/PageMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/pages/mail/PageMail.java
@@ -124,8 +124,11 @@ public class PageMail extends AbsTab {
 		public static final String zMovetToToAddressContextMenu = "css=div[id^='POPUP_DWT'] tbody div[id='MOVE_TO_TO'][class*='ZDisabled'] table tbody tr[id='POPUP_MOVE_TO_TO']";
 		public static final String zMoveToCcAddressContextMenu = "css=div[id^='POPUP_DWT'] tbody div[id='MOVE_TO_CC'] table tbody tr[id='POPUP_MOVE_TO_CC']";
 		public static final String zMoveToBccAddressContextMenu = "css=div[id^='POPUP_DWT'] tbody div[id='MOVE_TO_BCC'] table tbody tr[id='POPUP_MOVE_TO_BCC']";
-
-		// Msg header Address Context menu
+		
+		// Message header Address bubble
+		public static final String zAddressBubbleInHeaderCss = "css=table[id$='_hdrTable'] span.addrBubble";
+		
+		// Message header Address Context menu
 		public static final String zCopyMsgHdrContextMenu = "css=div[id^='zcs'][class^='ActionMenu ']  tbody div[id='COPY'] table tbody tr[id='POPUP_COPY']";
 		public static final String zFindEmailsMsgHdrContextMenu = "css=div[id^='zcs'][class^='ActionMenu ']  tbody div[id='SEARCH_MENU'] table tbody tr[id='POPUP_SEARCH_MENU']";
 		public static final String zNewEmailsMsgHdrContextMenu = "css=div[id^='zcs'][class^='ActionMenu ']  tbody div[id='NEW_MESSAGE'] table tbody tr[id='POPUP_NEW_MESSAGE']";
@@ -2414,4 +2417,6 @@ public class PageMail extends AbsTab {
 		}
 		return null;
 	}
+	
+	
 }

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/headers/CheckEmailAddressBubble.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/headers/CheckEmailAddressBubble.java
@@ -1,0 +1,100 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.qa.selenium.projects.ajax.tests.mail.mail.headers;
+
+import org.testng.annotations.Test;
+import com.zimbra.qa.selenium.framework.core.Bugs;
+import com.zimbra.qa.selenium.framework.ui.Action;
+import com.zimbra.qa.selenium.framework.ui.Button;
+import com.zimbra.qa.selenium.framework.util.ConfigProperties;
+import com.zimbra.qa.selenium.framework.util.HarnessException;
+import com.zimbra.qa.selenium.framework.util.ZAssert;
+import com.zimbra.qa.selenium.projects.ajax.core.SetGroupMailByMessagePreference;
+import com.zimbra.qa.selenium.projects.ajax.pages.mail.PageMail.Locators;
+
+public class CheckEmailAddressBubble extends SetGroupMailByMessagePreference {
+
+	public CheckEmailAddressBubble() throws HarnessException {
+		logger.info("New "+ CheckEmailAddressBubble.class.getCanonicalName());
+		super.startingPage = app.zPageMail;
+		super.startingAccountPreferences.put("zimbraPrefGroupMailBy", "message");		
+	}
+
+
+	@Bugs (ids = "57895" )
+	@Test (description = "Verify that email address containing '-', '_' etc. are also displayed in address bubble",
+			groups = { "functional", "L2" })
+
+	public void CheckEmailAddressBubble_01() throws HarnessException {
+
+		final String mimeFile = ConfigProperties.getBaseDirectory() + "/data/public/mime/unrecognizedEmailAddress.txt";
+		final String subject = "Email address bubble check";
+		
+		// Some email addresses present in the mime
+		final String email1 = "ay__@msn.com";
+		final String email2 = "cilgin.kiz.35@hotmail.com";
+		final String email3 = "deniz-sirtikkizil@hotmail.com";
+		final String email4 = "cettia@cettia.com";
+		final String email5 = "cenkkaya@residencehotel.com.tr";
+		final String email6 = "cizgi1963@hotmail.com";
+
+		// Inject the sample mime
+		injectMessage(app.zGetActiveAccount(), mimeFile);
+
+		// Refresh current view
+		app.zPageMail.zToolbarPressButton(Button.B_REFRESH);
+
+		// Select the message so that it shows in the reading pane
+		app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
+		
+		// Verify that email address are are recognized and displayed in bubble in message view
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email1 +"')"),
+				"Verify that " + email1 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email2 +"')"),
+				"Verify that " + email2 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email3 +"')"),
+				"Verify that " + email3 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email4 +"')"),
+				"Verify that " + email4 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email5 +"')"),
+				"Verify that " + email5 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email6 +"')"),
+				"Verify that " + email6 + "is displayed in address bubble");
+		
+		// Refresh the UI and Select Conversation view
+		app.zPageMail.zRefreshUI();
+		app.zPageMail.zToolbarPressButton(Button.B_MAIL_VIEW_BY_CONVERSATION);
+		
+		// Select the message so that it shows in the reading pane
+		app.zPageMail.zListItem(Action.A_LEFTCLICK, subject);
+		
+		// Verify that email address are are recognized and displayed in bubble in conversation view
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email1 +"')"),
+				"Verify that " + email1 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email2 +"')"),
+				"Verify that " + email2 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email3 +"')"),
+				"Verify that " + email3 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email4 +"')"),
+				"Verify that " + email4 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email5 +"')"),
+				"Verify that " + email5 + "is displayed in address bubble");
+		ZAssert.assertTrue(app.zPageMail.sIsElementPresent(Locators.zAddressBubbleInHeaderCss + ":contains('"+ email6 +"')"),
+				"Verify that " + email6 + "is displayed in address bubble");
+		
+	}
+}


### PR DESCRIPTION
Add automation test to verify that email address containing special character like '-', '_', ''. etc are recognized and displayed in bubbles in the message header

Bug 57895 - Certain email addresses not recognized 