### PR TITLE
ZCS-4436: Removing unused code and creating data at startup for external server

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
@@ -88,7 +88,7 @@ public class ZimbraAccount {
 
 	/*
 	 * Create an account with the email address account<num>@<testdomain> The
-	 * password is set to config property "adminPwd"
+	 * password is set to config property "adminPassword"
 	 */
 	public ZimbraAccount() {
 		this(null, null);
@@ -331,11 +331,10 @@ public class ZimbraAccount {
 	@SuppressWarnings("serial")
 	private static final Map<String, String> accountAttrs = new HashMap<String, String>() {
 		{
-			if (ConfigProperties.getStringProperty("server.host").startsWith("pnq-")) {
-				put("zimbraPrefTimeZoneId", "Asia/Kolkata");
-
-			} else {
+			if (ConfigProperties.getStringProperty("server.host").contains(".eng.")) {
 				put("zimbraPrefTimeZoneId", "America/Chicago");
+			} else {
+				put("zimbraPrefTimeZoneId", "Asia/Kolkata");
 			}
 
 			if (Calendar.getInstance().get(Calendar.DAY_OF_WEEK) == Calendar.SATURDAY
@@ -1675,7 +1674,6 @@ public class ZimbraAccount {
 
 	public static void main(String[] args) throws HarnessException {
 
-		// ConfigProperties.getStringProperty("server.host","zqa-062.eng.zimbra.com");
 		String domain = ConfigProperties.getStringProperty("server.host");
 
 		// Configure log4j using the basic configuration

--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAdminAccount.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAdminAccount.java
@@ -28,7 +28,7 @@ public class ZimbraAdminAccount extends ZimbraAccount {
 
 	public ZimbraAdminAccount(String email) {
 		EmailAddress = email;
-		Password = "test123";
+		Password = ConfigProperties.getStringProperty("adminPassword");
 	}
 
 	/**
@@ -57,8 +57,8 @@ public class ZimbraAdminAccount extends ZimbraAccount {
 			AccountItem account = new AccountItem(email, ConfigProperties.getStringProperty("testdomain"));
 			ZimbraAdminAccount.AdminConsoleAdmin()
 					.soapSend("<CreateAccountRequest xmlns='urn:zimbraAdmin'>" + "<name>" + account.getEmailAddress()
-							+ "</name>" + "<password>test123</password>"
-							+ "<a xmlns='' n='zimbraIsDelegatedAdminAccount'>TRUE</a>"
+							+ "</name>" + "<password>" + ConfigProperties.getStringProperty("adminPassword")
+							+ "</password>" + "<a xmlns='' n='zimbraIsDelegatedAdminAccount'>TRUE</a>"
 							+ "<a xmlns='' n='zimbraPrefAdminConsoleWarnOnExit'>FALSE</a>" + "</CreateAccountRequest>");
 
 			Element[] createAccountResponse = ZimbraAdminAccount.AdminConsoleAdmin()

--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraDistributionList.java
@@ -33,20 +33,19 @@ public class ZimbraDistributionList {
 
 	/*
 	 * Create an account with the email address <name>@<domain> The password is set
-	 * to config property "adminPwd"
+	 * to config property "adminPassword"
 	 */
 	public ZimbraDistributionList(String email, String password) {
 
 		EmailAddress = email;
 		if ((email == null) || (email.trim().length() == 0)) {
 			EmailAddress = "dl" + ConfigProperties.getUniqueString() + "@"
-					+ ConfigProperties.getStringProperty("testdomain", "testdomain.com");
+					+ ConfigProperties.getStringProperty("testdomain");
 		}
 
 		Password = password;
 		if ((password == null) || (password.trim().length() == 0)) {
-			// password = ConfigProperties.getStringProperty("adminPwd", "test123");
-			password = "test123";
+			password = ConfigProperties.getStringProperty("adminPassword");
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraDomain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraDomain.java
@@ -111,10 +111,8 @@ public class ZimbraDomain {
 		ZimbraAdminAccount.GlobalAdmin()
 				.soapSend("<CreateGalSyncAccountRequest xmlns='urn:zimbraAdmin' name='" + datasourcename
 						+ "' type='zimbra' domain='" + DomainName + "' >" + "<account by='name'>" + galaccount
-						+ "</account>"
-						// + "<password>"+ ConfigProperties.getStringProperty("adminPwd", "test123")
-						// +"</password>"
-						+ "<password>" + "test123" + "</password>" + "</CreateGalSyncAccountRequest>");
+						+ "</account>" + "<password>" + ConfigProperties.getStringProperty("adminPassword")
+						+ "</password>" + "</CreateGalSyncAccountRequest>");
 
 		DomainGalSyncAccountID = ZimbraAdminAccount.GlobalAdmin()
 				.soapSelectValue("//admin:CreateGalSyncAccountResponse/admin:account", "id");

--- a/src/java/com/zimbra/qa/selenium/framework/util/staf/StafAbstract.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/staf/StafAbstract.java
@@ -216,7 +216,7 @@ public class StafAbstract {
     	logger.info("STAF Response Code: "+ StafResult.rc);
 
     	if (StafResult.rc == STAFResult.AccessDenied) {
-    		logger.error("On the server, use: staf local trust set machine *.eng.zimbra.com level 5");
+    		logger.error("On the server, use: staf local trust set machine *.zimbra.com level 5");
     	}
 
     	if (StafResult.rc != STAFResult.Ok) {

--- a/src/java/com/zimbra/qa/selenium/framework/util/staf/Stafpostqueue.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/staf/Stafpostqueue.java
@@ -117,7 +117,7 @@ public class Stafpostqueue extends StafServicePROCESS {
 			// Delete each ID one by one
 			deletePostqueueItems(qid);
 
-			throw new HarnessException("Message(s) never delivered from queue.  IDs: " + qid.toString());
+			throw new HarnessException("Message(s) never delivered from queue. IDs: " + qid.toString());
 
 		} else {
 
@@ -144,7 +144,10 @@ public class Stafpostqueue extends StafServicePROCESS {
 				}
 			}
 			if (isMessageDelivered.equals(false)) {
-				throw new HarnessException("Mailq not empty, total deffered messages: " + totalDeferredMessages);
+				String mailqInfo;
+				mailqInfo = "Mailq not empty, total deffered messages: " + totalDeferredMessages;
+				logger.info(mailqInfo);
+				//throw new HarnessException("Mailq not empty, total deffered messages: " + totalDeferredMessages);
 			}
 		}
 	}


### PR DESCRIPTION
ZCS-4436: Removing unused code and creating data at startup for external server.

- Using account password from config
- Creating test domain and accounts especially for AWS

Note: Ideally some CLI code shouldn't execute after creating data (2nd time run though), we will add smart logic or add some flag in ZimbraPreConfiguration method later by working on it if possible.