### PR TITLE
ZCS-4436: Public AWS server won't have relayhost so mailq stucks at mail delivery to uknown user

### DIFF
--- a/data/public/mime/Bugs/Bug100340/bug100340.txt
+++ b/data/public/mime/Bugs/Bug100340/bug100340.txt
@@ -29,19 +29,7 @@ Received: from mbs01.testdomain.com (mbs01.testdomain.com [10.110.0.177])
 	Wed,  3 Jun 2015 06:10:01 -0500 (CDT)
 Date: Wed, 3 Jun 2015 06:10:01 -0500 (CDT)
 From: Ashwini Oak <aoak@testdomain.com>
-To: Rohan Ambasta <rambasta@testdomain.com>, pbhandolkar <pbhandolkar@testdomain.com>, 
-	pgajjar <pgajjar@testdomain.com>, Vikas Galande <vgalande@testdomain.com>, 
-	Pallavi Khairnar <pkhairnar@testdomain.com>, 
-	Swati Khosre <skhosre@testdomain.com>, Ankit Kumar <kumara@testdomain.com>, 
-	Satyam Kumar <kumars@testdomain.com>, 
-	Piyush Nimoria <pnimoria@testdomain.com>, 
-	Chinmay Pathak <pathakc@testdomain.com>, sprasad <sprasad@testdomain.com>, 
-	Dawood Shaikh <dshaikh@testdomain.com>, Rahul Yadav <ryadav@testdomain.com>, 
-	Abhishek Zambre <azambre@testdomain.com>, Santosh Rao <srao@testdomain.com>, 
-	Shashank Tewari <stewari@testdomain.com>, 
-	Irfan Shaikh <ishaikh@testdomain.com>, 
-	Zimbra India Managers <india-managers@testdomain.com>, 
-	"Site: Pune, India, Building: Godrej Castlemaine, Floor: 3rd Floor, Room: Jupiter" <conf-jupiter@testdomain.com>
+To: globaladmin@testdomain.com
 Message-ID: <60442451.2147237.1433329801326.JavaMail.zimbra@testdomain.com>
 Subject: Schedule for Generic Training
 MIME-Version: 1.0

--- a/data/public/mime/Bugs/Bug106342/bug106342.txt
+++ b/data/public/mime/Bugs/Bug106342/bug106342.txt
@@ -36,15 +36,7 @@ Received: from mbs01e.testdomain.com (unknown [52.203.137.206])
 	Thu, 20 Oct 2016 05:34:06 -0400 (EDT)
 Date: Thu, 20 Oct 2016 05:38:02 -0400 (EDT)
 From: Ashwini Oak <aoak@testdomain.com>
-To: All Pune Employees <pune-employees@testdomain.com>, 
-	nilesh pawar <nilesh.pawar@testdomain.com>, 
-	sakchhi kiran <sakchhi.kiran@testdomain.com>, 
-	kalpesh patel <kalpesh.patel@testdomain.com>, 
-	mayur sonar <mayur.sonar@testdomain.com>, 
-	abhishek thakur <abhishek.thakur@testdomain.com>, 
-	prashant deshmukh <prashant.deshmukh@testdomain.com>, 
-	tejbahadur singh <tejbahadur.singh@testdomain.com>, 
-	kunal gorai <kunal.gorai@testdomain.com>
+To: globaladmin@testdomain.com
 Message-ID: <2021520083.8355581.1476956282541.JavaMail.zimbra@testdomain.com>
 Subject: Group photo with Steve
 MIME-Version: 1.0

--- a/data/public/mime/Bugs/Bug13911/bug13911att3713.txt
+++ b/data/public/mime/Bugs/Bug13911/bug13911att3713.txt
@@ -27,7 +27,7 @@ Received: from ?192.168.0.5? ( [83.95.130.147])
         by mx.google.com with ESMTP id s7sm657909uge.2007.01.18.01.00.55;
         Thu, 18 Jan 2007 01:00:59 -0800 (PST)
 Mime-Version: 1.0 (Apple Message framework v752.3)
-To: x@peytz.dk
+To: globaladmin@testdomain.com
 Message-Id: <81D27E3F-0881-4A14-B793-462E1D4C6CF6@peytz.dk>
 Content-Type: multipart/mixed; boundary=Apple-Mail-7--322391395
 Subject: subject13010064065623

--- a/data/public/mime/Bugs/Bug16213/bug16213att4501.txt
+++ b/data/public/mime/Bugs/Bug16213/bug16213att4501.txt
@@ -19,7 +19,7 @@ Received: by 10.35.22.17 with SMTP id z17mr13692098pyi;
 Received: by 10.35.9.5 with HTTP; Thu, 27 Jul 2006 13:49:44 -0700 (PDT)
 Message-ID: <1b5a348d06sdg072713@mail.gmail.com>
 Date: Thu, 27 Jul 2006 17:49:44 -0300
-To: ljk20k00k1je@testdomain.com
+To: globaladmin@testdomain.com
 Subject: Re: =?ISO-8859-1?Q?Encoding_test_-_ISO-8?=
  =?ISO-8859-1?Q?859-1_=E1=E1=E1_=E9=E9=E9_=ED=ED=ED_=E7=E7=E7?=
 MIME-Version: 1.0

--- a/data/public/mime/Bugs/Bug21013/bug21013att6662.txt
+++ b/data/public/mime/Bugs/Bug21013/bug21013att6662.txt
@@ -3,7 +3,7 @@ Date: Fri, 12 Oct 2007 16:12:16 -0700
 From: Foo Bar <foo@testdomain.com>
 User-Agent: Thunderbird 2.0.0.6 (Windows/20070728)
 MIME-Version: 1.0
-To: Matt Rhoades <matt@testdomain.com>
+To: globaladmin@testdomain.com
 Subject: [Fwd: CC&F QA all-hands]
 Content-Type: multipart/mixed;
  boundary="------------010209050105000008010309"
@@ -35,7 +35,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: CC&F QA all-hands
 Thread-Index: Acf5e3FvpBgjyTjXThKg0vfteyZdnwFhPOPg
 From: "Foo Bar" <foo@testdomain.com>
-To: yousef-all@testdomain.com
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 24 Sep 2007 23:12:36.0658 (UTC) FILETIME=[6537B120:01C7FF00]
 
 This is a MIME-formatted message.  If you see this text it means that your

--- a/data/public/mime/Bugs/Bug21415/bug21415att10438.txt
+++ b/data/public/mime/Bugs/Bug21415/bug21415att10438.txt
@@ -48,7 +48,7 @@ X-Priority: 1 (High)
 Priority: Urgent
 Importance: High
 From: "GACC ENCERRAMENTO" <gacc.encerramento@testdomain.com>
-To: <MATRIZ@TESTDOMAIN.COM>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 29 Apr 2008 19:09:35.0109 (UTC) FILETIME=[8FFD6350:01C8AA2C]
 X-MIMETrack: Itemize by SMTP Server on Zeus/Itaubanco(Release 6.5.4FP1 | June 19, 2005) at
  29/04/2008 16:09:37,

--- a/data/public/mime/Bugs/Bug21415/bug21415att8124.txt
+++ b/data/public/mime/Bugs/Bug21415/bug21415att8124.txt
@@ -18,7 +18,7 @@ Received: from depot.liquidsys.com (unknown [10.10.130.31])
 	by dogfood.zimbra.com (Postfix) with ESMTP id 19AC5185CE5;
 	Wed, 12 Dec 2007 18:39:43 -0800 (PST)
 From: Andy Clark <aclark@testdomain.com>
-To: "Anand Palaniswamy" <anandp@testdomain.com>, "Boris Burtin" <bburtin@testdomain.com>, "Brian Peterson" <brian@testdomain.com>, "Conrad Damon" <cdamon@testdomain.com>, "dcomfort" <dcomfort@testdomain.com>, "Dan Karp" <dkarp@testdomain.com>, "Ellen Shen" <eshen@testdomain.com>, "greg" <greg@testdomain.com>, "Jiho Hahm" <jhahm@testdomain.com>, "J.J.Zhuang" <jjzhuang@testdomain.com>, "Jong Yoon Lee" <jylee@testdomain.com>, "Kevin Henrikson" <khenrikson@testdomain.com>, "Kevin Kluge" <kluge@testdomain.com>, "marcmac" <marcmac@testdomain.com>, "Matt Rhoades" <matt@testdomain.com>, "Mihai Bazon" <mihai@testdomain.com>, "Parag Shah" <pshah@testdomain.com>, "Phoebe Shao" <pshao@testdomain.com>, "Quanah Gibson-Mount" <quanah@testdomain.com>, "Ross Dargahi" <rossd@testdomain.com>, "Sam Khavari" <sam@testdomain.com>, "Roland Schemers" <schemers@testdomain.com>, "tim brennan" <tim@testdomain.com>, "vstamatoiu" <vstamatoiu@testdomain.com>
+To: globaladmin@testdomain.com
 X-From-Perforce: Indeed
 Precedence: bulk
 Subject: subject12998912514374

--- a/data/public/mime/Bugs/Bug25624/bug25624att9322.txt
+++ b/data/public/mime/Bugs/Bug25624/bug25624att9322.txt
@@ -30,7 +30,7 @@ DomainKey-Signature: a=rsa-sha1; s=serpent; d=testdomain.com; c=nofws; q=dns;
 	content-transfer-encoding:x-mailer:x-mimeole:thread-index;
 	b=uZw13Cast6fDmQxVYl4wjU7u4vyPZBphGfp0Spat14/ACeRZaDVdrZpt8Wm7VdvQ
 From: "Michelle McPeters" <mbannon@testdomain.com>
-To: "'Candace Harrison'" <charrison@testdomain.com>
+To: globaladmin@testdomain.com
 Subject: Accepted: subject13001430504373
 Date: Fri, 7 Mar 2008 14:29:53 -0800
 Message-ID: <00d501c880a2$c3eee610$d41c490a@ds.corp.testdomain.com>

--- a/data/public/mime/Bugs/Bug27796/bug27796att10515.txt
+++ b/data/public/mime/Bugs/Bug27796/bug27796att10515.txt
@@ -48,12 +48,12 @@ From: Jilong Wang <swang@testdomain.com>
 User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.7.2) Gecko/20040804 Netscape/7.2 (ax)
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: "'devel-random'" <devel-random@testdomain.com>
+To: globaladmin@testdomain.com
 Subject: subject13001430504374
-Reply-To: Jilong Wang <swang@testdomain.com>
+Reply-To: globaladmin@testdomain.com
 X-Loop: devel-random@testdomain.com
 X-Sequence: 4707
-Errors-to: devel-random-owner@testdomain.com
+Errors-to: globaladmin@testdomain.com
 Precedence: bulk
 X-no-archive: yes
 List-Id: <devel-random.testdomain.com>

--- a/data/public/mime/Bugs/Bug31535/bug34401att14395.txt
+++ b/data/public/mime/Bugs/Bug31535/bug34401att14395.txt
@@ -1,7 +1,7 @@
 Return-Path: dconnelly@testdomain.com
 Message-Id: <98E8C173-CB55-4168-A9B3-1E8DA94D83B2@testdomain.com>
 From: David Connelly <dconnelly@testdomain.com>
-To: JJ Zhuang <jjzhuang@testdomain.com>
+To: globaladmin@testdomain.com
 Content-Type: multipart/mixed; boundary=Apple-Mail-12--163757278
 Mime-Version: 1.0 (Apple Message framework v930.3)
 X-ASG-Orig-Subj: screenshot

--- a/data/public/mime/Bugs/Bug60769/Bug60769.txt
+++ b/data/public/mime/Bugs/Bug60769/Bug60769.txt
@@ -29,7 +29,7 @@ Received: from home01 ([123.211.59.115]) by nschwotgx03p.mx.testdomain.com
           id <20110429033002.QRGO11080.nschwotgx03p.mx.testdomain.com@home01>
           for <removed@test.com>; Fri, 29 Apr 2011 03:30:02 +0000
 From: "Andrea Panosh" <obsured@testdomain.com>
-To: <removed@test.com>
+To: globaladmin@testdomain.com
 Subject: FW: Christian cartoons [SEC=UNCLASSIFIED]
 Date: Fri, 29 Apr 2011 13:30:06 +1000
 Message-ID: <6E8089171CF94D7CA8507B073DE33419@home01>

--- a/data/public/mime/Bugs/Bug64444/bug64444.txt
+++ b/data/public/mime/Bugs/Bug64444/bug64444.txt
@@ -1,5 +1,5 @@
 From: from13160123168433@testdomain.com
-To: to3163210168433@testdomain.com
+To: globaladmin@testdomain.com
 Subject: subject13150123168433
 Date: Tue, 13 Sep 2011 14:18:50 -0700
 X-AV-Caller-ID:5095551212

--- a/data/public/mime/Bugs/Bug65079/Bug65079.txt
+++ b/data/public/mime/Bugs/Bug65079/Bug65079.txt
@@ -1,8 +1,6 @@
 Return-Path: sender@testdomain.com
 From: "Sender" <sender@testdomain.com>
-To: <user@domain.com>,
-	<sender@testdomain.com>
-Cc: 
+To: globaladmin@testdomain.com
 Subject: subject13189993282183
 Date: Thu, 6 Oct 2011 08:33:52 -0700
 MIME-Version: 1.0

--- a/data/public/mime/Bugs/Bug65623/Bug65623.txt
+++ b/data/public/mime/Bugs/Bug65623/Bug65623.txt
@@ -1,6 +1,6 @@
 Date: Mon, 10 Oct 2011 09:00:51 +0200 (CEST)
 From: Foo Bar <foo@example.com>
-To: Bar Foo <bar@example.com>
+To: globaladmin@testdomain.com
 Subject: subject13189485723753
 Content-Type: multipart/mixed;
  boundary="=_9838f3f9-dea8-4b54-ba14-652d55621b34"

--- a/data/public/mime/Bugs/Bug65933/Bug65933.txt
+++ b/data/public/mime/Bugs/Bug65933/Bug65933.txt
@@ -1,7 +1,7 @@
 Date: Sat, 1 Oct 2011 00:01:07 -0400
 From: foo@example.com
 Subject: subject13188948451403
-To: bar@example.com
+To: globaladmin@testdomain.com
 MIME-Version: 1.0
 Content-Type: text/html
 

--- a/data/public/mime/Bugs/Bug66192/bug66192.txt
+++ b/data/public/mime/Bugs/Bug66192/bug66192.txt
@@ -20,7 +20,7 @@ Received: from mail2.testdomain.com (mail2.testdomain.com [212.64.156.12])
 	for <robert@testdomain.com>; Wed, 19 Oct 2011 11:50:29 +0100 (BST)
 Date: Wed, 19 Oct 2011 11:50:28 +0100 (BST)
 From: Tony Hu <tony@testdomain.com>
-To: Robert Zhang <robert@testdomain.com>
+To: globaladmin@testdomain.com
 Subject: Fwd: test bug66192
 In-Reply-To: <4051e4be-9fd8-4d33-be1e-2babaef0796b@mail2.testdomain.com>
 Content-Type: multipart/mixed;
@@ -159,8 +159,7 @@ e: 12pt; color: #333333">=E5=B0=8FZhao,<div><br></div><div>=E8=AF=B7=E4=B8=
 hr"><div style=3D"color:#000;font-weight:normal;font-style:normal;text-deco=
 ration:none;font-family:Helvetica,Arial,sans-serif;font-size:12pt;"><b>From=
 : </b>"=E5=A4=9A=E6=99=AE=E6=A3=AE-=E8=8B=9F=E5=85=B5" &lt;dopsing.go@gmail=
-.com&gt;<br><b>To: </b>"Henry Guo" &lt;henry@testdomain.com&gt;, zhao@flashba=
-y.com<br><b>Sent: </b>Saturday, 15 October, 2011 6:00:36 PM<br><b>Subject: =
+.com&gt;<br><b>To: globaladmin@testdomain.com<br><b>Sent: </b>Saturday, 15 October, 2011 6:00:36 PM<br><b>Subject: =
 </b>Re: =E5=90=8A=E5=B8=A6=E4=B8=9D=E5=8D=B0=E6=9C=BA=E5=99=A8<br><br><div>=
 =E9=83=AD=E6=80=BB=EF=BC=8C=E8=B5=B5=E4=B8=BB=E7=AE=A1=EF=BC=9A</div>
 <div>&nbsp;</div>
@@ -211,10 +210,7 @@ n>=E5=86=99=E9=81=93=EF=BC=9A<br>
 ; COLOR: #000; FONT-SIZE: 12pt; FONT-WEIGHT: normal; TEXT-DECORATION: none"=
 ><b>From: </b>"Henry Guo" &lt;<a href=3D"mailto:henry@testdomain.com" target=
 =3D"_blank">henry@testdomain.com</a>&gt;<br>
-<b>To: </b><a href=3D"mailto:sales@testdomain.com" target=3D"_blank">sales=
-@testdomain.com</a><br><b>Cc: </b><a href=3D"mailto:cha@testdomain.com" t=
-arget=3D"_blank">cha@testdomain.com</a>, "Kevin Zhao" &lt;<a href=3D"mailt=
-o:zhao@testdomain.com" target=3D"_blank">zhao@testdomain.com</a>&gt;<br>
+<b>To: globaladmin@testdomain.com<br><b><br>
 <b>Sent: </b>Wednesday, 12 October, 2011 11:36:34 AM<br><b>Subject: </b>=
 =E5=90=8A=E5=B8=A6=E4=B8=9D=E5=8D=B0=E6=9C=BA=E5=99=A8
 <div>
@@ -261,8 +257,7 @@ o:zhao@testdomain.com" target=3D"_blank">zhao@testdomain.com</a>&gt;<br>
 ; COLOR: #000; FONT-SIZE: 12pt; FONT-WEIGHT: normal; TEXT-DECORATION: none"=
 ><b>From: </b>"Yuan Dandan" &lt;<a href=3D"mailto:yuandandan@testdomain.com" =
 target=3D"_blank">yuandandan@testdomain.com</a>&gt;<br>
-<b>To: </b>"Henry Guo" &lt;<a href=3D"mailto:henry@testdomain.com" target=3D"=
-_blank">henry@testdomain.com</a>&gt;<br><b>Sent: </b>Tuesday, 11 October, 201=
+<b>To: globaladmin@testdomain.com<br><b>Sent: </b>Tuesday, 11 October, 201=
 1 10:31:29 PM<br><b>Subject: </b>NS=E9=97=AE=E9=A2=98=E7=82=B9<br><br>
 <div style=3D"FONT-FAMILY: Arial; COLOR: #333333; FONT-SIZE: 12pt">HI &nbsp=
 ; HENRY:

--- a/data/public/mime/Bugs/Bug66565/mime01.txt
+++ b/data/public/mime/Bugs/Bug66565/mime01.txt
@@ -1,6 +1,6 @@
 Date: Thu, 08 Sep 2011 10:16:46 -0700 (PDT)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: <u><i> subject13197565510464 </i></u>
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/Bugs/Bug67686/mime01.txt
+++ b/data/public/mime/Bugs/Bug67686/mime01.txt
@@ -1,5 +1,5 @@
 From: Foo Bar <foo@zqa-061.eng.zimbra.com>
-To: foo@zqa-061.eng.zimbra.com,bar@zqa-061.eng.zimbra.com,fee@zqa-061.eng.zimbra.com
+To: globaladmin@testdomain.com
 Subject: Re: subject13690880312762 Account moves - good news!
 Importance: Normal
 MIME-Version: 1.0
@@ -25,7 +25,7 @@ Sent from my Verizon Wireless Phone
 From: "Foo Bar" <foo@zqa-061.eng.zimbra.com>
 Date: Fri, Dec 9, 2011 17:51
 Subject: Account moves - good news!
-To: "Foo Bar" <foo@zqa-061.eng.zimbra.com>, "Fee Bar" <bar@zqa-061.eng.zimbra.com>
+To: globaladmin@testdomain.com
 
 I just moved another account to each mail host and I am NOT seeing the issue with the folder list.  
 It is also worth noting that I did not purge the originals (Justin had suggested this could be a memcache issue)

--- a/data/public/mime/Bugs/Bug67854/mime01.txt
+++ b/data/public/mime/Bugs/Bug67854/mime01.txt
@@ -1,6 +1,6 @@
 Date: Thu, 01 Dec 2011 09:43:36 -0800 (PST)
 From: vmwen1@zqa-061.eng.zimbra.com
-To: vmwen1@zqa-061.eng.zimbra.com
+To: globaladmin@testdomain.com
 Subject: subject13218526621403
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/Bugs/Bug72233/mime.txt
+++ b/data/public/mime/Bugs/Bug72233/mime.txt
@@ -1,6 +1,6 @@
 Date: Thu, 29 Mar 2012 15:40:12 -0700 (PDT)
 From: foo@testdomain.com
-To: bar@testdomain.com
+To: globaladmin@testdomain.com
 Subject: bug72233
 MIME-Version: 1.0
 Content-Type: multipart/alternative; 

--- a/data/public/mime/Bugs/Bug72248/mime.txt
+++ b/data/public/mime/Bugs/Bug72248/mime.txt
@@ -1,4 +1,4 @@
-To: foo@testdomain.com
+To: globaladmin@testdomain.com
 From: bar@testdomain.com
 Subject: subject13217218621403
 Date: Wed, 28 Mar 2012 14:45:39 -0700

--- a/data/public/mime/Bugs/Bug81565/mime1.txt
+++ b/data/public/mime/Bugs/Bug81565/mime1.txt
@@ -1,6 +1,6 @@
 Date: Wed, 8 May 2013 13:40:44 -0700 (PDT)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: Bug81565
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/Bugs/Bug81565/mime2.txt
+++ b/data/public/mime/Bugs/Bug81565/mime2.txt
@@ -1,6 +1,6 @@
 Date: Wed, 8 May 2013 13:47:18 -0700 (PDT)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: Bug81565B
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/Bugs/Bug82073/mime1.txt
+++ b/data/public/mime/Bugs/Bug82073/mime1.txt
@@ -1,6 +1,6 @@
 Date: Wed, 8 May 2013 15:59:44 -0700 (PDT)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: 13680547408344 & 13680547408345
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8

--- a/data/public/mime/Bugs/Bug82303/mime.txt
+++ b/data/public/mime/Bugs/Bug82303/mime.txt
@@ -1,6 +1,6 @@
 Date: Wed, 22 May 2013 10:52:33 -0700 (PDT)
 From: vmwen2@zqa-062.eng.zimbra.com
-To: vmwen1 <vmwen1@zqa-062.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: bug82303
 MIME-Version: 1.0
 Content-Type: multipart/alternative; 

--- a/data/public/mime/Bugs/Bug96820/Bug96820_VeryLargeMessage.txt
+++ b/data/public/mime/Bugs/Bug96820/Bug96820_VeryLargeMessage.txt
@@ -1,7 +1,6 @@
 Date: Thu, 25 Feb 2016 10:24:30 +0400 (GMT+04:00)
 From: vmwen2@zqa-062.eng.zimbra.com
-To: xyz@testdomain.com
-Cc: xyz@testdomain.com
+To: globaladmin@testdomain.com
 Subject: Very large message
 MIME-Version: 1.0
 Content-Type: multipart/alternative; 

--- a/data/public/mime/Excel_Data_Formatting_Mime.txt
+++ b/data/public/mime/Excel_Data_Formatting_Mime.txt
@@ -29,7 +29,7 @@ Received: from zqa-061.eng.zimbra.com (zqa-061.eng.vmware.com [10.137.244.145])
 	for <user2@zqa-061.eng.zimbra.com>; Wed, 22 Jul 2015 02:23:40 -0900 (HDT)
 Date: Wed, 22 Jul 2015 02:23:40 -0900 (HADT)
 From: admin@zqa-061.eng.zimbra.com
-To: user2 <user2@zqa-061.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Message-ID: <721503481.352.1437564220356.JavaMail.zimbra@zqa-061.eng.zimbra.com>
 Subject: Test Excel Data Formatting
 MIME-Version: 1.0

--- a/data/public/mime/ExternalImg.txt
+++ b/data/public/mime/ExternalImg.txt
@@ -21,7 +21,7 @@ Received: from z54.puneqa.lab (z54.puneqa.lab [10.117.82.54])
 	for <girish1@z54.puneqa.lab>; Thu, 21 Apr 2011 16:14:30 +0530 (IST)
 Date: Thu, 21 Apr 2011 16:14:29 +0530 (IST)
 From: admintest@testdoamin.com
-To: admin <admin@testdoamin.com>
+To: globaladmin@testdomain.com
 Subject: TestTrustedAddress
 Content-Type: multipart/alternative;
  boundary="=_32bbf761-05c7-4906-addb-d192adb12f68"

--- a/data/public/mime/Invite_Message.txt
+++ b/data/public/mime/Invite_Message.txt
@@ -30,7 +30,7 @@ Received: from zqa-062.eng.zimbra.com (zqa-062.eng.zimbra.com [10.137.244.62])
 	for <girish1@zqa-062.eng.zimbra.com>; Mon,  8 Apr 2013 01:24:01 -0700 (PDT)
 Date: Mon, 8 Apr 2013 01:24:01 -0700 (PDT)
 From: admin@zqa-062.eng.zimbra.com
-To: girish1 <girish1@zqa-062.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Message-ID: <158081883.13.1365409441378.JavaMail.zimbra@zqa-062.eng.zimbra.com>
 Subject: Test Edit Reply
 MIME-Version: 1.0

--- a/data/public/mime/TwoAttachments.txt
+++ b/data/public/mime/TwoAttachments.txt
@@ -1,7 +1,7 @@
 Date: Wed, 8 Aug 2012 12:23:39 -0700 (PDT)
 From: vmwen2@zqa-062.eng.vmware.com
-To: vmwen1 <vmwen1@zqa-062.eng.vmware.com>
-In-Reply-To: <1109569634.156.1344453817165.JavaMail.root@zqa-062.eng.vmware.com>
+To: globaladmin@testdomain.com
+In-Reply-To: globaladmin@testdomain.com
 Subject: TwoAttachmentsForward
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/cantSeeAttachForLargeMsg_Bug30893.txt
+++ b/data/public/mime/cantSeeAttachForLargeMsg_Bug30893.txt
@@ -44,7 +44,7 @@ X-Priority: 1
 Priority: Urgent
 Importance: high
 From: "Neena Kulkarni" <mum-bcd@testdomain.com>
-To: "Rajesh Segu" <rsegu@testdomain.com>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 04 Aug 2008 10:51:01.0331 (UTC) FILETIME=[FC0EDA30:01C8F61F]
 
 This is a multi-part message in MIME format.
@@ -131,7 +131,7 @@ Contact- 000-00000000 / 00000000000
 -----Original Message-----
 From: Rajesh Segu [mailto:rsegu@testdomain.com]=20
 Sent: Monday, August 04, 2008 11:28 AM
-To: Neena Kulkarni; Satishkumar Sugumaran; Rajesh Segu
+To: globaladmin@testdomain.com
 Subject: RE: Pl find eco class itinerary! Pl confirm the same!
 
 =20
@@ -550,9 +550,7 @@ From: Abinash Tripathy [mailto:abinash.tripathy@testdomain.com]=20
 
 Sent: Monday, August 04, 2008 9:55 AM
 
-To: Satishkumar Sugumaran; Rajesh Segu
-
-Cc: Neena Kulkarni
+To: globaladmin@testdomain.com
 
 Subject: Re: Pl find eco class itinerary! Pl confirm the same!
 
@@ -592,9 +590,7 @@ Otherwise we have to again start rescheduling.
 
 > From: "Rajesh Segu" <rajesh.segu@testdomain.com>
 
-> To: "Neena Kulkarni" <mum-bcd@testdomain.com>
-
-> Cc: satishs@testdomain.com, "Atiah Zarar" <atiah@testdomain.com>
+> To: globaladmin@testdomain.com
 
 > Sent: Friday, August 1, 2008 5:58:32 AM GMT -08:00 US/Canada Pacific
 
@@ -992,9 +988,7 @@ From: Rajesh Segu [mailto:rajesh.segu@testdomain.com]=20
 
 > > Sent: Friday, August 01, 2008 2:31 PM
 
-> > To: Neena Kulkarni
-
-> > Cc: satishs@testdomain.com; Atiah Zarar; blr-travel
+> > To: globaladmin@testdomain.com
 
 > > Subject: Re: US Travel Details
 
@@ -1112,9 +1106,7 @@ From: Rajesh Segu [mailto:rajesh.segu@testdomain.com]=20
 
 > > > Sent: Friday, August 01, 2008 2:19 PM
 
-> > > To: Neena Kulkarni
-
-> > > Cc: satishs@testdomain.com; Atiah Zarar
+> > > To: globaladmin@testdomain.com
 
 > > > Subject: Re: US Travel Details
 
@@ -1430,9 +1422,7 @@ From: Rajesh Segu [mailto:rajesh.segu@testdomain.com]=20
 
 > > > > Sent: Thursday, July 31, 2008 1:48 PM
 
-> > > > To: Neena Kulkarni
-
-> > > > Cc: satishs@testdomain.com; Atiah Zarar
+> > > > To: globaladmin@testdomain.com
 
 > > > > Subject: Re: US Travel Details
 
@@ -2331,7 +2321,7 @@ style=3D'font-size:
 10.0pt'>-----Original Message-----<br>
 From: Rajesh Segu [mailto:rsegu@testdomain.com] <br>
 Sent: Monday, August 04, 2008 11:28 AM<br>
-To: Neena Kulkarni; Satishkumar Sugumaran; Rajesh Segu<br>
+To: globaladmin@testdomain.com<br>
 Subject: RE: Pl find eco class itinerary! Pl confirm the =
 same!</span></font></p>
 
@@ -3205,12 +3195,7 @@ AM<o:p></o:p></span></font></p>
 
 <p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
 style=3D'font-size:
-10.0pt'>To: Satishkumar Sugumaran; Rajesh =
-Segu<o:p></o:p></span></font></p>
-
-<p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
-style=3D'font-size:
-10.0pt'>Cc: Neena Kulkarni<o:p></o:p></span></font></p>
+10.0pt'>To: globaladmin@testdomain.com<o:p></o:p></span></font></p>
 
 <p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
 style=3D'font-size:
@@ -3296,15 +3281,7 @@ style=3D'font-size:
 
 <p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
 style=3D'font-size:
-10.0pt'>&gt; To: &quot;Neena Kulkarni&quot; =
-&lt;mum-bcd@testdomain.com&gt;<o:p></o:p></span></font></p>
-
-<p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
-style=3D'font-size:
-10.0pt'>&gt; Cc: satishs@testdomain.com, &quot;<st1:PersonName =
-w:st=3D"on">Atiah
- Zarar</st1:PersonName>&quot; =
-&lt;atiah@testdomain.com&gt;<o:p></o:p></span></font></p>
+10.0pt'>&gt; To: globaladmin@testdomain.com<o:p></o:p></span></font></p>
 
 <p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
 style=3D'font-size:
@@ -4138,13 +4115,7 @@ PM<o:p></o:p></span></font></p>
 
 <p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
 style=3D'font-size:
-10.0pt'>&gt; &gt; To: Neena Kulkarni<o:p></o:p></span></font></p>
-
-<p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
-style=3D'font-size:
-10.0pt'>&gt; &gt; Cc: satishs@testdomain.com; <st1:PersonName =
-w:st=3D"on">Atiah Zarar</st1:PersonName>;
-blr-travel<o:p></o:p></span></font></p>
+10.0pt'>&gt; &gt; To: globaladmin@testdomain.com<o:p></o:p></span></font></p>
 
 <p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
 style=3D'font-size:
@@ -4390,13 +4361,7 @@ PM<o:p></o:p></span></font></p>
 
 <p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
 style=3D'font-size:
-10.0pt'>&gt; &gt; &gt; To: Neena Kulkarni<o:p></o:p></span></font></p>
-
-<p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
-style=3D'font-size:
-10.0pt'>&gt; &gt; &gt; Cc: satishs@testdomain.com; <st1:PersonName =
-w:st=3D"on">Atiah
- Zarar</st1:PersonName><o:p></o:p></span></font></p>
+10.0pt'>&gt; &gt; &gt; To: globaladmin@testdomain.com<o:p></o:p></span></font></p>
 
 <p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
 style=3D'font-size:
@@ -5089,12 +5054,6 @@ PM<o:p></o:p></span></font></p>
 style=3D'font-size:
 10.0pt'>&gt; &gt; &gt; &gt; To: Neena =
 Kulkarni<o:p></o:p></span></font></p>
-
-<p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
-style=3D'font-size:
-10.0pt'>&gt; &gt; &gt; &gt; Cc: satishs@testdomain.com; <st1:PersonName =
-w:st=3D"on">Atiah
- Zarar</st1:PersonName><o:p></o:p></span></font></p>
 
 <p class=3DMsoPlainText><font size=3D2 face=3D"Courier New"><span =
 style=3D'font-size:
@@ -6336,7 +6295,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: YOUR TRAVEL INFORMATION
 Thread-Index: Acj2HZC7PnItKKLwTuyN9A7vznE66Q==
 From: "BCD TRAVEL INDIA PVT.LTD          (AGENTID01998137)" <emailserver@pop3.testdomain.com>
-To: "Neena Kulkarni" <mum-bcd@testdomain.com>
+To: globaladmin@testdomain.com
 
 This is a multi-part message in MIME format.
 

--- a/data/public/mime/cantViewMessage_Bug4738.txt
+++ b/data/public/mime/cantViewMessage_Bug4738.txt
@@ -22,7 +22,7 @@ Received: from frontdesk (adsl-67-122-179-222.dsl.pltn13.pacbell.net [67.122.179
 	by mail.winstor.net (Postfix) with ESMTP id 705FF348003
 	for <kevinh@testdomain.com>; Fri, 28 Oct 2005 14:13:14 -0700 (PDT)
 From: "Sandy Zimmer" <sandy@testdomain.com>
-To: "'Kevin Henrikson'" <kevinh@testdomain.com>
+To: globaladmin@testdomain.com
 Subject: RE: funny messages
 Date: Fri, 28 Oct 2005 14:23:41 -0700
 Message-ID: <006801c5dc05$df3273e0$6c00a8c0@frontdesk>
@@ -35,7 +35,7 @@ X-Mailer: Microsoft Outlook CWS, Build 9.0.2416 (9.0.2910.0)
 X-MimeOLE: Produced By Microsoft MimeOLE V6.00.2800.1506
 Importance: Normal
 In-Reply-To: <1814603.18681130533600447.JavaMail.root@dogfood.liquidsys.com>
-Disposition-Notification-To: "Sandy Zimmer" <sandy@testdomain.com>
+Disposition-Notification-To: globaladmin@testdomain.com
 X-Virus-Scanned: amavisd-new at winstor.net
 X-Virus-Scanned: amavisd-new at dogfood
 X-Spam-Status: No, hits=-2.355 tagged_above=-10 required=6.6 autolearn=no

--- a/data/public/mime/cantViewMultipartMessage_Bug43586.txt
+++ b/data/public/mime/cantViewMultipartMessage_Bug43586.txt
@@ -6,7 +6,7 @@ Received: from mail.testdomain.com (LHLO
 Received: from nodoa.infagri.lan (nodoa.infagri.lan [192.168.50.4])
 	by webmail.testdomain.com (Postfix) with ESMTP id 919E1202C35B
 	for <l.andreotti@webmail.testdomain.com>; Tue, 15 Dec 2009 14:54:54 +0100 (CET)
-Resent-To: l.andreotti@webmail.testdomain.com
+Resent-To: globaladmin@testdomain.com
 Resent-From: l.andreotti@testdomain.com
 Resent-Message-Id: <B0003570366@nodoa.infagri.lan>
 Resent-Date: Tue, 15 Dec 2009 14:54:54 +0100

--- a/data/public/mime/continouslyPromptingReadReceipt_Bug44128.txt
+++ b/data/public/mime/continouslyPromptingReadReceipt_Bug44128.txt
@@ -37,9 +37,8 @@ Received: from [94.252.245.200] (helo=DannyPC)
 From: "Salma Al-Jandali--British Training" <testZimbra@testdomain.com>
 X-Barracuda-BBL-IP: 94.252.245.200
 X-Barracuda-RBL-IP: 94.252.245.200
-To: "Salma Al-Jandali--British Training" <testZimbra@testdomain.com>
+To: globaladmin@testdomain.com
 References: 
-In-Reply-To: 
 X-ASG-Orig-Subj: =?windows-1256?B?z+bRx8og5uPEyuPRx8ogx+Hj0d/SIMfhyNHt2Mfk7SDdyNHH7dEgMg==?=
 	=?windows-1256?B?MDEw?=
 Subject: Continous read receipt prompting
@@ -51,7 +50,7 @@ Content-Type: multipart/alternative;
 X-Mailer: Microsoft Office Outlook 12.0
 Thread-Index: AcqY9w4KrU/jDKMJQjGESmQ/5lgd5AAAAeDgAAD2UVA=
 Content-Language: ar-sy
-Disposition-Notification-To: "Salma Al-Jandali--British Training" <testZimbra@testdomain.com>
+Disposition-Notification-To: globaladmin@testdomain.com
 X-Barracuda-Connect: mailrelay2.surf.sy[94.252.191.129]
 X-Barracuda-Start-Time: 1263900819
 X-Barracuda-Virus-Scanned: by Barracuda Spam Firewall at zimbra.com

--- a/data/public/mime/conversation01/mime01.txt
+++ b/data/public/mime/conversation01/mime01.txt
@@ -1,7 +1,7 @@
 Return-Path: foo@example.com
 Date: Thu, 22 Dec 2011 11:38:03 -0800 (PST)
 From: Foo User <foo@example.com>
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: Conversation13155016716713
 Content-Type: multipart/alternative;
  boundary="=_8b4ca532-ca02-4f09-9eaf-a977ac68af6c"

--- a/data/public/mime/conversation01/mime02.txt
+++ b/data/public/mime/conversation01/mime02.txt
@@ -1,7 +1,7 @@
 Return-Path: bar@example.com
 Date: Thu, 22 Dec 2011 11:38:24 -0800 (PST)
 From: Bar User <bar@example.com>
-To: foo@example.com
+To: globaladmin@testdomain.com
 Subject: Re: Conversation13155016716713
 Content-Type: multipart/alternative;
  boundary="=_bda03244-e099-431b-be06-87b9c31b0414"

--- a/data/public/mime/conversation02/mime01.txt
+++ b/data/public/mime/conversation02/mime01.txt
@@ -1,7 +1,7 @@
 Return-Path: foo@example.com
 Date: Thu, 22 Dec 2011 11:38:03 -0800 (PST)
 From: Foo User <foo@example.com>
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: Conversation13155016716714
 Content-Type: multipart/alternative;
  boundary="=_8b4ca532-ca02-4f09-9eaf-a977ac68af6c"

--- a/data/public/mime/conversation02/mime02.txt
+++ b/data/public/mime/conversation02/mime02.txt
@@ -1,7 +1,7 @@
 Return-Path: bar@example.com
 Date: Thu, 22 Dec 2011 11:38:24 -0800 (PST)
 From: Bar User <bar@example.com>
-To: foo@example.com
+To: globaladmin@testdomain.com
 Subject: Re: Conversation13155016716714
 Content-Type: multipart/alternative;
  boundary="=_bda03244-e099-431b-be06-87b9c31b0414"
@@ -21,7 +21,7 @@ more
 
 
 From: "Matthew Rhoades " <matt@ zimbra .com> 
-To: matt@ zimbra .com 
+To: globaladmin@testdomain.com
 Sent: Thursday, 22 December, 2011 11:38:03 AM 
 Subject: conversation01 
 

--- a/data/public/mime/createApptFromICSAttachment1_Bug27959.txt
+++ b/data/public/mime/createApptFromICSAttachment1_Bug27959.txt
@@ -20,7 +20,7 @@ Received: from z54.puneqa.lab (z54.puneqa.lab [10.117.82.54])
 	for <admin@z54.puneqa.lab>; Tue,  8 Jun 2010 12:00:12 +0530 (IST)
 Date: Tue, 8 Jun 2010 12:00:12 +0530 (IST)
 From: root@z54.puneqa.lab
-To: admin  <admin@z54.puneqa.lab>
+To: globaladmin@testdomain.com
 Message-ID: <8978934.2194.1275978611955.JavaMail.root@z54.puneqa.lab>
 In-Reply-To: <27374481.2190.1275978565535.JavaMail.root@z54.puneqa.lab>
 Subject: Testing ics attachment1 - "Add to Calendar" functionality

--- a/data/public/mime/createApptFromICSAttachment2_Bug27959.txt
+++ b/data/public/mime/createApptFromICSAttachment2_Bug27959.txt
@@ -1,6 +1,6 @@
 Date: Tue, 8 Jun 2010 12:01:35 +0530 (IST)
 From: root@z54.puneqa.lab
-To: admin  <admin@z54.puneqa.lab>
+To: globaladmin@testdomain.com
 Message-ID: <30143368.2205.1275978695889.JavaMail.root@z54.puneqa.lab>
 In-Reply-To: <14851388.2197.1275978673352.JavaMail.root@z54.puneqa.lab>
 Subject: Verify ics attachment2 - "Add to Calendar" functionality

--- a/data/public/mime/date01/en_us_invalid_dates.txt
+++ b/data/public/mime/date01/en_us_invalid_dates.txt
@@ -1,5 +1,5 @@
 From: foo@foo.com 
-To: foo@foo.com 
+To: globaladmin@testdomain.com 
 Subject: subject1293323025009
 MIME-Version: 1.0 
 Content-Type: text/plain; charset=utf-8 

--- a/data/public/mime/date01/en_us_valid_dates.txt
+++ b/data/public/mime/date01/en_us_valid_dates.txt
@@ -1,5 +1,5 @@
 From: foo@foo.com 
-To: foo@foo.com 
+To: globaladmin@testdomain.com 
 Subject: subject12912323015009
 MIME-Version: 1.0 
 Content-Type: text/plain; charset=utf-8 

--- a/data/public/mime/email00/mime.txt
+++ b/data/public/mime/email00/mime.txt
@@ -1,7 +1,7 @@
 ﻿From: "User 1" <admin@testdomain.com>
 To: "'User 2'" <admin@testdomain.com>
 References: <1460921948.730077.1340312105003.JavaMail.root@testdomain.com> <979016627.730884.1340313033566.JavaMail.root@testdomain.com>
-In-Reply-To: <979016627.730884.1340313033566.JavaMail.root@testdomain.com>
+In-Reply-To: globaladmin@testdomain.com
 Subject: ZCS 8 triage
 Date: Mon, 25 Jun 2012 12:20:34 -0700
 Message-ID: <11d9ee62.00000ff0.00000050@zimbra-PC7632>
@@ -60,9 +60,7 @@ Hopefully the list will be quite short.  I’ll send out an email next Monday.
 
 From: Kevin Henrikson [mailto:kevinh@testdomain.com]
 Sent: Thursday, June 21, 2012 2:11 PM
-To: Jeff Wagner; Jeff Flanigan; Todd Richmond; Brian P. Peterson; Ellen 
-Shen; Matt Rhoades; Bill Hwang; Sandesh Joseph Almeida
-Cc: Jon Dybik; Lavanya Shastri; John Robb
+To: globaladmin@testdomain.com
 Subject: zcs 8 triage
 
 
@@ -1809,8 +1807,7 @@ style=3D'font-size:10.0pt;font-family:"Tahoma","sans-serif"'>From:</span>=
 Kevin Henrikson [mailto:kevinh@testdomain.com] <br><b>Sent:</b> Thursday, =
 June 21, 2012 2:11 PM<br><b>To:</b> Jeff Wagner; Jeff Flanigan; Todd =
 Richmond; Brian P. Peterson; Ellen Shen; Matt Rhoades; Bill Hwang; =
-Sandesh Joseph Almeida<br><b>Cc:</b> Jon Dybik; Lavanya Shastri; John =
-Robb<br><b>Subject:</b> zcs 8 triage<o:p></o:p></span></p></div></div><p =
+Sandesh Joseph Almeida<br><b><br><b>Subject:</b> zcs 8 triage<o:p></o:p></span></p></div></div><p =
 class=3DMsoNormal><o:p>&nbsp;</o:p></p><div><p class=3DMsoNormal =
 style=3D'margin-bottom:12.0pt'><span style=3D'font-family:"Trebuchet =
 MS","sans-serif";color:black'><br>Hey guys I ran the ZCS -&gt; =

--- a/data/public/mime/email00/mime_wReplyTo.txt
+++ b/data/public/mime/email00/mime_wReplyTo.txt
@@ -1,7 +1,6 @@
 From: from13016959916873@example.com
-To: to13016959916873@example.com
-Cc: cc13016959916873@example.com
-Reply-To: replyto13016959916873@example.com
+To: globaladmin@testdomain.com
+Reply-To: globaladmin@testdomain.com
 Subject: subject13016959916873
 MIME-Version: 1.0 
 Content-Type: text/plain; charset=utf-8 

--- a/data/public/mime/email00/mime_wResentFrom.txt
+++ b/data/public/mime/email00/mime_wResentFrom.txt
@@ -1,10 +1,10 @@
 Return-Path: from13011239916873@example.com
 Resent-Date: Tue, 30 Aug 2011 19:30:06 -0700 (PDT)
 Resent-From: resentfrom13016943216873@example.com
-Resent-To: bar@example.com
+Resent-To: globaladmin@testdomain.com
 Date: Mon, 29 Aug 2011 16:10:42 -0700 (PDT)
 From: from13011239916873@example.com
-To: foo@example.com
+To: globaladmin@testdomain.com
 Subject: subject13147509564213
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email00/mime_wSender.txt
+++ b/data/public/mime/email00/mime_wSender.txt
@@ -1,8 +1,6 @@
 From: from12996131112962@example.com
-To: to12996131112962@example.com
-Cc: cc12996131112962@example.com
+To: globaladmin@testdomain.com
 Sender: sender12996131112962@example.com
-Errors-To: errorsto12996131112962@example.com
 Subject: subject12996131112962
 MIME-Version: 1.0 
 Content-Type: text/plain; charset=utf-8 

--- a/data/public/mime/email01/en_us_invalid_phone.txt
+++ b/data/public/mime/email01/en_us_invalid_phone.txt
@@ -1,5 +1,5 @@
 From: foo@foo.com 
-To: foo@foo.com 
+To: globaladmin@testdomain.com 
 Subject: subject12977323025009
 MIME-Version: 1.0 
 Content-Type: text/plain; charset=utf-8 

--- a/data/public/mime/email01/en_us_valid_phone.txt
+++ b/data/public/mime/email01/en_us_valid_phone.txt
@@ -1,5 +1,5 @@
 From: foo@foo.com 
-To: foo@foo.com 
+To: globaladmin@testdomain.com 
 Subject: subject12977323015009
 MIME-Version: 1.0 
 Content-Type: text/plain; charset=utf-8 

--- a/data/public/mime/email02/mime01.txt
+++ b/data/public/mime/email02/mime01.txt
@@ -1,6 +1,6 @@
 Date: Thu, 08 Sep 2011 10:16:46 -0700 (PDT)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: Subject13155016716713
 Message-ID: <6656aab9-175a-46c0-86f7-9eba7ce1e3fc@zqa-171>
 Content-Type: multipart/alternative;

--- a/data/public/mime/email03/1
+++ b/data/public/mime/email03/1
@@ -25,9 +25,9 @@ Received: from localhost (dors@localhost)ESMTP id i1RNOhSX009487; Fri, 27
 Date: Fri, 27 Feb 2004 15:24:43 -0800 (PST)
 X-Zimbra-Received: Fri, 27 Feb 2004 15:24:43 -0800 (PST)
 From: =?iso-8859-2?Q?Andrzej_K=B1kol?=  <dors@cac.washington.edu>
-To: Jim Fox <fox@cac.washington.edu>, =?iso-8859-2?q?mi=E9rt_nem_jelzi_a_hib=E1t=3F?= <sam@bam.com>
+To: globaladmin@testdomain.com
 Subject: Re: [pubcookie-dev] summary of current activities (anchors)
-In-Reply-To: <Pine.LNX.4.58.0402270848570.15454@los.cac.washington.edu>
+In-Reply-To: globaladmin@testdomain.com
 Message-ID: <Pine.LNX.4.58.0402271502300.7302@red0.cac.washington.edu>
 References: <Pine.LNX.4.58.0402241658020.7646@red1.cac.washington.edu>
 	 <Pine.LNX.4.58.0402270848570.15454@los.cac.washington.edu>
@@ -37,7 +37,6 @@ X-Uwash-Spam: Gauge=IIIIIIII, Probability=8%, Report='__TO_MALFORMED_2 0,
 	__IN_REP_TO 0, __HAS_MSGID 0, __SANE_MSGID 0, __REFERENCES 0,
 	__MIME_VERSION 0, __CT_TEXT_PLAIN 0, __CT 0, EMAIL_ATTRIBUTION 0,
 	QUOTED_EMAIL_TEXT 0, __MIME_TEXT_ONLY 0, REFERENCES 0.000, IN_REP_TO 0'
-cc: pubcookie-dev@u.washington.edu
 X-BeenThere: pubcookie-dev@u.washington.edu
 X-Mailman-Version: 2.1
 Precedence: list
@@ -53,7 +52,6 @@ List-Subscribe:
 	<http://mailman.u.washington.edu/mailman/listinfo/pubcookie-dev>,
 	<mailto:pubcookie-dev-request@mailman.u.washington.edu?subject=subscribe>
 Sender: pubcookie-dev-bounces@mailman.u.washington.edu
-Errors-To: pubcookie-dev-bounces@mailman.u.washington.edu
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/
 X-Evolution: 00000001-0110
 

--- a/data/public/mime/email03/100
+++ b/data/public/mime/email03/100
@@ -10,17 +10,16 @@ Received: (qmail 54937 invoked by uid 500); 19 Sep 2005 00:10:50 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 54839 invoked from network); 19 Sep 2005 00:10:49 -0000
 Message-ID: <017601c37e42$7a7b2d20$d41e11ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
-Cc: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <012801c37e19$9ef367e0$d41e11ac@lightbox>
 	 <1063914139.11628.10.camel@slapshot.stanford.edu>
 Subject: Re: Future XMLBeans feature work?

--- a/data/public/mime/email03/101
+++ b/data/public/mime/email03/101
@@ -10,17 +10,16 @@ Received: (qmail 70224 invoked by uid 500); 23 Sep 2003 16:25:06 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 70209 invoked from network); 23 Sep 2003 16:25:06 -0000
 Message-ID: <001301c381ef$3a69b980$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: "Eric Vasilik" <ericvas@bea.com>, "David Bau" <davidbau@bea.com>, "Robert Wyrick" <rwyrick@fedex.com>
-Cc: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <4B2B4C417991364996F035E1EE39E2E11E9D5D@uskiex01.amer.bea.com>
 Subject: RE: GDateBuilder question
 Date: Tue, 23 Sep 2003 12:24:55 -0400
@@ -57,7 +56,7 @@ difference between Z and +0:00?
 David
 ----- Original Message ----- 
 From: "Eric Vasilik" <ericvas@bea.com>
-To: "David Bau" <davidbau@bea.com>; "Robert Wyrick" <rwyrick@fedex.com>
+To: globaladmin@testdomain.com
 Sent: Tuesday, September 23, 2003 11:38 AM
 Subject: [bea-readme] RE: GDateBuilder question
 
@@ -96,7 +95,7 @@ betwen -14:00 and +14:00");
 -----Original Message-----
 From: Robert Wyrick [mailto:rwyrick@fedex.com]
 Sent: Monday, September 22, 2003 3:02 PM
-To: Eric Vasilik
+To: globaladmin@testdomain.com
 Subject: GDateBuilder question
 
 

--- a/data/public/mime/email03/102
+++ b/data/public/mime/email03/102
@@ -9,12 +9,12 @@ Received: (qmail 55579 invoked by uid 500); 8 Oct 2003 16:29:44 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 55545 invoked from network); 8 Oct 2003 16:29:38 -0000
 Date: Wed, 8 Oct 2003 12:29:41 -0400
 X-Zimbra-Received: Wed, 8 Oct 2003 12:29:41 -0400
@@ -22,7 +22,7 @@ Mime-Version: 1.0 (Apple Message framework v552)
 Content-Type: text/plain; charset=US-ASCII; format=flowed
 Subject: Namespace Question...
 From: Tom Condon <tom_condon@vrtx.com>
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Content-Transfer-Encoding: 7bit
 Message-Id: <9E289A90-F9AC-11D7-B5A5-000393D5A006@vrtx.com>
 X-Mailer: Apple Mail (2.552)

--- a/data/public/mime/email03/103
+++ b/data/public/mime/email03/103
@@ -9,19 +9,19 @@ Received: (qmail 90663 invoked by uid 500); 15 Sep 2003 23:49:52 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 90650 invoked from network); 15 Sep 2003 23:49:51 -0000
 X-Authentication-Warning: slapshot.stanford.edu: smith set sender to
 	smith@stanford.edu using -f
 Subject: Re: XmlBeans source code has been checked in ...
 From: Roland Smith <smith@stanford.edu>
-To: xmlbeans-dev@xml.apache.org
-In-Reply-To: <1063669515.18282.10.camel@slapshot.stanford.edu>
+To: globaladmin@testdomain.com
+In-Reply-To: globaladmin@testdomain.com
 References: <4B2B4C417991364996F035E1EE39E2E10D8E06@uskiex01.amer.bea.com>
 	 <1063669515.18282.10.camel@slapshot.stanford.edu>
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email03/104
+++ b/data/public/mime/email03/104
@@ -10,12 +10,12 @@ Received: (qmail 69411 invoked by uid 500); 22 Oct 2003 23:45:49 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 69380 invoked from network); 22 Oct 2003 23:45:49 -0000
 Message-ID: <3F971628.6030303@wyrick.org>
 Date: Wed, 22 Oct 2004 17:43:36 -0600
@@ -24,10 +24,10 @@ From: Robert Wyrick <rob@wyrick.org>
 User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.4) Gecko/20030711
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: deep equals implementation?
 References: <OF27BE0517.D02F021E-ONCA256DC7.008108C4@tmca.com.au>
-In-Reply-To: <OF27BE0517.D02F021E-ONCA256DC7.008108C4@tmca.com.au>
+In-Reply-To: globaladmin@testdomain.com
 X-Enigmail-Version: 0.76.1.0
 X-Enigmail-Supports: pgp-inline, pgp-mime
 Content-Type: text/plain; charset=ISO-8859-1; format=flowed

--- a/data/public/mime/email03/105
+++ b/data/public/mime/email03/105
@@ -9,18 +9,18 @@ Received: (qmail 32804 invoked by uid 500); 7 Oct 2003 21:37:57 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 32791 invoked from network); 7 Oct 2003 21:37:57 -0000
 X-Authentication-Warning: slapshot.stanford.edu: smith set sender to
 	smith@stanford.edu using -f
 Subject: cursor question...
 From: Roland Smith <smith@stanford.edu>
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 Message-Id: <1065562680.23507.50.camel@slapshot.stanford.edu>

--- a/data/public/mime/email03/106
+++ b/data/public/mime/email03/106
@@ -9,12 +9,12 @@ Received: (qmail 44503 invoked by uid 500); 8 Oct 2003 17:15:11 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 44468 invoked from network); 8 Oct 2003 17:15:10 -0000
 X-Authentication-Warning: www.princetongames.org: ammulder owned process
 	doing -bs
@@ -22,7 +22,7 @@ Date: Wed, 8 Oct 2003 13:17:52 -0400 (EDT)
 X-Zimbra-Received: Wed, 8 Oct 2003 13:17:52 -0400 (EDT)
 From: Aaron Mulder <ammulder@alumni.princeton.edu>
 X-X-Sender: ammulder@www.princetongames.org
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: XMLBeans Speed
 Message-ID: <Pine.LNX.4.44.0310081306040.20642-100000@www.princetongames.org>
 MIME-Version: 1.0

--- a/data/public/mime/email03/107
+++ b/data/public/mime/email03/107
@@ -10,12 +10,12 @@ Received: (qmail 20435 invoked by uid 500); 21 Oct 2003 14:04:17 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 20347 invoked from network); 21 Oct 2003 14:04:16 -0000
 X-MIMEOLE: Produced By Microsoft Exchange V6.0.6487.1
 content-class: urn:content-classes:message
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Feature Request: Serialization
 Thread-Index: AcOX3DaMdeJu7QfRRzej3kBn8sL3zQ==
 From: "Jochen Rebhan" <jochen.rebhan@primaverasoft.pt>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/
 X-Evolution: 0000006b-0010

--- a/data/public/mime/email03/108
+++ b/data/public/mime/email03/108
@@ -9,24 +9,24 @@ Received: (qmail 12710 invoked by uid 500); 3 Oct 2003 19:52:34 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 12697 invoked from network); 3 Oct 2003 19:52:33 -0000
 Date: Fri, 3 Oct 2003 12:52:38 -0700
 X-Zimbra-Received: Fri, 3 Oct 2003 12:52:38 -0700
 From: Scott Ziegler <zieg@bea.com>
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: builtin type conversions
 Message-ID: <20031003195238.GA19811@zieg.beasys.com>
 References: <1065122063.14001.18.camel@zieg>
 	 <013801c389c3$79b021c0$0fa8a8c0@lightbox>
 Mime-Version: 1.0
 Content-Disposition: inline
-In-Reply-To: <013801c389c3$79b021c0$0fa8a8c0@lightbox>
+In-Reply-To: globaladmin@testdomain.com
 User-Agent: Mutt/1.4.1i
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 Content-Type: text/plain; CHARSET=us-ascii

--- a/data/public/mime/email03/109
+++ b/data/public/mime/email03/109
@@ -13,8 +13,8 @@ List-Post: <mailto:xmlbeans-cvs@xml.apache.org>
 List-Help: <mailto:xmlbeans-cvs-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-cvs-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-cvs-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-cvs@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: globaladmin@testdomain.com
 Received: (qmail 95589 invoked from network); 16 Sep 2003 19:57:48 -0000
 Received: from unknown (HELO minotaur.apache.org) (209.237.227.194) by
 	daedalus.apache.org with SMTP; 16 Sep 2003 19:57:48 -0000
@@ -23,7 +23,7 @@ Date: 16 Sep 2003 19:57:59 -0000
 X-Zimbra-Received: 16 Sep 2003 19:57:59 -0000
 Message-ID: <20030916195759.90402.qmail@minotaur.apache.org>
 From: ericvas@apache.org
-To: xml-xmlbeans-cvs@apache.org
+To: globaladmin@testdomain.com
 Subject: cvs commit:
 	xml-xmlbeans/v1/src/xmlcomp/org/apache/xmlbeans/impl/tool CodeGenUtil.java
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -65,7 +65,7 @@ ericvas     2003/09/16 12:57:59
   -eric.vasilik@bea.com.
   -
   +In the mean time, if you've got more questions, please post your questions
-  +to xmlbeans-user@xml.apache.org (you need to subscribe prior to posting,
+  +to globaladmin@testdomain.com (you need to subscribe prior to posting,
   +by sending a blank mail to xmlbeans-user-subscribe@xml.apache.org).
    
    

--- a/data/public/mime/email03/110
+++ b/data/public/mime/email03/110
@@ -9,17 +9,17 @@ Received: (qmail 54267 invoked by uid 500); 10 Oct 2003 22:57:22 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 54254 invoked from network); 10 Oct 2003 22:57:21 -0000
 Subject: Re: bts notes
 From: Scott Ziegler <zieg@bea.com>
-To: xmlbeans-dev@xml.apache.org
-In-Reply-To: <035601c38f45$75309760$0fa8a8c0@lightbox>
+To: globaladmin@testdomain.com
+In-Reply-To: globaladmin@testdomain.com
 References: <5.2.1.1.0.20031009120354.03384fe8@san-francisco.beasys.com>
 	 <030c01c38eae$78d032f0$0fa8a8c0@lightbox> <1065748890.15848.28.camel@zieg>
 	 <035601c38f45$75309760$0fa8a8c0@lightbox>

--- a/data/public/mime/email03/111
+++ b/data/public/mime/email03/111
@@ -9,17 +9,16 @@ Received: (qmail 59743 invoked by uid 500); 29 Sep 2003 15:27:09 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 59684 invoked from network); 29 Sep 2003 15:27:09 -0000
 Message-ID: <003501c3869e$25cfdc80$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: "Eric Vasilik" <eric.vasilik@bea.com>
-Cc: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: V2 Store discussion...
 Date: Mon, 29 Sep 2003 11:27:07 -0400
 X-Zimbra-Received: Mon, 29 Sep 2003 11:27:07 -0400

--- a/data/public/mime/email03/112
+++ b/data/public/mime/email03/112
@@ -9,18 +9,18 @@ Received: (qmail 57237 invoked by uid 500); 12 Sep 2003 19:43:10 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 57218 invoked from network); 12 Sep 2003 19:43:10 -0000
 X-VirusChecked: Checked
 X-Env-Sender: kkress@bankofny.com
 X-Msg-Ref: server-5.tower-20.messagelabs.com!1063395941!2020355
 X-StarScan-Version: 5.0.7; banners=bankofny.com,-,-
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Source Code
 MIME-Version: 1.0
 Message-ID: <OFE6F7D5EC.107AFC2B-ON85256D9F.006C34AF-85256D9F.006C4CB3@bankofny.com>
@@ -58,8 +58,7 @@ SAS, The Bank of New York                            484.605.4834
 Please respond to xmlbeans-dev
 
  
-        To:     xmlbeans-dev@xml.apache.org
-        cc: 
+        To:     globaladmin@testdomain.com
         Subject:        Source Code
 
 
@@ -104,8 +103,7 @@ SAS, The Bank of New York &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp
 <br><font size=1 face="sans-serif">Please respond to xmlbeans-dev</font>
 <br>
 <td><font size=1 face="Arial">&nbsp; &nbsp; &nbsp; &nbsp; </font>
-<br><font size=1 face="sans-serif">&nbsp; &nbsp; &nbsp; &nbsp; To: &nbsp; &nbsp; &nbsp; &nbsp;xmlbeans-dev@xml.apache.org</font>
-<br><font size=1 face="sans-serif">&nbsp; &nbsp; &nbsp; &nbsp; cc: &nbsp; &nbsp; &nbsp; &nbsp;</font>
+<br><font size=1 face="sans-serif">&nbsp; &nbsp; &nbsp; &nbsp; To: &nbsp; &nbsp; &nbsp; &nbsp;globaladmin@testdomain.com</font>
 <br><font size=1 face="sans-serif">&nbsp; &nbsp; &nbsp; &nbsp; Subject: &nbsp; &nbsp; &nbsp; &nbsp;Source Code</font></table>
 <br>
 <br>

--- a/data/public/mime/email03/113
+++ b/data/public/mime/email03/113
@@ -10,12 +10,12 @@ Received: (qmail 40887 invoked by uid 500); 10 Oct 2003 19:52:50 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 40873 invoked from network); 10 Oct 2003 19:52:50 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: noNamespace package alternatives
 Thread-Index: AcOPXpyOI+Mul6HaSsOuJNKGEY2xUQAB6a4gAABm8jA=
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 10 Oct 2003 19:52:53.0291 (UTC)
 	FILETIME=[17AA3FB0:01C38F68]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -49,7 +49,7 @@ Are you trying to change the packages that a schema compiles to?
 -----Original Message-----
 From: Breese, Dustin [mailto:dustin.breese@qwest.com]
 Sent: Friday, October 10, 2003 12:42 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: noNamespace package alternatives
 
 

--- a/data/public/mime/email03/114
+++ b/data/public/mime/email03/114
@@ -10,12 +10,12 @@ Received: (qmail 18021 invoked by uid 500); 30 Sep 2003 17:12:59 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 18008 invoked from network); 30 Sep 2003 17:12:59 -0000
 Message-ID: <3F79B992.7020206@bea.com>
 Date: Tue, 30 Sep 2003 10:12:50 -0700
@@ -25,11 +25,10 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4)
 	Gecko/20030624 Netscape/7.1 (ax)
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
-CC: Eric Vasilik <eric.vasilik@bea.com>
+To: globaladmin@testdomain.com
 Subject: Re: V2 Store discussion...
 References: <003501c3869e$25cfdc80$0fa8a8c0@lightbox>
-In-Reply-To: <003501c3869e$25cfdc80$0fa8a8c0@lightbox>
+In-Reply-To: globaladmin@testdomain.com
 Content-Type: text/plain; charset=ISO-8859-1; format=flowed
 Content-Transfer-Encoding: 7bit
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/115
+++ b/data/public/mime/email03/115
@@ -10,19 +10,19 @@ Received: (qmail 8085 invoked by uid 500); 10 Oct 2003 14:54:07 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 8072 invoked from network); 10 Oct 2003 14:54:06 -0000
 Message-Id: <sf868fcc.033@corp-gw.mantech.com>
 X-Mailer: Novell GroupWise Internet Agent 5.5.6.1
 Date: Fri, 10 Oct 2003 10:53:37 -0400
 X-Zimbra-Received: Fri, 10 Oct 2003 10:53:37 -0400
 From: "Darrell Teague" <darrell.teague@mantech.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Re: Parallel Extension Question
 Mime-Version: 1.0
 Content-Type: text/plain; charset=US-ASCII

--- a/data/public/mime/email03/116
+++ b/data/public/mime/email03/116
@@ -10,12 +10,12 @@ Received: (qmail 76384 invoked by uid 500); 18 Sep 2003 05:30:09 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 76368 invoked from network); 18 Sep 2003 05:30:09 -0000
 Message-ID: <3F6942EB.70502@sauria.com>
 Date: Wed, 17 Sep 2003 22:30:19 -0700
@@ -25,10 +25,10 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.5b)
 	Gecko/20030901 Thunderbird/0.2
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Getting the distribution onto a download site somewhere ...
 References: <4B2B4C417991364996F035E1EE39E2E108504A@uskiex01.amer.bea.com>
-In-Reply-To: <4B2B4C417991364996F035E1EE39E2E108504A@uskiex01.amer.bea.com>
+In-Reply-To: globaladmin@testdomain.com
 X-Enigmail-Version: 0.81.6.0
 X-Enigmail-Supports: pgp-inline, pgp-mime
 Content-Type: text/plain; charset=ISO-8859-1; format=flowed

--- a/data/public/mime/email03/117
+++ b/data/public/mime/email03/117
@@ -9,13 +9,13 @@ Received: (qmail 83195 invoked by uid 500); 15 Sep 2003 23:37:31 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
-Delivered-To: moderator for xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
+Delivered-To: moderator for globaladmin@testdomain.com
 Received: (qmail 28369 invoked from network); 15 Sep 2003 21:07:19 -0000
 content-class: urn:content-classes:message
 Subject: XmlBeans source code has been checked in ...
@@ -31,8 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: XmlBeans source code has been checked in ...
 Thread-Index: AcN7zVqm0/g4nXKTTMKpPiP8n2fcuw==
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
-Cc: <xmlbeans-user@xml.apache.org>, <xmlbeans-cvs@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 15 Sep 2003 21:07:25.0008 (UTC)
 	FILETIME=[5CB05D00:01C37BCD]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/118
+++ b/data/public/mime/email03/118
@@ -9,16 +9,16 @@ Received: (qmail 10734 invoked by uid 500); 16 Sep 2003 05:22:25 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
-Delivered-To: moderator for xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
+Delivered-To: moderator for globaladmin@testdomain.com
 Received: (qmail 97557 invoked from network); 16 Sep 2003 05:05:57 -0000
 From: "Sascha Kulawik" <sascha@kulawik.de>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Patch for Unicode-Build-Bug
 Date: Tue, 16 Sep 2003 07:07:06 +0200
 X-Zimbra-Received: Tue, 16 Sep 2003 07:07:06 +0200

--- a/data/public/mime/email03/119
+++ b/data/public/mime/email03/119
@@ -10,16 +10,16 @@ Received: (qmail 17044 invoked by uid 500); 26 Sep 2003 23:05:45 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 17029 invoked from network); 26 Sep 2003 23:05:45 -0000
 Message-ID: <02be01c38482$b24d2140$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <5.2.1.1.0.20030926140425.021e21d8@san-francisco.beasys.com>
 Subject: Re: V2 store
 Date: Fri, 26 Sep 2003 19:05:35 -0400

--- a/data/public/mime/email03/120
+++ b/data/public/mime/email03/120
@@ -8,16 +8,16 @@ Received: from mail.apache.org (daedalus.apache.org [208.185.179.12]) by
 Received: (qmail 6300 invoked by uid 500); 4 Dec 2003 21:31:18 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 6287 invoked from network); 4 Dec 2003 21:31:18 -0000
 Message-ID: <015a01c3baad$e640c9a0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <FAF98113-25D3-11D8-BCCC-000393D5A006@vrtx.com>
 Subject: Re: XMLBeans or perhaps just an XML question...
 Date: Thu, 4 Dec 2003 16:30:53 -0500
@@ -57,7 +57,7 @@ document) subtrees, complete with subelements and so on, into your <body>.
 David
 ----- Original Message ----- 
 From: "Thomas Condon" <tom_condon@vrtx.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Wednesday, December 03, 2003 4:02 PM
 Subject: [xmlbeans-user] XMLBeans or perhaps just an XML question...
 

--- a/data/public/mime/email03/121
+++ b/data/public/mime/email03/121
@@ -10,12 +10,12 @@ Received: (qmail 70161 invoked by uid 500); 20 Sep 2003 08:52:58 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 70148 invoked from network); 20 Sep 2003 08:52:58 -0000
 X-Sent: 20 Sep 2003 08:52:40 GMT
 Date: Sat, 20 Sep 2003 09:54:53 +0100
@@ -23,9 +23,9 @@ X-Zimbra-Received: Sat, 20 Sep 2003 09:54:53 +0100
 Subject: Re: Getting the distribution onto a download site somewhere ...
 Mime-Version: 1.0 (Apple Message framework v482)
 From: robert burrell donkin <rdonkin@apache.org>
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Content-Transfer-Encoding: 7bit
-In-Reply-To: <4B2B4C417991364996F035E1EE39E2E11E9976@uskiex01.amer.bea.com>
+In-Reply-To: globaladmin@testdomain.com
 Message-Id: <1A1CC0FE-EB48-11D7-BE61-003065DC754C@apache.org>
 X-Mailer: Apple Mail (2.482)
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -67,7 +67,7 @@ On Thursday, September 18, 2003, at 09:59 PM, David Remy wrote:
 >> -----Original Message-----
 >> From: Ted Leung [mailto:twleung@sauria.com]
 >> Sent: Wednesday, September 17, 2003 10:30 PM
->> To: xmlbeans-dev@xml.apache.org
+>> To: globaladmin@testdomain.com
 >> Subject: Re: Getting the distribution onto a download site
 >> somewhere ...
 >>

--- a/data/public/mime/email03/122
+++ b/data/public/mime/email03/122
@@ -10,16 +10,16 @@ Received: (qmail 85752 invoked by uid 500); 25 Nov 2003 23:19:57 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 85732 invoked from network); 25 Nov 2003 23:19:57 -0000
 X-Sent: 25 Nov 2003 23:20:03 GMT
 Mime-Version: 1.0 (Apple Message framework v606)
-In-Reply-To: <5.2.1.1.0.20031124140854.023b6ec8@san-francisco.beasys.com>
+In-Reply-To: globaladmin@testdomain.com
 References: <5.2.1.1.0.20031114151841.01a6aea0@san-francisco.beasys.com>
 	 <5.2.1.1.0.20031112103429.01de1458@san-francisco.beasys.com>
 	 <5.2.1.1.0.20031114151841.01a6aea0@san-francisco.beasys.com>
@@ -30,7 +30,7 @@ From: robert burrell donkin <rdonkin@apache.org>
 Subject: Re: Start-with-java annotations
 Date: Tue, 25 Nov 2003 23:20:02 +0000
 X-Zimbra-Received: Tue, 25 Nov 2003 23:20:02 +0000
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 X-Mailer: Apple Mail (2.606)
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 Content-Type: text/plain; CHARSET=ISO-8859-1; FORMAT=flowed

--- a/data/public/mime/email03/123
+++ b/data/public/mime/email03/123
@@ -10,12 +10,12 @@ Received: (qmail 19148 invoked by uid 500); 24 Sep 2003 07:57:34 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 19135 invoked from network); 24 Sep 2003 07:57:34 -0000
 content-class: urn:content-classes:message
 MIME-Version: 1.0
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Advert police strikes again
 Thread-Index: AcOCbnPFx9A84QGPQZejBD6rwwL2MAAAVrXw
 From: "Cliff Schmidt" <cliff@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 24 Sep 2003 07:57:47.0348 (UTC)
 	FILETIME=[8B1EE940:01C38271]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/124
+++ b/data/public/mime/email03/124
@@ -10,17 +10,17 @@ Received: (qmail 50790 invoked by uid 500); 22 Sep 2003 23:09:18 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 50774 invoked from network); 22 Sep 2003 23:09:17 -0000
 Date: Tue, 23 Sep 2003 08:14:08 +0900
 X-Zimbra-Received: Tue, 23 Sep 2003 08:14:08 +0900
 From: Tetsuya Kitahata <tetsuya@apache.org>
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Getting the distribution onto a download site somewhere ...
 In-Reply-To: <3F6F755F.7030105@sauria.com>
 References: <3F6F5565.3000506@outerthought.org>
@@ -52,7 +52,7 @@ That's all.
 (I am willing to put the news at jakarta.apache.org top page)
 
 In such an announcement, please note that the you should tell people the
-existence of "xmlbeans-user@xml.apache.org" mailing list
+existence of "globaladmin@testdomain.com" mailing list
 for building the powerful users' community.
 
 --

--- a/data/public/mime/email03/125
+++ b/data/public/mime/email03/125
@@ -10,16 +10,16 @@ Received: (qmail 76446 invoked by uid 500); 18 Nov 2003 21:35:55 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 76433 invoked from network); 18 Nov 2003 21:35:55 -0000
 Message-ID: <001e01c3ae1b$eb42a7f0$900210ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <3FBA4748.4010302@tzi.de>
 Subject: Re:problem with SchemaTypeLoaders and xsi:type attributes
 Date: Tue, 18 Nov 2003 16:34:02 -0500
@@ -59,7 +59,7 @@ David
 
 ----- Original Message ----- 
 From: "Arne Jacobs" <jarne@tzi.de>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Tuesday, November 18, 2003 11:22 AM
 Subject: [xmlbeans-dev] problem with SchemaTypeLoaders and xsi:type
 attributes

--- a/data/public/mime/email03/126
+++ b/data/public/mime/email03/126
@@ -10,12 +10,12 @@ Received: (qmail 72364 invoked by uid 500); 25 Sep 2003 07:24:29 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 72350 invoked from network); 25 Sep 2003 07:24:29 -0000
 Message-ID: <3F729838.1010105@sauria.com>
 Date: Thu, 25 Sep 2003 00:24:40 -0700
@@ -26,10 +26,10 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.5)
 	Gecko/20030923 Thunderbird/0.3
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: code to contribute: JAM
 References: <4B2B4C417991364996F035E1EE39E2E1085062@uskiex01.amer.bea.com>
-In-Reply-To: <4B2B4C417991364996F035E1EE39E2E1085062@uskiex01.amer.bea.com>
+In-Reply-To: globaladmin@testdomain.com
 X-Enigmail-Version: 0.81.6.0
 X-Enigmail-Supports: pgp-inline, pgp-mime
 Content-Transfer-Encoding: 7bit
@@ -59,7 +59,7 @@ Ted
 > -----Original Message-----
 > From: Patrick Calahan [mailto:pcal@bea.com]
 > Sent: Wednesday, September 24, 2003 5:24 PM
-> To: xmlbeans-dev@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: code to contribute: JAM
 > 
 > 

--- a/data/public/mime/email03/127
+++ b/data/public/mime/email03/127
@@ -8,18 +8,18 @@ Received: from mail.apache.org (daedalus.apache.org [208.185.179.12]) by
 Received: (qmail 8937 invoked by uid 500); 3 Dec 2003 21:02:19 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 8923 invoked from network); 3 Dec 2003 21:02:19 -0000
 Mime-Version: 1.0 (Apple Message framework v606)
 Content-Transfer-Encoding: 7bit
 Message-Id: <FAF98113-25D3-11D8-BCCC-000393D5A006@vrtx.com>
 Content-Type: text/plain; charset=US-ASCII; format=flowed
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 From: Thomas Condon <tom_condon@vrtx.com>
 Subject: XMLBeans or perhaps just an XML question...
 Date: Wed, 3 Dec 2004 16:02:18 -0500

--- a/data/public/mime/email03/128
+++ b/data/public/mime/email03/128
@@ -9,19 +9,19 @@ Received: (qmail 69113 invoked by uid 500); 2 Oct 2003 14:28:36 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 69096 invoked from network); 2 Oct 2003 14:28:35 -0000
 Message-Id: <sf7bfdd5.032@corp-gw.mantech.com>
 X-Mailer: Novell GroupWise Internet Agent 5.5.6.1
 Date: Thu, 02 Oct 2003 10:28:33 -0400
 X-Zimbra-Received: Thu, 02 Oct 2003 10:28:33 -0400
 From: "Darrell Teague" <darrell.teague@mantech.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: RE: Finalizers
 Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="=_18465605.4B2AA21F"
@@ -64,7 +64,7 @@ Have you looked at using weak references for the XML->Cursor references?
 -----Original Message-----
 From: Eric Vasilik [mailto:ericvas@bea.com]=20
 Sent: Wednesday, October 01, 2003 1:14 PM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: Finalizers
 
 
@@ -113,7 +113,7 @@ particular object no longer needed finalization.  Does such a thing exist?
 -----Original Message-----
 From: Darrell Teague [mailto:darrell.teague@mantech.com]
 Sent: Wednesday, October 01, 2003 8:49 AM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Finalizers
 
 
@@ -235,7 +235,7 @@ rsor=20
 references?<BR><BR>-----Original Message-----<BR>From: Eric Vasilik [<A=20
 href=3D"mailto:ericvas@bea.com]">mailto:ericvas@bea.com]</A> <BR>Sent: Wedn=
 esday,=20
-October 01, 2003 1:14 PM<BR>To: xmlbeans-dev@xml.apache.org<BR>Subject: RE:=
+October 01, 2003 1:14 PM<BR>To: globaladmin@testdomain.com<BR>Subject: RE:=
 =20
 Finalizers<BR><BR><BR>My plans for the next version of the store are to rem=
 ove=20
@@ -286,7 +286,7 @@ Message-----<BR>From: Darrell Teague [<A=20
 href=3D"mailto:darrell.teague@mantech.com]">mailto:darrell.teague@mantech.c=
 om]</A><BR>Sent:=20
 Wednesday, October 01, 2003 8:49 AM<BR>To:=20
-xmlbeans-dev@xml.apache.org<BR>Subject: Re: Finalizers<BR><BR><BR>Two more =
+globaladmin@testdomain.com<BR>Subject: Re: Finalizers<BR><BR><BR>Two more =
 cents=20
 on this topic...<BR><BR>Joshua Bloch of Sun and many others (myself include=
 d)=20

--- a/data/public/mime/email03/129
+++ b/data/public/mime/email03/129
@@ -10,16 +10,16 @@ Received: (qmail 59289 invoked by uid 500); 28 Oct 2003 22:35:57 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 59198 invoked from network); 28 Oct 2003 22:35:54 -0000
 Sensitivity: 
 Subject: Re: Versioning of XML Schema
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 X-Mailer: Lotus Notes Release 5.0.8  June 18, 2001
 Message-ID: <OF7BDA7D87.B2BF23FF-ONCA256DCD.007AD642@tmca.com.au>
 From: Dmitri.Colebatch@toyota.com.au
@@ -75,10 +75,9 @@ dim
 
 "Koller, Shmuel" <Shmuel_Koller@bmc.com> on 29/10/2003 03:28:15 AM
 
-Please respond to xmlbeans-user@xml.apache.org
+Please respond to globaladmin@testdomain.com
 
-To:    xmlbeans-user@xml.apache.org
-cc:
+To:    globaladmin@testdomain.com
 Subject:    Versioning of XML Schema
 
 Assume we have a XML standard (SOAP based) version 1 schema, with its

--- a/data/public/mime/email03/130
+++ b/data/public/mime/email03/130
@@ -9,12 +9,12 @@ Received: (qmail 47595 invoked by uid 500); 8 Oct 2003 15:38:39 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 47582 invoked from network); 8 Oct 2003 15:38:38 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -30,7 +30,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: relaxing the JDK 1.4 requirement
 Thread-Index: AcONsj6nNv1vBW03Q5uKwj/gR1D6WQ==
 From: "David Remy" <dremy@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 08 Oct 2003 15:38:41.0916 (UTC)
 	FILETIME=[404F9BC0:01C38DB2]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -44,7 +44,7 @@ forwarding.
 > From: Maurice_E_Sherman@Keane.Com=20
 > [mailto:Maurice_E_Sherman@Keane.Com]=20
 > Sent: Wednesday, October 08, 2003 7:42 AM
-> To: xmlbeans-user@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: relaxing the JDK 1.4 requirement
 >=20
 >=20

--- a/data/public/mime/email03/131
+++ b/data/public/mime/email03/131
@@ -10,12 +10,12 @@ Received: (qmail 99002 invoked by uid 500); 26 Sep 2003 17:21:26 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 98979 invoked from network); 26 Sep 2003 17:21:26 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: xmlbeans javadocs?
 Thread-Index: AcOEUSmOu3GOMvExQoaGVAT0WGJrcAAAO/Xg
 From: "David Remy" <dremy@bea.com>
-To: <xmlbeans-dev@xml.apache.org>, <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com, <globaladmin@testdomain.com>
 X-OriginalArrivalTime: 26 Sep 2003 17:21:30.0572 (UTC)
 	FILETIME=[A028D0C0:01C38452]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -72,7 +72,7 @@ her build options.
 > -----Original Message-----
 > From: Sullivan, Sean C - MWT [mailto:Sullivan.Sean@menlolog.com]
 > Sent: Friday, September 26, 2003 10:11 AM
-> To: 'xmlbeans-dev@xml.apache.org'
+> To: 'globaladmin@testdomain.com'
 > Subject: xmlbeans javadocs?
 >=20
 >=20

--- a/data/public/mime/email03/132
+++ b/data/public/mime/email03/132
@@ -9,21 +9,21 @@ Received: (qmail 22050 invoked by uid 500); 8 Oct 2003 05:14:43 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 22037 invoked from network); 8 Oct 2003 05:14:43 -0000
 Date: Tue, 7 Oct 2003 22:14:48 -0700
 X-Zimbra-Received: Tue, 7 Oct 2003 22:14:48 -0700
 Subject: Re: cursor question...
 Mime-Version: 1.0 (Apple Message framework v552)
 From: Roland Smith <smith@stanford.edu>
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Content-Transfer-Encoding: 7bit
-In-Reply-To: <4B2B4C417991364996F035E1EE39E2E10D8E20@uskiex01.amer.bea.com>
+In-Reply-To: globaladmin@testdomain.com
 Message-Id: <56A07A4A-F94E-11D7-8D14-000A95D98EF2@stanford.edu>
 X-Mailer: Apple Mail (2.552)
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -84,7 +84,7 @@ On Tuesday, October 7, 2003, at 07:44  PM, Eric Vasilik wrote:
 > -----Original Message-----
 > From: Roland Smith [mailto:smith@stanford.edu]
 > Sent: Tuesday, October 07, 2003 2:38 PM
-> To: xmlbeans-user@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: cursor question...
 >
 >

--- a/data/public/mime/email03/133
+++ b/data/public/mime/email03/133
@@ -9,12 +9,12 @@ Received: (qmail 75341 invoked by uid 500); 8 Oct 2003 17:34:17 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 75327 invoked from network); 8 Oct 2003 17:34:17 -0000
 Date: Wed, 8 Oct 2003 10:34:16 -0700
 X-Zimbra-Received: Wed, 8 Oct 2003 10:34:16 -0700
@@ -22,7 +22,7 @@ Subject: Re: Namespace Question...
 Content-Type: text/plain; charset=US-ASCII; format=flowed
 Mime-Version: 1.0 (Apple Message framework v552)
 From: Roland Smith <smith@stanford.edu>
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Content-Transfer-Encoding: 7bit
 In-Reply-To: <9E289A90-F9AC-11D7-B5A5-000393D5A006@vrtx.com>
 Message-Id: <A3D23A16-F9B5-11D7-803B-000A95D98EF2@stanford.edu>

--- a/data/public/mime/email03/134
+++ b/data/public/mime/email03/134
@@ -9,12 +9,12 @@ Received: (qmail 34018 invoked by uid 500); 13 Sep 2003 00:47:36 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 33974 invoked from network); 13 Sep 2003 00:47:35 -0000
 Subject: RE: Source Code
 MIME-Version: 1.0
@@ -30,8 +30,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Source Code
 Thread-Index: AcN5ZiChSunDY+HRRiebMFldzS110QABremg
 From: "Cliff Schmidt" <cliff@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
-Cc: <infrastructure@apache.org>, <pmc@incubator.apache.org>, <pmc@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 13 Sep 2003 00:47:43.0915 (UTC)
 	FILETIME=[A4883FB0:01C37990]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -64,8 +63,7 @@ On Friday, September 12, 2003 12:43 PM, kkress@bankofny.com wrote:
 Please respond to xmlbeans-dev=20
 
         =20
-        To:        xmlbeans-dev@xml.apache.org=20
-        cc:        =20
+        To:        globaladmin@testdomain.com=20
         Subject:        Source Code=20
 
 

--- a/data/public/mime/email03/135
+++ b/data/public/mime/email03/135
@@ -10,16 +10,16 @@ Received: (qmail 26758 invoked by uid 500); 21 Oct 2003 15:26:30 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 26744 invoked from network); 21 Oct 2003 15:26:30 -0000
 Message-ID: <013701c397e7$af16c350$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References:
 	 <1924BF350FC96B46A56BB38087B9B86E6A63BF@srvcorreio.primavera.local>
 Subject: Re: Feature Request: Serialization
@@ -51,7 +51,7 @@ David
 
 ----- Original Message ----- 
 From: "Jochen Rebhan" <jochen.rebhan@primaverasoft.pt>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Tuesday, October 21, 2003 10:04 AM
 Subject: [xmlbeans-dev] Feature Request: Serialization
 

--- a/data/public/mime/email03/136
+++ b/data/public/mime/email03/136
@@ -9,16 +9,16 @@ Received: (qmail 83704 invoked by uid 500); 3 Oct 2003 20:36:33 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 83681 invoked from network); 3 Oct 2003 20:36:33 -0000
 Message-ID: <018b01c389ee$08912ea0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Binding-config api checkin coming
 Date: Fri, 3 Oct 2003 16:36:29 -0400
 X-Zimbra-Received: Fri, 3 Oct 2003 16:36:29 -0400

--- a/data/public/mime/email03/137
+++ b/data/public/mime/email03/137
@@ -10,22 +10,22 @@ Received: (qmail 86197 invoked by uid 500); 29 Sep 2003 18:26:59 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 86154 invoked from network); 29 Sep 2003 18:26:59 -0000
 Message-Id: <5.2.1.1.0.20030929103344.01f72160@san-francisco.beasys.com>
 X-Sender: pcal@san-francisco.beasys.com (Unverified)
 X-Mailer: QUALCOMM Windows Eudora Version 5.2.1
 Date: Mon, 29 Sep 2003 11:23:48 -0700
 X-Zimbra-Received: Mon, 29 Sep 2003 11:23:48 -0700
-To: xmlbeans-dev@xml.apache.org, <christopher.fry@bea.com>, <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com, <globaladmin@testdomain.com>
 From: Patrick Calahan <pcal@bea.com>
 Subject: RE: V2 Store discussion...
-In-Reply-To: <4B2B4C417991364996F035E1EE39E2E10D8E0F@uskiex01.amer.bea.c om>
+In-Reply-To: globaladmin@testdomain.com
 Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="=====================_2067796==.ALT"
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -69,7 +69,7 @@ how much of a requirement threadsafe XMLBeans really is going to be for users.
 >-----Original Message-----
 >From: Chris Fry [mailto:christopher.fry@bea.com]
 >Sent: Monday, September 29, 2003 9:55 AM
->To: xmlbeans-dev@xml.apache.org; Eric Vasilik
+>To: globaladmin@testdomain.com
 >Subject: RE: V2 Store discussion...
 >
 >
@@ -86,8 +86,7 @@ how much of a requirement threadsafe XMLBeans really is going to be for users.
 > > -----Original Message-----
 > > From: David Bau [mailto:david.bau@bea.com]
 > > Sent: Monday, September 29, 2003 8:27 AM
-> > To: Eric Vasilik
-> > Cc: xmlbeans-dev@xml.apache.org
+> > To: globaladmin@testdomain.com
 > > Subject: V2 Store discussion...
 > >
 > >
@@ -157,7 +156,7 @@ Any thoughts?&nbsp; Any confusion about this trade off?&nbsp; <br><br>
 From: Chris Fry
 [<a href="mailto:christopher.fry@bea.com" eudora="autourl">mailto:christopher.fry@bea.com</a>]<br>
 Sent: Monday, September 29, 2003 9:55 AM<br>
-To: xmlbeans-dev@xml.apache.org; Eric Vasilik<br>
+To: globaladmin@testdomain.com;<br>
 Subject: RE: V2 Store discussion...<br><br>
 <br>
 I think you should be careful not to make the same mistakes that the
@@ -178,8 +177,7 @@ in WS-invocations...<br><br>
 &gt; From: David Bau
 [<a href="mailto:david.bau@bea.com" eudora="autourl">mailto:david.bau@bea.com</a>]<br>
 &gt; Sent: Monday, September 29, 2003 8:27 AM<br>
-&gt; To: Eric Vasilik<br>
-&gt; Cc: xmlbeans-dev@xml.apache.org<br>
+&gt; To: globaladmin@testdomain.com<br>
 &gt; Subject: V2 Store discussion...<br>
 &gt;<br>
 &gt;<br>

--- a/data/public/mime/email03/138
+++ b/data/public/mime/email03/138
@@ -9,12 +9,12 @@ Received: (qmail 70045 invoked by uid 500); 2 Oct 2003 17:07:01 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 69967 invoked from network); 2 Oct 2003 17:07:01 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -29,7 +29,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Finalizers
 Thread-Index: AcOI73v+ImO1hg37TJeq+ovAWlrBXwAFrutQ
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 02 Oct 2003 17:07:04.0817 (UTC)
 	FILETIME=[9A9B9610:01C38907]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -63,7 +63,7 @@ ould be called.
 -----Original Message-----
 From: Chris Maeda [mailto:cmaeda@granitehealth.com]
 Sent: Thursday, October 02, 2003 7:14 AM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: Finalizers
 
 
@@ -72,7 +72,7 @@ Have you looked at using weak references for the XML->Cursor references?
 -----Original Message-----
 From: Eric Vasilik [mailto:ericvas@bea.com]=20
 Sent: Wednesday, October 01, 2003 1:14 PM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: Finalizers
 
 
@@ -121,7 +121,7 @@ particular object no longer needed finalization.  Does such a thing exist?
 -----Original Message-----
 From: Darrell Teague [mailto:darrell.teague@mantech.com]
 Sent: Wednesday, October 01, 2003 8:49 AM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Finalizers
 
 

--- a/data/public/mime/email03/139
+++ b/data/public/mime/email03/139
@@ -9,12 +9,12 @@ Received: (qmail 98329 invoked by uid 500); 16 Sep 2003 00:06:50 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 98316 invoked from network); 16 Sep 2003 00:06:50 -0000
 Message-ID: <3F665421.7030603@sauria.com>
 Date: Mon, 15 Sep 2003 17:06:57 -0700
@@ -24,11 +24,11 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.5b)
 	Gecko/20030901 Thunderbird/0.2
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: XmlBeans source code has been checked in ...
 References: <4B2B4C417991364996F035E1EE39E2E10D8E06@uskiex01.amer.bea.com>
 	 <20030916085631.3D64.TETSUYA@apache.org>
-In-Reply-To: <20030916085631.3D64.TETSUYA@apache.org>
+In-Reply-To: globaladmin@testdomain.com
 X-Enigmail-Version: 0.81.6.0
 X-Enigmail-Supports: pgp-inline, pgp-mime
 Content-Type: text/plain; charset=ISO-8859-1; format=flowed

--- a/data/public/mime/email03/14
+++ b/data/public/mime/email03/14
@@ -6,7 +6,7 @@ Received: from churchill (unknown [10.10.130.116]) by kenny.example.zimbra.com
 	(Postfix) with ESMTP id B586640040E for <smith@example.zimbra.com>; Sat, 27
 	Mar 2004 14:42:18 -0800 (PST)
 From: "Ross Davidson, Ph.D." <davidson@example.zimbra.com>
-To: <smith@example.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: Linux Desktop Info
 Date: Sat, 27 Mar 2004 14:46:48 -0800
 X-Zimbra-Received: Sat, 27 Mar 2004 14:46:48 -0800

--- a/data/public/mime/email03/140
+++ b/data/public/mime/email03/140
@@ -10,12 +10,12 @@ Received: (qmail 27063 invoked by uid 500); 29 Sep 2003 18:53:06 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 27043 invoked from network); 29 Sep 2003 18:53:06 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: How to get my own package names?
 Thread-Index: AcOGtC0/W6/b/hm1TDGRB5HCIFh5RgABaMsQ
 From: "David Remy" <dremy@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 29 Sep 2003 18:53:11.0019 (UTC)
 	FILETIME=[EDEBABB0:01C386BA]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -81,7 +81,7 @@ ontent-type=3Dtext/plain.
 > -----Original Message-----
 > From: Vidar H=E5kestad [mailto:vidar@hawkis.com]
 > Sent: Sunday, September 28, 2003 9:09 AM
-> To: xmlbeans-user@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: How to get my own package names?
 >=20
 >=20

--- a/data/public/mime/email03/141
+++ b/data/public/mime/email03/141
@@ -9,12 +9,12 @@ Received: (qmail 62295 invoked by uid 500); 1 Oct 2003 21:21:38 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 62282 invoked from network); 1 Oct 2003 21:21:38 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -29,7 +29,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: problems with inheritance while saving XML
 Thread-Index: AcOIOlM+sKLv+KFdRhaSNzMSIz1FpAAJu9hw
 From: "David Remy" <dremy@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 01 Oct 2003 21:21:44.0738 (UTC)
 	FILETIME=[03BCC020:01C38862]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -90,7 +90,7 @@ ance();
 -----Original Message-----
 From: Carl_Elkin@vrtx.com [mailto:Carl_Elkin@vrtx.com]
 Sent: Wednesday, October 01, 2003 9:37 AM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: problems with inheritance while saving XML
 
 

--- a/data/public/mime/email03/142
+++ b/data/public/mime/email03/142
@@ -9,16 +9,16 @@ Received: (qmail 65751 invoked by uid 500); 2 Oct 2003 19:46:51 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 65738 invoked from network); 2 Oct 2003 19:46:51 -0000
 Message-ID: <00f201c3891d$eda75810$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <sf7c27f2.095@corp-gw.mantech.com>
 Subject: Re: Source Build Problem
 Date: Thu, 2 Oct 2003 15:46:51 -0400

--- a/data/public/mime/email03/143
+++ b/data/public/mime/email03/143
@@ -9,13 +9,13 @@ Received: (qmail 68069 invoked by uid 500); 15 Sep 2003 23:20:25 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
-Delivered-To: moderator for xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
+Delivered-To: moderator for globaladmin@testdomain.com
 Received: (qmail 28369 invoked from network); 15 Sep 2003 21:07:19 -0000
 content-class: urn:content-classes:message
 Subject: XmlBeans source code has been checked in ...
@@ -31,8 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: XmlBeans source code has been checked in ...
 Thread-Index: AcN7zVqm0/g4nXKTTMKpPiP8n2fcuw==
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
-Cc: <xmlbeans-user@xml.apache.org>, <xmlbeans-cvs@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 15 Sep 2003 21:07:25.0008 (UTC)
 	FILETIME=[5CB05D00:01C37BCD]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/144
+++ b/data/public/mime/email03/144
@@ -10,12 +10,12 @@ Received: (qmail 23705 invoked by uid 500); 18 Sep 2005 19:31:16 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 23692 invoked from network); 18 Sep 2005 19:31:16 -0000
 Message-ID: <3F6A0808.7020901@sauria.com>
 Date: Thu, 18 Sep 2005 12:31:20 -0700
@@ -25,10 +25,10 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.5b)
 	Gecko/20030901 Thunderbird/0.2
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Future XMLBeans feature work?
 References: <012801c37e19$9ef367e0$d41e11ac@lightbox>
-In-Reply-To: <012801c37e19$9ef367e0$d41e11ac@lightbox>
+In-Reply-To: globaladmin@testdomain.com
 X-Enigmail-Version: 0.81.6.0
 X-Enigmail-Supports: pgp-inline, pgp-mime
 Content-Type: text/plain; charset=ISO-8859-1; format=flowed

--- a/data/public/mime/email03/145
+++ b/data/public/mime/email03/145
@@ -9,16 +9,16 @@ Received: (qmail 59448 invoked by uid 500); 17 Sep 2003 18:03:54 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 59434 invoked from network); 17 Sep 2003 18:03:54 -0000
 Message-ID: <009901c37d46$0cbd2150$d41e11ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: About me
 Date: Wed, 17 Sep 2003 14:03:50 -0400
 X-Zimbra-Received: Wed, 17 Sep 2003 14:03:50 -0400

--- a/data/public/mime/email03/146
+++ b/data/public/mime/email03/146
@@ -10,16 +10,16 @@ Received: (qmail 16465 invoked by uid 500); 27 Oct 2003 23:00:16 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 16451 invoked from network); 27 Oct 2003 23:00:15 -0000
 Sensitivity: 
 Subject: Re: XML to Java at run-time
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 X-Mailer: Lotus Notes Release 5.0.8  June 18, 2001
 Message-ID: <OF4F0C2BB6.046A6524-ONCA256DCC.007DC715@tmca.com.au>
 From: Dmitri.Colebatch@toyota.com.au
@@ -63,10 +63,9 @@ dim
 
 "Koller, Shmuel" <Shmuel_Koller@bmc.com> on 28/10/2003 05:25:52 AM
 
-Please respond to xmlbeans-user@xml.apache.org
+Please respond to globaladmin@testdomain.com
 
-To:    xmlbeans-user@xml.apache.org
-cc:
+To:    globaladmin@testdomain.com
 Subject:    XML to Java at run-time
 
 I am looking at Java Binding tool for developing WebServices - incoming as

--- a/data/public/mime/email03/147
+++ b/data/public/mime/email03/147
@@ -9,18 +9,18 @@ Received: (qmail 92844 invoked by uid 500); 6 Nov 2003 18:08:29 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 92821 invoked from network); 6 Nov 2003 18:08:29 -0000
 X-VirusChecked: Checked
 X-Env-Sender: kkress@bankofny.com
 X-Msg-Ref: server-20.tower-16.messagelabs.com!1068142109!2561783
 X-StarScan-Version: 5.1.9.3; banners=bankofny.com,-,-
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Official release yet?
 MIME-Version: 1.0
 Message-ID: <OF6D187C6B.A8259626-ON85256DD6.0062A9E2-85256DD6.006382FF@bankofny.com>
@@ -82,8 +82,7 @@ Srinivas Yermal <syermal@encover.com>
 Please respond to xmlbeans-user
 
  
-        To:     xmlbeans-user@xml.apache.org
-        cc: 
+        To:     globaladmin@testdomain.com
         Subject:        Official release yet?
 
 
@@ -167,8 +166,7 @@ SAS, The Bank of New York &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp
 <br><font size=1 face="sans-serif">Please respond to xmlbeans-user</font>
 <br>
 <td><font size=1 face="Arial">&nbsp; &nbsp; &nbsp; &nbsp; </font>
-<br><font size=1 face="sans-serif">&nbsp; &nbsp; &nbsp; &nbsp; To: &nbsp; &nbsp; &nbsp; &nbsp;xmlbeans-user@xml.apache.org</font>
-<br><font size=1 face="sans-serif">&nbsp; &nbsp; &nbsp; &nbsp; cc: &nbsp; &nbsp; &nbsp; &nbsp;</font>
+<br><font size=1 face="sans-serif">&nbsp; &nbsp; &nbsp; &nbsp; To: &nbsp; &nbsp; &nbsp; &nbsp;globaladmin@testdomain.com</font>
 <br><font size=1 face="sans-serif">&nbsp; &nbsp; &nbsp; &nbsp; Subject: &nbsp; &nbsp; &nbsp; &nbsp;Official release yet?</font></table>
 <br>
 <br>

--- a/data/public/mime/email03/148
+++ b/data/public/mime/email03/148
@@ -10,12 +10,12 @@ Received: (qmail 45584 invoked by uid 500); 26 Sep 2003 01:49:05 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 45529 invoked from network); 26 Sep 2003 01:49:05 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -31,8 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: licenses for jaxb-api.jar and jax-qname.jar...?
 Thread-Index: AcODwu8XPWNwo9bjQxOP0jKDepWtHgAA1/1wAAJtd7A=
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
-Cc: <pmc@incubator.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 26 Sep 2003 01:49:14.0209 (UTC)
 	FILETIME=[637D2D10:01C383D0]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -50,7 +49,7 @@ xmlbeans.
 -----Original Message-----
 From: Eric Vasilik=20
 Sent: Thursday, September 25, 2003 5:38 PM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: licenses for jaxb-api.jar and jax-qname.jar...?
 
 
@@ -62,7 +61,7 @@ xis.  Where would one be able to get the jaxb api?
 -----Original Message-----
 From: robert burrell donkin [mailto:rdonkin@apache.org]
 Sent: Thursday, September 25, 2003 5:15 PM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: licenses for jaxb-api.jar and jax-qname.jar...?
 
 

--- a/data/public/mime/email03/149
+++ b/data/public/mime/email03/149
@@ -10,12 +10,12 @@ Received: (qmail 47829 invoked by uid 500); 23 Sep 2003 00:58:07 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 47816 invoked from network); 23 Sep 2003 00:58:07 -0000
 content-class: urn:content-classes:message
 MIME-Version: 1.0
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Getting the distribution onto a download site somewhere ...
 Thread-Index: AcOBV5GSHUShUhs+RYm1kWriMwOp4wAB9l5A
 From: "Cliff Schmidt" <cliff@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 22 Sep 2003 23:58:55.0326 (UTC)
 	FILETIME=[7B1687E0:01C38165]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/15
+++ b/data/public/mime/email03/15
@@ -7,7 +7,7 @@ Received: from [10.10.130.109] (unknown [10.10.130.109]) by
 	<smith@example.zimbra.com>; Fri, 26 Mar 2004 16:43:58 -0800 (PST)
 Subject: outlook...
 From: "Smith, Roland Q. (VP)" <smith@example.zimbra.com>
-To: smith@example.zimbra.com
+To: globaladmin@testdomain.com
 Content-Type: multipart/mixed; boundary="=-mTT+IyyX+d829XGe+k1/"
 Message-Id: <1080348223.24248.6.camel@localhost.localdomain>
 Mime-Version: 1.0

--- a/data/public/mime/email03/150
+++ b/data/public/mime/email03/150
@@ -10,12 +10,12 @@ Received: (qmail 58367 invoked by uid 500); 22 Sep 2003 01:38:54 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 58353 invoked from network); 22 Sep 2003 01:38:54 -0000
 Message-ID: <3F6E52B4.7060306@sauria.com>
 Date: Sun, 21 Sep 2003 18:39:00 -0700
@@ -25,10 +25,10 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.5b)
 	Gecko/20030901 Thunderbird/0.2
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Getting the distribution onto a download site somewhere ...
 References: <4B2B4C417991364996F035E1EE39E2E11E9976@uskiex01.amer.bea.com>
-In-Reply-To: <4B2B4C417991364996F035E1EE39E2E11E9976@uskiex01.amer.bea.com>
+In-Reply-To: globaladmin@testdomain.com
 X-Enigmail-Version: 0.81.6.0
 X-Enigmail-Supports: pgp-inline, pgp-mime
 Content-Type: text/plain; charset=ISO-8859-1; format=flowed

--- a/data/public/mime/email03/151
+++ b/data/public/mime/email03/151
@@ -9,12 +9,12 @@ Received: (qmail 55567 invoked by uid 500); 10 Oct 2003 20:08:04 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 55551 invoked from network); 10 Oct 2003 20:08:04 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -30,7 +30,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: noNamespace package alternatives
 Thread-Index: AcOPaRo65/vubJPgTL20VBqtEGJ00gAAAmlgAAA82jA=
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 10 Oct 2003 20:07:53.0660 (UTC)
 	FILETIME=[3053A7C0:01C38F6A]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -45,7 +45,7 @@ he.org&msgId=3D1035917
 -----Original Message-----
 From: Breese, Dustin [mailto:dustin.breese@qwest.com]
 Sent: Friday, October 10, 2003 1:01 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: noNamespace package alternatives
 
 
@@ -59,7 +59,7 @@ Dustin
 -----Original Message-----
 From: Eric Vasilik [mailto:ericvas@bea.com]=20
 Sent: Friday, October 10, 2003 1:53 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: noNamespace package alternatives
 
 The -repackage option exists for the purposes of building the XmlBeans
@@ -73,7 +73,7 @@ Are you trying to change the packages that a schema compiles to?
 -----Original Message-----
 From: Breese, Dustin [mailto:dustin.breese@qwest.com]
 Sent: Friday, October 10, 2003 12:42 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: noNamespace package alternatives
 
 

--- a/data/public/mime/email03/152
+++ b/data/public/mime/email03/152
@@ -10,12 +10,12 @@ Received: (qmail 87688 invoked by uid 500); 10 Oct 2003 14:44:54 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 87662 invoked from network); 10 Oct 2003 14:44:54 -0000
 X-Authentication-Warning: www.princetongames.org: ammulder owned process
 	doing -bs
@@ -23,9 +23,9 @@ Date: Fri, 10 Oct 2003 10:47:39 -0400 (EDT)
 X-Zimbra-Received: Fri, 10 Oct 2003 10:47:39 -0400 (EDT)
 From: Aaron Mulder <ammulder@alumni.princeton.edu>
 X-X-Sender: ammulder@www.princetongames.org
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Parallel Extension Question
-In-Reply-To: <sf86768f.045@corp-gw.mantech.com>
+In-Reply-To: globaladmin@testdomain.com
 Message-ID: <Pine.LNX.4.44.0310101041450.26242-100000@www.princetongames.org>
 MIME-Version: 1.0
 Content-Type: TEXT/PLAIN; charset=US-ASCII

--- a/data/public/mime/email03/153
+++ b/data/public/mime/email03/153
@@ -10,15 +10,15 @@ Received: (qmail 46671 invoked by uid 500); 29 Sep 2003 17:03:24 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 46653 invoked from network); 29 Sep 2003 17:03:23 -0000
-Reply-To: <christopher.fry@bea.com>
+Reply-To: globaladmin@testdomain.com
 From: "Chris Fry" <christopher.fry@bea.com>
-To: <xmlbeans-dev@xml.apache.org>, "'Eric Vasilik'" <eric.vasilik@bea.com>
+To: globaladmin@testdomain.com
 Subject: RE: V2 Store discussion...
 Date: Mon, 29 Sep 2003 09:54:39 -0700
 X-Zimbra-Received: Mon, 29 Sep 2003 09:54:39 -0700
@@ -30,7 +30,7 @@ X-Priority: 3 (Normal)
 X-MSMail-Priority: Normal
 X-Mailer: Microsoft Outlook CWS, Build 9.0.2416 (9.0.2911.0)
 X-MimeOLE: Produced By Microsoft MimeOLE V6.00.2800.1106
-In-Reply-To: <003501c3869e$25cfdc80$0fa8a8c0@lightbox>
+In-Reply-To: globaladmin@testdomain.com
 Importance: Normal
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/
@@ -49,8 +49,7 @@ in WS-invocations...
 > -----Original Message-----
 > From: David Bau [mailto:david.bau@bea.com]
 > Sent: Monday, September 29, 2003 8:27 AM
-> To: Eric Vasilik
-> Cc: xmlbeans-dev@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: V2 Store discussion...
 >
 >

--- a/data/public/mime/email03/154
+++ b/data/public/mime/email03/154
@@ -10,12 +10,12 @@ Received: (qmail 9659 invoked by uid 500); 14 Oct 2003 21:48:48 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 9632 invoked from network); 14 Oct 2003 21:48:48 -0000
 Date: Tue, 14 Oct 2003 17:48:52 -0400
 X-Zimbra-Received: Tue, 14 Oct 2003 17:48:52 -0400
@@ -23,9 +23,9 @@ Subject: Re: XMLBeans/Java Web Start Issues
 Content-Type: text/plain; charset=US-ASCII; format=flowed
 Mime-Version: 1.0 (Apple Message framework v552)
 From: Tom Condon <tom_condon@vrtx.com>
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Content-Transfer-Encoding: 7bit
-In-Reply-To: <D44A54C298394F4E967EC8538B1E00F10248C932@lgchexch002.lgc.com>
+In-Reply-To: globaladmin@testdomain.com
 Message-Id: <33833A1C-FE90-11D7-BDED-000393D5A006@vrtx.com>
 X-Mailer: Apple Mail (2.552)
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/155
+++ b/data/public/mime/email03/155
@@ -9,17 +9,16 @@ Received: (qmail 96946 invoked by uid 500); 3 Oct 2003 17:36:40 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
-Delivered-To: moderator for xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
+Delivered-To: moderator for globaladmin@testdomain.com
 Received: (qmail 17591 invoked from network); 3 Oct 2003 15:42:23 -0000
 In-Reply-To: <013701c389c2$b6a7d920$0fa8a8c0@lightbox>
-To: xmlbeans-user@xml.apache.org
-Cc: xmlbeans-dev@xml.apache.org, xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: ArrayStoreException when using RMI
 MIME-Version: 1.0
 X-Mailer: Lotus Notes Release 6.0.1 February 07, 2003
@@ -100,11 +99,11 @@ minOccurs="0" maxOccurs="unbounded"/>
 "David Bau" <david.bau@bea.com> 
 10/03/2003 11:26 AM
 Please respond to
-xmlbeans-user@xml.apache.org
+globaladmin@testdomain.com
 
 
 To
-<xmlbeans-user@xml.apache.org>, <xmlbeans-dev@xml.apache.org>
+<globaladmin@testdomain.com>, <globaladmin@testdomain.com>
 cc
 
 Subject
@@ -132,7 +131,7 @@ Anybody else on xmlbeans-dev have any insights?
 David
 ----- Original Message ----- 
 From: Carl_Elkin@vrtx.com
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Sent: Friday, October 03, 2003 10:51 AM
 Subject: [xmlbeans-dev] ArrayStoreException when using RMI
 
@@ -323,15 +322,15 @@ follows at the end of this message.]</font>
 <tr valign=top>
 <td bgcolor=white>
 <div align=center><font size=1 face="sans-serif">Please respond to<br>
-xmlbeans-user@xml.apache.org</font></div></table>
+globaladmin@testdomain.com</font></div></table>
 <br>
 <td width=59%>
 <table width=100%>
 <tr>
 <td>
 <div align=right><font size=1 face="sans-serif">To</font></div>
-<td valign=top><font size=1 face="sans-serif">&lt;xmlbeans-user@xml.apache.org&gt;,
-&lt;xmlbeans-dev@xml.apache.org&gt;</font>
+<td valign=top><font size=1 face="sans-serif">&lt;globaladmin@testdomain.com&gt;,
+&lt;globaladmin@testdomain.com&gt;</font>
 <tr>
 <td>
 <div align=right><font size=1 face="sans-serif">cc</font></div>
@@ -365,7 +364,7 @@ Anybody else on xmlbeans-dev have any insights?<br>
 David<br>
 ----- Original Message ----- <br>
 From: Carl_Elkin@vrtx.com<br>
-To: xmlbeans-user@xml.apache.org<br>
+To: globaladmin@testdomain.com<br>
 Sent: Friday, October 03, 2003 10:51 AM<br>
 Subject: [xmlbeans-dev] ArrayStoreException when using RMI<br>
 <br>

--- a/data/public/mime/email03/156
+++ b/data/public/mime/email03/156
@@ -10,16 +10,16 @@ Received: (qmail 90330 invoked by uid 500); 23 Oct 2003 00:10:09 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 90317 invoked from network); 23 Oct 2003 00:10:08 -0000
 Sensitivity: 
 Subject: Re: deep equals implementation?
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 X-Mailer: Lotus Notes Release 5.0.8  June 18, 2001
 Message-ID: <OF9AE3F412.FBC55E0F-ONCA256DC8.0000C26C@tmca.com.au>
 From: Dmitri.Colebatch@toyota.com.au
@@ -48,10 +48,9 @@ dim
 
 Robert Wyrick <rob@wyrick.org> on 23/10/2003 09:43:36 AM
 
-Please respond to xmlbeans-user@xml.apache.org
+Please respond to globaladmin@testdomain.com
 
-To:    xmlbeans-user@xml.apache.org
-cc:
+To:    globaladmin@testdomain.com
 Subject:    Re: deep equals implementation?
 
 With careful use of :

--- a/data/public/mime/email03/157
+++ b/data/public/mime/email03/157
@@ -9,16 +9,16 @@ Received: (qmail 10407 invoked by uid 500); 13 Sep 2003 11:29:02 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 10392 invoked from network); 13 Sep 2003 11:29:01 -0000
 Message-ID: <023801c379ea$395c14f0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <022901c379e9$2d9387d0$0fa8a8c0@lightbox>
 Subject: list archiving
 Date: Sat, 13 Sep 2003 07:28:57 -0400

--- a/data/public/mime/email03/158
+++ b/data/public/mime/email03/158
@@ -10,16 +10,16 @@ Received: (qmail 84538 invoked by uid 500); 22 Sep 2005 20:35:42 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 84516 invoked from network); 22 Sep 2005 20:35:42 -0000
 Message-ID: <00fe01c38149$14b7c750$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>, "robert burrell donkin" <rdonkin@apache.org>
+To: globaladmin@testdomain.com
 References: <A6AD8022-EB4B-11D7-A7F2-003065DC754C@apache.org>
 Subject: Re: Future XMLBeans feature work?
 Date: Mon, 22 Sep 2005 16:35:35 -0400

--- a/data/public/mime/email03/159
+++ b/data/public/mime/email03/159
@@ -10,15 +10,15 @@ Received: (qmail 5774 invoked by uid 500); 11 Nov 2003 20:14:14 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 5720 invoked from network); 11 Nov 2003 20:14:14 -0000
 Mime-Version: 1.0 (Apple Message framework v606)
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Message-Id: <9A06B7E0-1483-11D8-B5EC-000393D5A006@vrtx.com>
 Content-Type: multipart/alternative; boundary=Apple-Mail-1-80133309
 From: Tom Condon <tom_condon@vrtx.com>

--- a/data/public/mime/email03/16
+++ b/data/public/mime/email03/16
@@ -13,7 +13,7 @@ Received: from [192.168.1.224] (adsl-67-122-207-249.dsl.pltn13.pacbell.net
 	cipher=RC4-SHA bits=128 verify=NOT) for <smith@stanford.edu>; Thu, 25
 	Mar 2004 00:43:40 -0800
 Mime-Version: 1.0 (Apple Message framework v613)
-To: Roland Smith <smith@stanford.edu>
+To: globaladmin@testdomain.com
 Message-Id: <0B56D393-7E38-11D8-967E-000A95D98EF2@stanford.edu>
 Content-Type: multipart/mixed; boundary=Apple-Mail-1-965086687
 From: Roland Smith <smith@stanford.edu>

--- a/data/public/mime/email03/160
+++ b/data/public/mime/email03/160
@@ -5,7 +5,7 @@ Received: from [10.10.130.25] (slapshot.example.zimbra.com [10.10.130.25]) by
 	<smith@example.zimbra.com>; Mon, 21 Jun 2004 10:29:10 -0700 (PDT)
 Subject: Subject: 2004-05 Benefits Plan
 From: Frank Baldwin <fbaldwin@example.zimbra.com>
-To: Andy Flomm <aflomm@example.zimbra.com>
+To: globaladmin@testdomain.com
 Content-Type: multipart/mixed; boundary="=-FKgPtgsPfbUxukkEOnIb"
 Message-Id: <1087838950.26256.1.camel@slapshot.example.zimbra.com>
 Mime-Version: 1.0

--- a/data/public/mime/email03/161
+++ b/data/public/mime/email03/161
@@ -1,5 +1,5 @@
 From: Betsy Aversano <baversano@example.zimbra.com>
-To: Andy Flomm <aflomm@example.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: Company BBQ, August 13th
 Date: Mon, 21 Jun 2004 10:20:10 -0700
 X-Zimbra-Received: Mon, 21 Jun 2004 10:20:10 -0700

--- a/data/public/mime/email03/162
+++ b/data/public/mime/email03/162
@@ -1,7 +1,7 @@
 From: Courtney Averill <caverill@example.zimbra.com>
 Date: Mon, 21 Jun 2004 9:15:10 -0700
 X-Zimbra-Received: Mon, 21 Jun 2004 9:15:10 -0700
-To: Andy Flomm <aflomm@example.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: Department update
 Message-ID: <1087838950.26256.3.camel@slapshot.example.zimbra.com>
 

--- a/data/public/mime/email03/163
+++ b/data/public/mime/email03/163
@@ -1,7 +1,7 @@
 From: Reggie Armstrong <rarmstrong@example.zimbra.com>
 Date: Fri, 18 Jun 2004 11:34:10 -0700
 X-Zimbra-Received: Fri, 18 Jun 2004 11:34:10 -0700
-To: Andy Flomm <aflomm@example.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: FW: Supply re-order - ?
 Message-ID: <1087838950.26256.4.camel@slapshot.example.zimbra.com>
 
@@ -15,7 +15,7 @@ Thank you, but we just received a shipment of supplies here in Customer Support,
 ---- Original Message --------------------
 From: Andy Flomm <aflomm@example.zimbra.com>
 Sent: Thursday, June 3, 2004 9:08 AM
-To: Reggie Armstrong <rarmstrong@example.zimbra.com>
+To: globaladmin@testdomain.com
 Subject:  Supply re-order - ? 
   
 Reggie, 

--- a/data/public/mime/email03/164
+++ b/data/public/mime/email03/164
@@ -1,7 +1,7 @@
 From: Samuel Darmo <samuel@example.zimbra.com>
 Date: Mon, 21 Jun 2004 9:00:10 -0700
 X-Zimbra-Received: Mon, 21 Jun 2004 9:00:10 -0700
-To: Andy Flomm <aflomm@example.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: Important Company Announcement
 Message-ID: <1087838950.26256.5.camel@slapshot.example.zimbra.com>
 

--- a/data/public/mime/email03/165
+++ b/data/public/mime/email03/165
@@ -1,7 +1,7 @@
 From: Carol Pham <cpham@example.zimbra.com>
 Date: Mon, 21 Jun 2004 9:39:10 -0700
 X-Zimbra-Received: Mon, 21 Jun 2004 9:39:10 -0700
-To: Andy Flomm <aflomm@example.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: RE: Inventory report
 Message-ID: <1087838950.26256.6.camel@slapshot.example.zimbra.com>
 
@@ -15,7 +15,7 @@ Carol
 ---- Original Message --------------------
 From: Carol Pham <cpham@example.zimbra.com>
 Sent: Friday, June 4, 2004 10:08 AM
-To: Carol Pham <cpham@example.zimbra.com>
+To: globaladmin@testdomain.com
 Subject:  Inventory Report 
   
 Carol, 

--- a/data/public/mime/email03/166
+++ b/data/public/mime/email03/166
@@ -13,7 +13,7 @@ Thread-Topic: Test with unspecified MAIL FROM
 Thread-Index: AcRa5dlgCVyEvpTsQBuvTVxPv1TYTw==
 X-MimeOLE: Produced By Microsoft Exchange V6.5.7226.0
 From: <No Where>
-To: "Jiho Hamm" <jhamm@toons.Zimbra.com>
+To: globaladmin@testdomain.com
 
 This is a multi-part message in MIME format.
 

--- a/data/public/mime/email03/167
+++ b/data/public/mime/email03/167
@@ -24,7 +24,7 @@ Received: from rocket (localhost [127.0.0.1])
 Date:	Wed, 16 Jun 2004 09:23:44 +0200
 X-Zimbra-Received: Wed, 16 Jun 2004 09:23:44 +0200
 From: Andreas Schmidt <andy@space.wh1.tu-dresden.de>
-To: linux-kernel@vger.kernel.org
+To: globaladmin@testdomain.com
 Subject: Re: Frequent system freezes after kernel bug
 X-Gnus-Mail-Source: file:/var/spool/mail/palanis
 Message-ID: <20040616072344.GC28402@rocket>
@@ -34,7 +34,7 @@ Content-Type:	text/plain; charset=US-ASCII;
 	Format=Flowed	DelSp=Yes
 Content-Disposition: inline
 Content-Transfer-Encoding: 7BIT
-In-Reply-To: <20040612183742.GE1733@rocket> (from andy@space.wh1.tu-dresden.de on Sat, Jun 12, 2004 at 20:37:42 +0200)
+In-Reply-To: globaladmin@testdomain.com
 X-Mailer: Balsa 2.0.17
 Lines:	130
 Sender: linux-kernel-owner@vger.kernel.org

--- a/data/public/mime/email03/168
+++ b/data/public/mime/email03/168
@@ -13,7 +13,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Here are my ski pictures!
 Thread-Index: AcR0Kvovu/UKEe//ST2fD6GQBX9grg==
 From: "Ross Davidson" <davidson@example.zimbra.com>
-To: <roland@example.zimbra.com>
+To: globaladmin@testdomain.com
 X-Evolution-Source: imap://smith@exch1.example.zimbra.com/
 X-Evolution: 00000008-0130
 

--- a/data/public/mime/email03/169
+++ b/data/public/mime/email03/169
@@ -1,5 +1,5 @@
 From: "Job" <job@example.com>
-To: <sample@example.com>
+To: globaladmin@testdomain.com
 Subject: Meeting Follow Up
 Date: Wed, 21 Sep 2005 10:52:05 -0700
 MIME-Version: 1.0

--- a/data/public/mime/email03/17
+++ b/data/public/mime/email03/17
@@ -16,7 +16,7 @@ Date: Thu, 25 Mar 2004 03:07:21 -0800 (PST)
 X-Zimbra-Received: Thu, 25 Mar 2004 03:07:21 -0800 (PST)
 From: Roland Smith <roland_smith@yahoo.com>
 Subject: Fwd: screenshots
-To: smith@stanford.edu
+To: globaladmin@testdomain.com
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="0-291023275-1080212841=:64893"
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/
@@ -38,7 +38,7 @@ Note: forwarded message attached.
 --0-291023275-1080212841=:64893
 Content-Type: message/rfc822
 
-X-Apparently-To: roland_smith@yahoo.com via 216.136.131.235; Thu, 25 Mar
+X-Apparently-To: globaladmin@testdomain.com via 216.136.131.235; Thu, 25 Mar
 	2004 00:47:12 -0800
 Return-Path: <davidson@yahoo.com>
 Received: from 216.136.131.206  (HELO web11303.mail.yahoo.com)
@@ -48,8 +48,8 @@ Received: from [67.120.104.39] by web11303.mail.yahoo.com via HTTP; Thu, 25
 	Mar 2004 00:47:10 PST
 Date: Thu, 25 Mar 2004 00:47:10 -0800 (PST)
 From: Ross Davidson <davidson@yahoo.com>
-Reply-To: davidson@yahoo.com
-To: roland_smith@yahoo.com
+Reply-To: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="0-803096222-1080204430=:44557"
 Content-Length: 334538

--- a/data/public/mime/email03/18
+++ b/data/public/mime/email03/18
@@ -8,7 +8,7 @@ Received: from smtp011.mail.yahoo.com (smtp011.mail.yahoo.com
 Received: from unknown (HELO churchill) (davidson@208.15.232.133 with
 	login) by smtp011.mail.yahoo.com with SMTP; 31 Mar 2004 22:07:59 -0000
 From: "Ross Davidson" <davidson@yahoo.com>
-To: <roland@example.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: 
 Date: Wed, 31 Mar 2004 14:08:00 -0800
 X-Zimbra-Received: Wed, 31 Mar 2004 14:08:00 -0800

--- a/data/public/mime/email03/19
+++ b/data/public/mime/email03/19
@@ -13,8 +13,7 @@ Received: from [192.168.1.224] (adsl-67-122-207-249.dsl.pltn13.pacbell.net
 	cipher=RC4-SHA bits=128 verify=NOT) for <smith@stanford.edu>; Thu, 25
 	Mar 2004 00:43:40 -0800
 Mime-Version: 1.0 (Apple Message framework v613)
-To: Roland Smith <smith@stanford.edu>
-CC: roland_smith@yahoo.com
+To: globaladmin@testdomain.com
 Message-Id: <0B56D393-7E38-11D8-967E-000A95D98EF2@stanford.edu>
 Content-Type: multipart/mixed; boundary=Apple-Mail-1-965086687
 From: Roland Smith <smith@stanford.edu>

--- a/data/public/mime/email03/20
+++ b/data/public/mime/email03/20
@@ -7,7 +7,7 @@ Received: from [10.10.130.109] (unknown [10.10.130.109]) by
 	<smith@example.zimbra.com>; Tue, 27 Apr 2004 17:42:40 -0700 (PDT)
 Subject: AdminGuide...
 From: Roland Smith <smith@example.zimbra.com>
-To: smith@example.zimbra.com
+To: globaladmin@testdomain.com
 Content-Type: multipart/mixed; boundary="=-rSmOyociNcb+yWQQX9jC"
 Message-Id: <1083113270.16292.0.camel@localhost.localdomain>
 Mime-Version: 1.0

--- a/data/public/mime/email03/21
+++ b/data/public/mime/email03/21
@@ -8,12 +8,12 @@ Received: from mail.apache.org (daedalus.apache.org [208.185.179.12]) by
 Received: (qmail 42154 invoked by uid 500); 2 Dec 2003 23:53:38 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 42141 invoked from network); 2 Dec 2003 23:53:37 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.5.6944.0
 Content-class: urn:content-classes:message
@@ -31,7 +31,7 @@ Thread-Topic: java.lang.UnsupportedOperationException: This operation
 	requires xqrl.jar
 Thread-Index: AcO5L1p1SbwNauYyR4+V6oufZRZEMA==
 From: "Emil Marceta" <emarceta@layer7tech.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/
 X-Evolution: 00000015-0010

--- a/data/public/mime/email03/22
+++ b/data/public/mime/email03/22
@@ -9,17 +9,16 @@ Received: (qmail 71895 invoked by uid 500); 17 Sep 2003 00:52:40 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 71882 invoked from network); 17 Sep 2003 00:52:40 -0000
 Message-ID: <00c601c37cb5$ff5437a0$d41e11ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: "Lawrence Jones" <ljones@bea.com>
-Cc: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <4B2B4C417991364996F035E1EE39E2E11DF15D@uskiex01.amer.bea.com>
 Subject: Re: [bea-readme] Patch Submission 
 Date: Tue, 16 Sep 2003 20:52:40 -0400
@@ -45,8 +44,7 @@ David
 
 ----- Original Message ----- 
 From: "Lawrence Jones" <ljones@bea.com>
-To: "David Bau" <davidbau@bea.com>
-Cc: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Tuesday, September 16, 2003 8:28 PM
 Subject: [bea-readme] Patch Submission
 

--- a/data/public/mime/email03/23
+++ b/data/public/mime/email03/23
@@ -9,12 +9,12 @@ Received: (qmail 68452 invoked by uid 500); 6 Nov 2003 18:01:16 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 68421 invoked from network); 6 Nov 2003 18:01:16 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -29,7 +29,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Official release yet?
 Thread-Index: AcOj9WAq9yphtrGeTPycgjKg+rWC7wAlMavA
 From: "David Remy" <dremy@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 06 Nov 2003 18:01:19.0897 (UTC)
 	FILETIME=[FB3EA090:01C3A48F]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -110,7 +110,7 @@ rem
 > -----Original Message-----
 > From: Srinivas Yermal [mailto:syermal@encover.com]
 > Sent: Wednesday, November 05, 2003 2:25 PM
-> To: xmlbeans-user@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: Official release yet?
 >=20
 >=20

--- a/data/public/mime/email03/24
+++ b/data/public/mime/email03/24
@@ -10,16 +10,16 @@ Received: (qmail 48109 invoked by uid 500); 10 Oct 2003 15:18:13 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 48096 invoked from network); 10 Oct 2003 15:18:13 -0000
 Message-ID: <033f01c38f41$b021d7c0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <sf868fcc.033@corp-gw.mantech.com>
 Subject: Re: Parallel Extension Question
 Date: Fri, 10 Oct 2003 11:17:57 -0400
@@ -44,7 +44,7 @@ David
 
 ----- Original Message ----- 
 From: "Darrell Teague" <darrell.teague@mantech.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Friday, October 10, 2003 10:53 AM
 Subject: [xmlbeans-dev] Re: Parallel Extension Question
 

--- a/data/public/mime/email03/25
+++ b/data/public/mime/email03/25
@@ -10,17 +10,16 @@ Received: (qmail 63486 invoked by uid 500); 27 Sep 2003 00:04:14 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 63473 invoked from network); 27 Sep 2003 00:04:14 -0000
 Message-ID: <031601c3848a$ddf4ff40$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
-Cc: <mitch.upton@bea.com>
+To: globaladmin@testdomain.com
 Subject: Fw:  Mapping XML type QName to Java Class name?
 Date: Fri, 26 Sep 2003 20:04:04 -0400
 X-Zimbra-Received: Fri, 26 Sep 2003 20:04:04 -0400
@@ -54,7 +53,7 @@ David
 
 ----- Original Message ----- 
 From: Mitch Upton
-To: David Bau
+To: globaladmin@testdomain.com
 Sent: Friday, September 26, 2003 7:37 PM
 Subject: Mapping XML type QName to Java Class name?
 

--- a/data/public/mime/email03/26
+++ b/data/public/mime/email03/26
@@ -10,16 +10,16 @@ Received: (qmail 89431 invoked by uid 500); 11 Nov 2003 21:03:21 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 89414 invoked from network); 11 Nov 2003 21:03:21 -0000
 Message-ID: <016901c3a897$3a4d2c10$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <9A06B7E0-1483-11D8-B5EC-000393D5A006@vrtx.com>
 Subject: Re: Need some help with validation error...
 Date: Tue, 11 Nov 2003 16:03:15 -0500
@@ -47,7 +47,7 @@ the command-line validator?  Are the schemas compiled or loaded dynamically?
 David
 ----- Original Message ----- 
 From: Tom Condon
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Sent: Tuesday, November 11, 2003 3:14 PM
 Subject: [xmlbeans-user] Need some help with validation error...
 

--- a/data/public/mime/email03/27
+++ b/data/public/mime/email03/27
@@ -9,12 +9,12 @@ Received: (qmail 98761 invoked by uid 500); 25 Sep 2003 06:26:11 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 98741 invoked from network); 25 Sep 2003 06:26:11 -0000
 Message-ID: <3F728A8D.1090006@sauria.com>
 Date: Wed, 24 Sep 2003 23:26:21 -0700
@@ -25,7 +25,7 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.5)
 	Gecko/20030923 Thunderbird/0.3
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: STAX
 References: <4C2F1577F2EF2840A9AE9EC61860C8810A0FED@usseex01.amer.bea.com>
 	 <001301c38318$1c525f40$6401a8c0@third>

--- a/data/public/mime/email03/28
+++ b/data/public/mime/email03/28
@@ -10,16 +10,16 @@ Received: (qmail 90561 invoked by uid 500); 19 Nov 2003 18:33:59 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 90547 invoked from network); 19 Nov 2003 18:33:58 -0000
 Message-ID: <000001c3aecb$aac0ebf0$900210ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <001a01c3adc2$538f8080$1400a8c0@solero>
 Subject: Re: Problem with variable content containers ( lengthy )
 Date: Wed, 19 Nov 2003 07:20:24 -0500

--- a/data/public/mime/email03/29
+++ b/data/public/mime/email03/29
@@ -9,12 +9,12 @@ Received: (qmail 35526 invoked by uid 500); 13 Sep 2003 08:42:18 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 35511 invoked from network); 13 Sep 2003 08:42:17 -0000
 X-Sent: 13 Sep 2003 08:42:30 GMT
 Date: Sat, 13 Sep 2003 09:44:36 +0100
@@ -23,9 +23,9 @@ Subject: Re: Source Code
 Content-Type: text/plain; charset=US-ASCII; format=flowed
 Mime-Version: 1.0 (Apple Message framework v482)
 From: robert burrell donkin <rdonkin@apache.org>
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Content-Transfer-Encoding: 7bit
-In-Reply-To: <1734.68.55.36.165.1063362239.squirrel@www.lig.net>
+In-Reply-To: globaladmin@testdomain.com
 Message-Id: <81795406-E5C6-11D7-AE6D-003065DC754C@apache.org>
 X-Mailer: Apple Mail (2.482)
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/30
+++ b/data/public/mime/email03/30
@@ -9,19 +9,19 @@ Received: (qmail 37054 invoked by uid 500); 1 Oct 2003 15:49:36 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 37041 invoked from network); 1 Oct 2003 15:49:35 -0000
 Message-Id: <sf7abf52.056@corp-gw.mantech.com>
 X-Mailer: Novell GroupWise Internet Agent 5.5.6.1
 Date: Wed, 01 Oct 2003 11:49:22 -0400
 X-Zimbra-Received: Wed, 01 Oct 2003 11:49:22 -0400
 From: "Darrell Teague" <darrell.teague@mantech.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Re: Finalizers
 Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="=_58061082.4120A8F1"

--- a/data/public/mime/email03/31
+++ b/data/public/mime/email03/31
@@ -9,12 +9,12 @@ Received: (qmail 72717 invoked by uid 500); 8 Oct 2003 17:33:40 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 72704 invoked from network); 8 Oct 2003 17:33:40 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -30,7 +30,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: XMLBeans Speed
 Thread-Index: AcONv8On9aL251+hRkyEB8a62FPy0wAAiVZA
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 08 Oct 2003 17:33:44.0333 (UTC)
 	FILETIME=[5278DBD0:01C38DC2]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -53,7 +53,7 @@ ng the timing?
 -----Original Message-----
 From: Aaron Mulder [mailto:ammulder@alumni.princeton.edu]
 Sent: Wednesday, October 08, 2003 10:18 AM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: XMLBeans Speed
 
 

--- a/data/public/mime/email03/32
+++ b/data/public/mime/email03/32
@@ -10,19 +10,19 @@ Received: (qmail 45691 invoked by uid 500); 18 Sep 2005 19:42:19 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 45677 invoked from network); 18 Sep 2005 19:42:19 -0000
 X-Authentication-Warning: slapshot.stanford.edu: smith set sender to
 	smith@stanford.edu using -f
 Subject: Re: Future XMLBeans feature work?
 From: Roland Smith <smith@stanford.edu>
-To: "xmlbeans-dev@xml.apache.org" <xmlbeans-dev@xml.apache.org>
-In-Reply-To: <012801c37e19$9ef367e0$d41e11ac@lightbox>
+To: "globaladmin@testdomain.com" <globaladmin@testdomain.com>
+In-Reply-To: globaladmin@testdomain.com
 References: <012801c37e19$9ef367e0$d41e11ac@lightbox>
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email03/33
+++ b/data/public/mime/email03/33
@@ -10,12 +10,12 @@ Received: (qmail 94206 invoked by uid 500); 29 Sep 2003 18:31:56 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 94192 invoked from network); 29 Sep 2003 18:31:56 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -30,7 +30,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: V2 Store discussion...
 Thread-Index: AcOGt1JGnC/fKvzFRl+BqbhJLU6XpAAAB1qQ
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-dev@xml.apache.org>, <christopher.fry@bea.com>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 29 Sep 2003 18:31:25.0317 (UTC)
 	FILETIME=[E3A95B50:01C386B7]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -49,8 +49,7 @@ eaking.
 -----Original Message-----
 From: Patrick Calahan [mailto:pcal@bea.com]
 Sent: Monday, September 29, 2003 11:24 AM
-To: xmlbeans-dev@xml.apache.org; christopher.fry@bea.com; xmlbeans-dev@xml.=
-apache.org
+To: globaladmin@testdomain.com
 Subject: RE: V2 Store discussion...
 
 
@@ -89,7 +88,7 @@ Any thoughts?  Any confusion about this trade off? =20
 -----Original Message-----
 From: Chris Fry [mailto:christopher.fry@bea.com]
 Sent: Monday, September 29, 2003 9:55 AM
-To: xmlbeans-dev@xml.apache.org; Eric Vasilik
+To: globaladmin@testdomain.com
 Subject: RE: V2 Store discussion...
 
 
@@ -106,8 +105,7 @@ in WS-invocations...
 > -----Original Message-----
 > From: David Bau [mailto:david.bau@bea.com]
 > Sent: Monday, September 29, 2003 8:27 AM
-> To: Eric Vasilik
-> Cc: xmlbeans-dev@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: V2 Store discussion...
 >
 >

--- a/data/public/mime/email03/34
+++ b/data/public/mime/email03/34
@@ -9,12 +9,12 @@ Received: (qmail 33180 invoked by uid 500); 10 Oct 2003 02:50:26 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 33167 invoked from network); 10 Oct 2003 02:50:26 -0000
 X-Authentication-Warning: www.princetongames.org: ammulder owned process
 	doing -bs
@@ -22,7 +22,7 @@ Date: Thu, 9 Oct 2003 22:53:17 -0400 (EDT)
 X-Zimbra-Received: Thu, 9 Oct 2003 22:53:17 -0400 (EDT)
 From: Aaron Mulder <ammulder@alumni.princeton.edu>
 X-X-Sender: ammulder@www.princetongames.org
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Parallel Extension Question
 Message-ID: <Pine.LNX.4.44.0310092239240.24519-100000@www.princetongames.org>
 MIME-Version: 1.0

--- a/data/public/mime/email03/35
+++ b/data/public/mime/email03/35
@@ -9,16 +9,16 @@ Received: (qmail 27459 invoked by uid 500); 2 Oct 2003 19:14:19 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 27418 invoked from network); 2 Oct 2003 19:14:18 -0000
 Subject: builtin type conversions
 From: Scott Ziegler <zieg@bea.com>
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 Message-Id: <1065122063.14001.18.camel@zieg>

--- a/data/public/mime/email03/36
+++ b/data/public/mime/email03/36
@@ -10,22 +10,22 @@ Received: (qmail 24357 invoked by uid 500); 29 Sep 2003 18:51:28 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 24317 invoked from network); 29 Sep 2003 18:51:28 -0000
 Message-Id: <5.2.1.1.0.20030929114718.020b2e98@san-francisco.beasys.com>
 X-Sender: pcal@san-francisco.beasys.com (Unverified)
 X-Mailer: QUALCOMM Windows Eudora Version 5.2.1
 Date: Mon, 29 Sep 2003 11:47:56 -0700
 X-Zimbra-Received: Mon, 29 Sep 2003 11:47:56 -0700
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 From: Patrick Calahan <pcal@bea.com>
 Subject: RE: V2 Store discussion...
-In-Reply-To: <4B2B4C417991364996F035E1EE39E2E11E9D74@uskiex01.amer.bea.c om>
+In-Reply-To: globaladmin@testdomain.com
 Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="=====================_3384796==.ALT"
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -53,8 +53,8 @@ I see.  Right, good point.
 >-----Original Message-----
 >From: Patrick Calahan [mailto:pcal@bea.com]
 >Sent: Monday, September 29, 2003 11:24 AM
->To: xmlbeans-dev@xml.apache.org; christopher.fry@bea.com; 
->xmlbeans-dev@xml.apache.org
+>To: globaladmin@testdomain.com; christopher.fry@bea.com; 
+>globaladmin@testdomain.com
 >Subject: RE: V2 Store discussion...
 >
 >
@@ -94,7 +94,7 @@ I see.  Right, good point.
 >-----Original Message-----
 >From: Chris Fry [mailto:christopher.fry@bea.com]
 >Sent: Monday, September 29, 2003 9:55 AM
->To: xmlbeans-dev@xml.apache.org; Eric Vasilik
+>To: globaladmin@testdomain.com; Eric Vasilik
 >Subject: RE: V2 Store discussion...
 >
 >
@@ -111,8 +111,7 @@ I see.  Right, good point.
 > > -----Original Message-----
 > > From: David Bau [mailto:david.bau@bea.com]
 > > Sent: Monday, September 29, 2003 8:27 AM
-> > To: Eric Vasilik
-> > Cc: xmlbeans-dev@xml.apache.org
+> > To: globaladmin@testdomain.com
 > > Subject: V2 Store discussion...
 > >
 > >
@@ -174,8 +173,8 @@ I see.&nbsp; Right, good point.<br>
 From: Patrick Calahan
 [<a href="mailto:pcal@bea.com" eudora="autourl">mailto:pcal@bea.com</a>]<br>
 Sent: Monday, September 29, 2003 11:24 AM<br>
-To: xmlbeans-dev@xml.apache.org; christopher.fry@bea.com;
-xmlbeans-dev@xml.apache.org<br>
+To: globaladmin@testdomain.com; christopher.fry@bea.com;
+globaladmin@testdomain.com<br>
 Subject: RE: V2 Store discussion...<br><br>
 <br>
 At 10:25 AM 9/29/2003 -0700, Eric Vasilik wrote:<br><br>
@@ -205,7 +204,7 @@ Any thoughts?&nbsp; Any confusion about this trade off?&nbsp; <br><br>
 From: Chris Fry
 [<a href="mailto:christopher.fry@bea.com" eudora="autourl">mailto:christopher.fry@bea.com</a>]<br>
 Sent: Monday, September 29, 2003 9:55 AM<br>
-To: xmlbeans-dev@xml.apache.org; Eric Vasilik<br>
+To: globaladmin@testdomain.com; Eric Vasilik<br>
 Subject: RE: V2 Store discussion...<br><br>
 <br>
 I think you should be careful not to make the same mistakes that the
@@ -226,8 +225,7 @@ in WS-invocations...<br><br>
 &gt; From: David Bau
 [<a href="mailto:david.bau@bea.com" eudora="autourl">mailto:david.bau@bea.com</a>]<br>
 &gt; Sent: Monday, September 29, 2003 8:27 AM<br>
-&gt; To: Eric Vasilik<br>
-&gt; Cc: xmlbeans-dev@xml.apache.org<br>
+&gt; To: globaladmin@testdomain.com<br>
 &gt; Subject: V2 Store discussion...<br>
 &gt;<br>
 &gt;<br>

--- a/data/public/mime/email03/37
+++ b/data/public/mime/email03/37
@@ -9,12 +9,12 @@ Received: (qmail 11830 invoked by uid 500); 17 Sep 2003 03:45:20 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 11816 invoked from network); 17 Sep 2003 03:45:20 -0000
 content-class: urn:content-classes:message
 MIME-Version: 1.0
@@ -29,7 +29,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: XmlBeans project logo
 Thread-Index: AcN8ziNAOMENN61ZSDWJpu3ojV7R0w==
 From: "David Remy" <dremy@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 17 Sep 2003 03:45:30.0638 (UTC)
 	FILETIME=[240C02E0:01C37CCE]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/38
+++ b/data/public/mime/email03/38
@@ -9,12 +9,12 @@ Received: (qmail 43300 invoked by uid 500); 21 Oct 2003 16:06:45 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 43173 invoked from network); 21 Oct 2003 16:06:44 -0000
 X-MIMEOLE: Produced By Microsoft Exchange V6.0.6487.1
 content-class: urn:content-classes:message
@@ -30,7 +30,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Feature Request: Serialization
 Thread-Index: AcOX57d/YJEy0WgrQDO8kSPXRyy+ewABM2xg
 From: "Jochen Rebhan" <jochen.rebhan@primaverasoft.pt>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/
 X-Evolution: 00000026-0010
@@ -60,7 +60,7 @@ j.rebhan@web.de
  -----Original Message-----
 From: 	David Bau [mailto:david.bau@bea.com]=20
 Sent:	ter=E7a-feira, 21 de Outubro de 2003 16:26
-To:	xmlbeans-dev@xml.apache.org
+To:	globaladmin@testdomain.com
 Subject:	Re: Feature Request: Serialization
 
 Hi Jochen -
@@ -79,7 +79,7 @@ David
 
 ----- Original Message -----=20
 From: "Jochen Rebhan" <jochen.rebhan@primaverasoft.pt>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Tuesday, October 21, 2003 10:04 AM
 Subject: [xmlbeans-dev] Feature Request: Serialization
 

--- a/data/public/mime/email03/39
+++ b/data/public/mime/email03/39
@@ -9,17 +9,16 @@ Received: (qmail 11182 invoked by uid 500); 3 Oct 2003 20:53:05 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 11168 invoked from network); 3 Oct 2003 20:53:05 -0000
 Message-ID: <019401c389f0$58380ad0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: "Lawrence Jones" <ljones@bea.com>, "David Bau" <davidbau@bea.com>
-Cc: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <4B2B4C417991364996F035E1EE39E2E11DF1EF@uskiex01.amer.bea.com>
 Subject: Re: Replacement for SniffedXmlInputStream.java
 Date: Fri, 3 Oct 2003 16:53:03 -0400
@@ -53,7 +52,7 @@ David
 
 ----- Original Message ----- 
 From: Lawrence Jones
-To: David Bau
+To: globaladmin@testdomain.com
 Sent: Friday, October 03, 2003 3:21 PM
 Subject: [xmlbeans-cvs] Replacement for SniffedXmlInputStream.java
 

--- a/data/public/mime/email03/4
+++ b/data/public/mime/email03/4
@@ -32,8 +32,7 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.4)
 	Gecko/20030624 Netscape/7.1 (ax)
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: Simon Josefsson <jas@extundo.com>
-CC: "Kurt D. Zeilenga" <Kurt@OpenLDAP.org>, SASL WG <ietf-sasl@imc.org>
+To: globaladmin@testdomain.com
 Subject: Re: SASLprep in rfc2222bis-06
 References: <200402162041.PAA20167@ietf.org>
 	 <6.0.1.1.0.20040216200054.04c9df08@127.0.0.1>	<4031F175.1070301@isode.com>
@@ -42,7 +41,7 @@ References: <200402162041.PAA20167@ietf.org>
 	 <ilullmr84gw.fsf@latte.josefsson.org>
 	 <6.0.1.1.0.20040225140352.04ba6fb8@127.0.0.1>
 	 <iluk72a20fy.fsf@latte.josefsson.org>
-In-Reply-To: <iluk72a20fy.fsf@latte.josefsson.org>
+In-Reply-To: globaladmin@testdomain.com
 Content-Type: text/plain; charset=us-ascii; format=flowed
 Content-Transfer-Encoding: 7bit
 Sender: owner-ietf-sasl@mail.imc.org

--- a/data/public/mime/email03/40
+++ b/data/public/mime/email03/40
@@ -9,17 +9,17 @@ Received: (qmail 53192 invoked by uid 500); 10 Oct 2003 01:21:23 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 53176 invoked from network); 10 Oct 2003 01:21:23 -0000
 Subject: Re: bts notes
 From: Scott Ziegler <zieg@bea.com>
-To: xmlbeans-dev@xml.apache.org
-In-Reply-To: <030c01c38eae$78d032f0$0fa8a8c0@lightbox>
+To: globaladmin@testdomain.com
+In-Reply-To: globaladmin@testdomain.com
 References: <5.2.1.1.0.20031009120354.03384fe8@san-francisco.beasys.com>
 	 <030c01c38eae$78d032f0$0fa8a8c0@lightbox>
 Content-Transfer-Encoding: 7bit
@@ -66,7 +66,7 @@ On Thu, 2003-10-09 at 14:44, David Bau wrote:
 > David
 > ----- Original Message ----- 
 > From: "Patrick Calahan" <pcal@bea.com>
-> To: "David Bau" <david.bau@bea.com>
+> To: globaladmin@testdomain.com
 > Sent: Thursday, October 09, 2003 3:06 PM
 > Subject: bts notes
 > 

--- a/data/public/mime/email03/41
+++ b/data/public/mime/email03/41
@@ -9,16 +9,16 @@ Received: (qmail 90750 invoked by uid 500); 19 Nov 2003 18:34:03 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 90736 invoked from network); 19 Nov 2003 18:34:03 -0000
 Message-ID: <000101c3aecb$ad507070$900210ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <5.2.1.1.0.20031112103429.01de1458@san-francisco.beasys.com>
 	 <5.2.1.1.0.20031114151841.01a6aea0@san-francisco.beasys.com>
 	 <789A0871-1A16-11D8-BC85-003065DC754C@apache.org>

--- a/data/public/mime/email03/42
+++ b/data/public/mime/email03/42
@@ -10,16 +10,16 @@ Received: (qmail 87294 invoked by uid 500); 25 Sep 2003 03:55:13 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 87279 invoked from network); 25 Sep 2003 03:55:13 -0000
 Message-ID: <001301c38318$1c525f40$6401a8c0@third>
 From: "Chris Fry" <christopher.fry@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <4C2F1577F2EF2840A9AE9EC61860C8810A0FED@usseex01.amer.bea.com>
 Subject: Re: STAX
 Date: Wed, 24 Sep 2003 20:50:06 -0700
@@ -47,7 +47,7 @@ FYI the jar is publicly available at http://jcp.org/en/jsr/detail?id=173
 -Chris
 ----- Original Message -----
 From: "Cliff Schmidt" <cliff@bea.com>
-To: <xmlbeans-dev@xml.apache.org>; <christopher.fry@bea.com>
+To: globaladmin@testdomain.com
 Sent: Wednesday, September 24, 2003 6:43 PM
 Subject: RE: STAX
 

--- a/data/public/mime/email03/43
+++ b/data/public/mime/email03/43
@@ -10,12 +10,12 @@ Received: (qmail 48245 invoked by uid 500); 10 Oct 2003 20:01:36 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 48232 invoked from network); 10 Oct 2003 20:01:36 -0000
 content-class: urn:content-classes:message
 Subject: RE: noNamespace package alternatives
@@ -31,7 +31,7 @@ X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 Thread-Topic: noNamespace package alternatives
 Thread-Index: AcOPaRo65/vubJPgTL20VBqtEGJ00gAAAmlg
 From: "Breese, Dustin" <dustin.breese@qwest.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/
 X-Evolution: 0000002b-0010
@@ -46,7 +46,7 @@ Dustin
 -----Original Message-----
 From: Eric Vasilik [mailto:ericvas@bea.com]=20
 Sent: Friday, October 10, 2003 1:53 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: noNamespace package alternatives
 
 The -repackage option exists for the purposes of building the XmlBeans
@@ -60,7 +60,7 @@ Are you trying to change the packages that a schema compiles to?
 -----Original Message-----
 From: Breese, Dustin [mailto:dustin.breese@qwest.com]
 Sent: Friday, October 10, 2003 12:42 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: noNamespace package alternatives
 
 

--- a/data/public/mime/email03/44
+++ b/data/public/mime/email03/44
@@ -10,16 +10,16 @@ Received: (qmail 87790 invoked by uid 500); 14 Nov 2003 21:32:24 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 87777 invoked from network); 14 Nov 2003 21:32:24 -0000
 Message-ID: <043701c3aaf6$c1dd2c00$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: XMLBeans V1 binding style arch writeup
 Date: Fri, 14 Nov 2003 16:32:04 -0500
 X-Zimbra-Received: Fri, 14 Nov 2003 16:32:04 -0500

--- a/data/public/mime/email03/45
+++ b/data/public/mime/email03/45
@@ -10,17 +10,16 @@ Received: (qmail 54857 invoked by uid 500); 19 Sep 2005 00:10:49 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 54839 invoked from network); 19 Sep 2005 00:10:49 -0000
 Message-ID: <017601c37e42$7a7b2d20$d41e11ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
-Cc: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <012801c37e19$9ef367e0$d41e11ac@lightbox>
 	 <1063914139.11628.10.camel@slapshot.stanford.edu>
 Subject: Re: Future XMLBeans feature work?

--- a/data/public/mime/email03/46
+++ b/data/public/mime/email03/46
@@ -9,12 +9,12 @@ Received: (qmail 1021 invoked by uid 500); 8 Oct 2003 02:44:24 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 994 invoked from network); 8 Oct 2003 02:44:23 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -30,7 +30,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: cursor question...
 Thread-Index: AcONG1AoaIi7Lz49SLKfDjopwt2HOQAKhu6g
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 08 Oct 2003 02:44:32.0792 (UTC)
 	FILETIME=[1A79C180:01C38D46]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -50,7 +50,7 @@ e.
 -----Original Message-----
 From: Roland Smith [mailto:smith@stanford.edu]
 Sent: Tuesday, October 07, 2003 2:38 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: cursor question...
 
 

--- a/data/public/mime/email03/47
+++ b/data/public/mime/email03/47
@@ -9,12 +9,12 @@ Received: (qmail 3961 invoked by uid 500); 22 Sep 2003 19:20:26 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 3948 invoked from network); 22 Sep 2003 19:20:26 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -29,7 +29,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Getting the distribution onto a download site somewhere ...
 Thread-Index: AcOBOZtZYghAyv6JQuujIMz5/B0znwAAHXow
 From: "David Remy" <dremy@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 22 Sep 2003 19:20:31.0071 (UTC)
 	FILETIME=[96937EF0:01C3813E]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -77,7 +77,7 @@ rem
 > -----Original Message-----
 > From: Ted Leung [mailto:twleung@sauria.com]=20
 > Sent: Monday, September 22, 2003 11:44 AM
-> To: xmlbeans-dev@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: Re: Getting the distribution onto a download site=20
 > somewhere ...
 >=20

--- a/data/public/mime/email03/48
+++ b/data/public/mime/email03/48
@@ -9,16 +9,16 @@ Received: (qmail 26518 invoked by uid 500); 23 Oct 2003 00:53:37 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 26505 invoked from network); 23 Oct 2003 00:53:37 -0000
 Sensitivity: 
 Subject: RE: deep equals implementation?
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 X-Mailer: Lotus Notes Release 5.0.8  June 18, 2001
 Message-ID: <OF1B4C50E4.B7785DBF-ONCA256DC8.0004D9E2@tmca.com.au>
 From: Dmitri.Colebatch@toyota.com.au
@@ -45,10 +45,9 @@ dim
 
 "Eric Vasilik" <ericvas@bea.com> on 23/10/2003 10:33:49 AM
 
-Please respond to xmlbeans-user@xml.apache.org
+Please respond to globaladmin@testdomain.com
 
-To:    <xmlbeans-user@xml.apache.org>
-cc:
+To:    <globaladmin@testdomain.com>
 Subject:    RE: deep equals implementation?
 
 Substituting namespaces is not appropriate in this case.  What it seems you
@@ -79,7 +78,7 @@ the right direction.
 From: Dmitri.Colebatch@toyota.com.au
 [mailto:Dmitri.Colebatch@toyota.com.au]
 Sent: Wednesday, October 22, 2003 5:08 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: deep equals implementation?
 
 
@@ -98,10 +97,9 @@ dim
 
 Robert Wyrick <rob@wyrick.org> on 23/10/2003 09:43:36 AM
 
-Please respond to xmlbeans-user@xml.apache.org
+Please respond to globaladmin@testdomain.com
 
-To:    xmlbeans-user@xml.apache.org
-cc:
+To:    globaladmin@testdomain.com
 Subject:    Re: deep equals implementation?
 
 With careful use of :

--- a/data/public/mime/email03/49
+++ b/data/public/mime/email03/49
@@ -8,16 +8,16 @@ Received: from mail.apache.org (daedalus.apache.org [208.185.179.12]) by
 Received: (qmail 11945 invoked by uid 500); 4 Dec 2003 23:42:20 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 11932 invoked from network); 4 Dec 2003 23:42:19 -0000
 Message-ID: <017001c3bac0$34cf16a0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <FAF98113-25D3-11D8-BCCC-000393D5A006@vrtx.com>
 	 <015a01c3baad$e640c9a0$0fa8a8c0@lightbox>
 	 <F349361B-26AD-11D8-A026-000393D5A006@vrtx.com>
@@ -46,7 +46,7 @@ the tags removed (and &lt; entities etc resolved).
 David
 ----- Original Message ----- 
 From: "Thomas Condon" <tom_condon@vrtx.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Thursday, December 04, 2003 6:02 PM
 Subject: [xmlbeans-user] Re: XMLBeans or perhaps just an XML question...
 

--- a/data/public/mime/email03/50
+++ b/data/public/mime/email03/50
@@ -10,16 +10,16 @@ Received: (qmail 94354 invoked by uid 500); 10 Oct 2003 15:45:12 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 94326 invoked from network); 10 Oct 2003 15:45:11 -0000
 Message-ID: <035601c38f45$75309760$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <5.2.1.1.0.20031009120354.03384fe8@san-francisco.beasys.com>
 	 <030c01c38eae$78d032f0$0fa8a8c0@lightbox> <1065748890.15848.28.camel@zieg>
 Subject: Re: bts notes
@@ -40,7 +40,7 @@ Thanks again, notes below for both emails.
 
 ----- Original Message ----- 
 From: "Scott Ziegler" <zieg@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Thursday, October 09, 2003 9:21 PM
 Subject: [xmlbeans-dev] Re: bts notes
 
@@ -88,7 +88,7 @@ Will add factory methods that opeate on files/streams.
 > > David
 > > ----- Original Message ----- 
 > > From: "Patrick Calahan" <pcal@bea.com>
-> > To: "David Bau" <david.bau@bea.com>
+> > To: globaladmin@testdomain.com
 > > Sent: Thursday, October 09, 2003 3:06 PM
 > > Subject: bts notes
 > >

--- a/data/public/mime/email03/51
+++ b/data/public/mime/email03/51
@@ -10,16 +10,16 @@ Received: (qmail 12539 invoked by uid 500); 21 Oct 2003 16:35:22 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 12515 invoked from network); 21 Oct 2003 16:35:22 -0000
 Message-ID: <014401c397f1$4e992e00$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References:
 	 <1924BF350FC96B46A56BB38087B9B86E6A6461@srvcorreio.primavera.local>
 Subject: RE: Feature Request: Serialization
@@ -47,7 +47,7 @@ David
 
 ----- Original Message ----- 
 From: "Jochen Rebhan" <jochen.rebhan@primaverasoft.pt>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Tuesday, October 21, 2003 12:06 PM
 Subject: [xmlbeans-dev] RE: Feature Request: Serialization
 
@@ -77,7 +77,7 @@ j.rebhan@web.de
  -----Original Message-----
 From: David Bau [mailto:david.bau@bea.com]
 Sent: ter?a-feira, 21 de Outubro de 2003 16:26
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Feature Request: Serialization
 
 Hi Jochen -
@@ -95,7 +95,7 @@ David
 
 ----- Original Message ----- 
 From: "Jochen Rebhan" <jochen.rebhan@primaverasoft.pt>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Tuesday, October 21, 2003 10:04 AM
 Subject: [xmlbeans-dev] Feature Request: Serialization
 

--- a/data/public/mime/email03/52
+++ b/data/public/mime/email03/52
@@ -9,16 +9,16 @@ Received: (qmail 66771 invoked by uid 500); 3 Oct 2003 21:22:34 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 66758 invoked from network); 3 Oct 2003 21:22:33 -0000
 Message-ID: <01c701c389f4$769779d0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Adding Patrick Calahan as a committer
 Date: Fri, 3 Oct 2003 17:22:33 -0400
 X-Zimbra-Received: Fri, 3 Oct 2003 17:22:33 -0400

--- a/data/public/mime/email03/53
+++ b/data/public/mime/email03/53
@@ -10,16 +10,16 @@ Received: (qmail 1878 invoked by uid 500); 18 Sep 2005 19:18:24 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 1864 invoked from network); 18 Sep 2005 19:18:24 -0000
 Message-ID: <012801c37e19$9ef367e0$d41e11ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Future XMLBeans feature work?
 Date: Thu, 18 Sep 2005 15:18:19 -0400
 X-Zimbra-Received: Thu, 18 Sep 2005 15:18:19 -0400

--- a/data/public/mime/email03/54
+++ b/data/public/mime/email03/54
@@ -9,19 +9,19 @@ Received: (qmail 87775 invoked by uid 500); 15 Sep 2003 23:45:13 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 87762 invoked from network); 15 Sep 2003 23:45:13 -0000
 X-Authentication-Warning: slapshot.stanford.edu: smith set sender to
 	smith@stanford.edu using -f
 Subject: Re: XmlBeans source code has been checked in ...
 From: Roland Smith <smith@stanford.edu>
-To: xmlbeans-dev@xml.apache.org
-In-Reply-To: <4B2B4C417991364996F035E1EE39E2E10D8E06@uskiex01.amer.bea.com>
+To: globaladmin@testdomain.com
+In-Reply-To: globaladmin@testdomain.com
 References: <4B2B4C417991364996F035E1EE39E2E10D8E06@uskiex01.amer.bea.com>
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email03/55
+++ b/data/public/mime/email03/55
@@ -10,12 +10,12 @@ Received: (qmail 12818 invoked by uid 500); 23 Oct 2003 00:33:43 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 12805 invoked from network); 23 Oct 2003 00:33:43 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -30,7 +30,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: deep equals implementation?
 Thread-Index: AcOY+g1p3kAYoER0Rjup9R242UzWPAAAd5rg
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 23 Oct 2003 00:33:51.0353 (UTC)
 	FILETIME=[54CF5E90:01C398FD]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -66,7 +66,7 @@ There are probably other techniques you can use, but this should put you in=
 From: Dmitri.Colebatch@toyota.com.au
 [mailto:Dmitri.Colebatch@toyota.com.au]
 Sent: Wednesday, October 22, 2003 5:08 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: deep equals implementation?
 
 
@@ -85,10 +85,9 @@ dim
 
 Robert Wyrick <rob@wyrick.org> on 23/10/2003 09:43:36 AM
 
-Please respond to xmlbeans-user@xml.apache.org
+Please respond to globaladmin@testdomain.com
 
-To:    xmlbeans-user@xml.apache.org
-cc:
+To:    globaladmin@testdomain.com
 Subject:    Re: deep equals implementation?
 
 With careful use of :

--- a/data/public/mime/email03/56
+++ b/data/public/mime/email03/56
@@ -9,16 +9,16 @@ Received: (qmail 8348 invoked by uid 500); 13 Sep 2003 11:21:32 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 8334 invoked from network); 13 Sep 2003 11:21:32 -0000
 Message-ID: <022901c379e9$2d9387d0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Setting up bugzilla, list archiving, etc
 Date: Sat, 13 Sep 2003 07:21:27 -0400
 X-Zimbra-Received: Sat, 13 Sep 2003 07:21:27 -0400
@@ -38,7 +38,7 @@ and we're basically ready to check it into apache CVS now; we're just
 waiting on infrastructure to set up accounts and cvs access for us.  We're
 also going to start using this mailing list for development work, which
 means we need to make sure user discussions happen on
-xmlbeans-user@xml.apache.org.
+globaladmin@testdomain.com.
 
 Forgive me for a bit, for a little while things on xmlbeans-dev are going to
 have to be boring setup issues.  We need a functional development space

--- a/data/public/mime/email03/57
+++ b/data/public/mime/email03/57
@@ -10,12 +10,12 @@ Received: (qmail 78432 invoked by uid 500); 10 Oct 2003 20:28:03 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 78418 invoked from network); 10 Oct 2003 20:28:03 -0000
 content-class: urn:content-classes:message
 Subject: RE: noNamespace package alternatives
@@ -30,7 +30,7 @@ X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 Thread-Topic: noNamespace package alternatives
 Thread-Index: AcOPajzyGSpCQez+RzSj0VMfdK68PgAAk0Cw
 From: "Breese, Dustin" <dustin.breese@qwest.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 Content-Type: text/plain; CHARSET=us-ascii
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/
@@ -57,7 +57,7 @@ Dustin
 -----Original Message-----
 From: Eric Vasilik [mailto:ericvas@bea.com]=20
 Sent: Friday, October 10, 2003 2:08 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: noNamespace package alternatives
 
 You want to use a .xsdconfig file:
@@ -68,7 +68,7 @@ che.org&msgId=3D1035917
 -----Original Message-----
 From: Breese, Dustin [mailto:dustin.breese@qwest.com]
 Sent: Friday, October 10, 2003 1:01 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: noNamespace package alternatives
 
 
@@ -82,7 +82,7 @@ Dustin
 -----Original Message-----
 From: Eric Vasilik [mailto:ericvas@bea.com]=20
 Sent: Friday, October 10, 2003 1:53 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: noNamespace package alternatives
 
 The -repackage option exists for the purposes of building the XmlBeans
@@ -96,7 +96,7 @@ Are you trying to change the packages that a schema compiles to?
 -----Original Message-----
 From: Breese, Dustin [mailto:dustin.breese@qwest.com]
 Sent: Friday, October 10, 2003 12:42 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: noNamespace package alternatives
 
 

--- a/data/public/mime/email03/58
+++ b/data/public/mime/email03/58
@@ -9,12 +9,12 @@ Received: (qmail 96594 invoked by uid 500); 1 Oct 2003 17:14:28 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 96581 invoked from network); 1 Oct 2003 17:14:27 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -29,7 +29,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Finalizers
 Thread-Index: AcOIM6KhGv/ZLmAyR8eg1QrVBIbC4gACNCSw
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 01 Oct 2003 17:14:27.0714 (UTC)
 	FILETIME=[782E8E20:01C3883F]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -79,7 +79,7 @@ ar object no longer needed finalization.  Does such a thing exist?
 -----Original Message-----
 From: Darrell Teague [mailto:darrell.teague@mantech.com]
 Sent: Wednesday, October 01, 2003 8:49 AM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Finalizers
 
 

--- a/data/public/mime/email03/59
+++ b/data/public/mime/email03/59
@@ -10,12 +10,12 @@ Received: (qmail 41121 invoked by uid 500); 10 Oct 2003 18:28:46 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 37600 invoked from network); 10 Oct 2003 18:27:59 -0000
 Date: Fri, 10 Oct 2003 14:24:22 -0400
 X-Zimbra-Received: Fri, 10 Oct 2003 14:24:22 -0400
@@ -23,7 +23,7 @@ Mime-Version: 1.0 (Apple Message framework v552)
 Content-Type: text/plain; delsp=yes; charset=US-ASCII; format=flowed
 Subject: XMLBeans/Java Web Start Issues
 From: Tom Condon <tom_condon@vrtx.com>
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Content-Transfer-Encoding: 7bit
 Message-Id: <F876C2FA-FB4E-11D7-8890-000393D5A006@vrtx.com>
 X-Mailer: Apple Mail (2.552)

--- a/data/public/mime/email03/6
+++ b/data/public/mime/email03/6
@@ -1,11 +1,10 @@
 Date: Fri, 27 Feb 2004 15:24:43 -0800 (PST)
 X-Zimbra-Received: Fri, 27 Feb 2004 15:24:43 -0800 (PST)
 From: "Smith, Roland Q" <roland.smith@stanford.edu>
-To: Samuel Darmo <samuel@darmo.com>
+To: globaladmin@testdomain.com
 Subject: Here it is - (650) 780-4567
 Content-Type: TEXT/PLAIN; charset=US-ASCII
 X-Zimbra-Object: phone
-cc: davidson@yahoo.com
 X-Evolution: 00000006-0000
 Message-Id: <1084918355.24984.0.camel@slapshot.example.zimbra.com>
 Mime-Version: 1.0

--- a/data/public/mime/email03/60
+++ b/data/public/mime/email03/60
@@ -8,15 +8,15 @@ Received: from mail.apache.org (daedalus.apache.org [208.185.179.12]) by
 Received: (qmail 42334 invoked by uid 500); 4 Dec 2003 23:02:34 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 42321 invoked from network); 4 Dec 2003 23:02:34 -0000
 Mime-Version: 1.0 (Apple Message framework v606)
-In-Reply-To: <015a01c3baad$e640c9a0$0fa8a8c0@lightbox>
+In-Reply-To: globaladmin@testdomain.com
 References: <FAF98113-25D3-11D8-BCCC-000393D5A006@vrtx.com>
 	 <015a01c3baad$e640c9a0$0fa8a8c0@lightbox>
 Content-Type: multipart/alternative; boundary=Apple-Mail-1--70040791
@@ -25,7 +25,7 @@ From: Thomas Condon <tom_condon@vrtx.com>
 Subject: Re: XMLBeans or perhaps just an XML question...
 Date: Thu, 4 Dec 2004 18:02:36 -0500
 X-Zimbra-Received: Thu, 4 Dec 2004 18:02:36 -0500
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 X-Mailer: Apple Mail (2.606)
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/
@@ -79,7 +79,7 @@ On Dec 4, 2003, at 4:30 PM, David Bau wrote:
 > David
 > ----- Original Message -----
 > From: "Thomas Condon" <tom_condon@vrtx.com>
-> To: <xmlbeans-user@xml.apache.org>
+> To: globaladmin@testdomain.com
 > Sent: Wednesday, December 03, 2003 4:02 PM
 > Subject: [xmlbeans-user] XMLBeans or perhaps just an XML question...
 >
@@ -199,7 +199,7 @@ David
 
 From: "Thomas Condon" <<tom_condon@vrtx.com>
 
-To: <<xmlbeans-user@xml.apache.org>
+To: <<globaladmin@testdomain.com>
 
 Sent: Wednesday, December 03, 2003 4:02 PM
 

--- a/data/public/mime/email03/61
+++ b/data/public/mime/email03/61
@@ -13,9 +13,9 @@ List-Post: <mailto:xmlbeans-cvs@xml.apache.org>
 List-Help: <mailto:xmlbeans-cvs-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-cvs-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-cvs-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-cvs@xml.apache.org
-Delivered-To: moderator for xmlbeans-cvs@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: globaladmin@testdomain.com
+Delivered-To: globaladmin@testdomain.com
 Received: (qmail 28369 invoked from network); 15 Sep 2003 21:07:19 -0000
 content-class: urn:content-classes:message
 Subject: XmlBeans source code has been checked in ...
@@ -30,8 +30,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: XmlBeans source code has been checked in ...
 Thread-Index: AcN7zVqm0/g4nXKTTMKpPiP8n2fcuw==
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
-Cc: <xmlbeans-user@xml.apache.org>, <xmlbeans-cvs@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 15 Sep 2003 21:07:25.0008 (UTC)
 	FILETIME=[5CB05D00:01C37BCD]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/62
+++ b/data/public/mime/email03/62
@@ -10,19 +10,19 @@ Received: (qmail 10368 invoked by uid 500); 10 Oct 2003 13:06:22 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 10307 invoked from network); 10 Oct 2003 13:06:22 -0000
 Message-Id: <sf86768f.045@corp-gw.mantech.com>
 X-Mailer: Novell GroupWise Internet Agent 5.5.6.1
 Date: Fri, 10 Oct 2003 09:06:10 -0400
 X-Zimbra-Received: Fri, 10 Oct 2003 09:06:10 -0400
 From: "Darrell Teague" <darrell.teague@mantech.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Re: Parallel Extension Question
 Mime-Version: 1.0
 Content-Type: text/plain; charset=US-ASCII

--- a/data/public/mime/email03/63
+++ b/data/public/mime/email03/63
@@ -10,16 +10,16 @@ Received: (qmail 80673 invoked by uid 500); 29 Sep 2003 17:24:57 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 80658 invoked from network); 29 Sep 2003 17:24:56 -0000
 Message-ID: <00c201c386ad$8f81d2a0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>, <christopher.fry@bea.com>, "'Eric Vasilik'" <eric.vasilik@bea.com>
+To: globaladmin@testdomain.com
 References: <005201c386aa$5fe5bdc0$2f1e11ac@farralon>
 Subject: Re: [xmlbeans-dev] RE: V2 Store discussion...
 Date: Mon, 29 Sep 2003 13:17:26 -0400

--- a/data/public/mime/email03/64
+++ b/data/public/mime/email03/64
@@ -9,19 +9,19 @@ Received: (qmail 46064 invoked by uid 500); 16 Sep 2003 13:29:01 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 46051 invoked from network); 16 Sep 2003 13:29:00 -0000
 Message-Id: <sf66d7de.097@corp-gw.mantech.com>
 X-Mailer: Novell GroupWise Internet Agent 5.5.6.1
 Date: Tue, 16 Sep 2003 09:28:40 -0400
 X-Zimbra-Received: Tue, 16 Sep 2003 09:28:40 -0400
 From: "Darrell Teague" <darrell.teague@mantech.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Re: XmlBeans source code has been checked in ...
 Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="=_2E707B0E.8AEB5BE4"

--- a/data/public/mime/email03/65
+++ b/data/public/mime/email03/65
@@ -10,16 +10,16 @@ Received: (qmail 24555 invoked by uid 500); 20 Oct 2003 18:52:38 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 24541 invoked from network); 20 Oct 2003 18:52:38 -0000
 Message-ID: <007e01c3973b$52489920$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <1A17D44A-032B-11D8-A2FC-000393D5A006@vrtx.com>
 Subject: Re: Strange problem.....
 Date: Mon, 20 Oct 2003 14:52:31 -0400
@@ -49,7 +49,7 @@ David
 
 ----- Original Message ----- 
 From: "Tom Condon" <tom_condon@vrtx.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Monday, October 20, 2003 2:27 PM
 Subject: [xmlbeans-dev] Strange problem.....
 

--- a/data/public/mime/email03/66
+++ b/data/public/mime/email03/66
@@ -9,12 +9,12 @@ Received: (qmail 61870 invoked by uid 500); 22 Sep 2003 01:42:23 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 61855 invoked from network); 22 Sep 2003 01:42:23 -0000
 Message-ID: <3F6E5385.4060600@sauria.com>
 Date: Sun, 21 Sep 2003 18:42:29 -0700
@@ -24,11 +24,10 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.5b)
 	Gecko/20030901 Thunderbird/0.2
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
-Cc: general@incubator.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Getting the distribution onto a download site somewhere ...
 References: <1A1CC0FE-EB48-11D7-BE61-003065DC754C@apache.org>
-In-Reply-To: <1A1CC0FE-EB48-11D7-BE61-003065DC754C@apache.org>
+In-Reply-To: globaladmin@testdomain.com
 X-Enigmail-Version: 0.81.6.0
 X-Enigmail-Supports: pgp-inline, pgp-mime
 Content-Type: text/plain; charset=ISO-8859-1; format=flowed

--- a/data/public/mime/email03/67
+++ b/data/public/mime/email03/67
@@ -9,12 +9,12 @@ Received: (qmail 80693 invoked by uid 500); 20 Nov 2003 23:13:33 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 80678 invoked from network); 20 Nov 2003 23:13:33 -0000
 X-Sent: 20 Nov 2003 23:13:39 GMT
 Mime-Version: 1.0 (Apple Message framework v606)
@@ -29,7 +29,7 @@ From: robert burrell donkin <rdonkin@apache.org>
 Subject: Re: XmlBeans.jar size
 Date: Thu, 20 Nov 2003 23:16:11 +0000
 X-Zimbra-Received: Thu, 20 Nov 2003 23:16:11 +0000
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 X-Mailer: Apple Mail (2.606)
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/

--- a/data/public/mime/email03/68
+++ b/data/public/mime/email03/68
@@ -10,12 +10,12 @@ Received: (qmail 81296 invoked by uid 500); 25 Sep 2003 01:43:05 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 81281 invoked from network); 25 Sep 2003 01:43:05 -0000
 content-class: urn:content-classes:message
 MIME-Version: 1.0
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: STAX
 Thread-Index: AcOC+n4NPM3IJJvlQdyzdXUSS/qi9AABcRlQ
 From: "Cliff Schmidt" <cliff@bea.com>
-To: <xmlbeans-dev@xml.apache.org>, <christopher.fry@bea.com>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 25 Sep 2003 01:43:14.0162 (UTC)
 	FILETIME=[62789D20:01C38306]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N

--- a/data/public/mime/email03/69
+++ b/data/public/mime/email03/69
@@ -10,12 +10,12 @@ Received: (qmail 74726 invoked by uid 500); 18 Nov 2003 18:22:17 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 74699 invoked from network); 18 Nov 2003 18:22:17 -0000
 Message-ID: <3FBA62DF.4080803@cspowers.com>
 Date: Tue, 18 Nov 2003 10:20:15 -0800
@@ -25,7 +25,7 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.5b)
 	Gecko/20030901 Thunderbird/0.2
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Failed to build with "network downloads disabled" error
 	message.
 References: <3FB9C683.8010503@cspowers.com>

--- a/data/public/mime/email03/7
+++ b/data/public/mime/email03/7
@@ -1,5 +1,5 @@
 From: "Ross Davidson" <davidson@yahoo.com>
-To: samuel@darmo.com
+To: globaladmin@testdomain.com
 Subject: meeting
 X-Zimbra-Object: email-address
 Date: Fri, 27 Feb 2004 14:41:25 -0800

--- a/data/public/mime/email03/70
+++ b/data/public/mime/email03/70
@@ -10,12 +10,12 @@ Received: (qmail 13531 invoked by uid 500); 30 Sep 2003 18:51:45 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 13507 invoked from network); 30 Sep 2003 18:51:45 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: XMLBeans website
 Thread-Index: AcOHew8fOOB58/1ZQdKqJTaD9P9yygAAs+bQ
 From: "Cezar Andrei" <cezar@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 30 Sep 2003 18:51:49.0851 (UTC)
 	FILETIME=[E7F42AB0:01C38783]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -52,7 +52,7 @@ Cezar
 > -----Original Message-----
 > From: David Remy=20
 > Sent: Tuesday, September 30, 2003 12:49 PM
-> To: xmlbeans-dev@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: XMLBeans website
 >=20
 >=20

--- a/data/public/mime/email03/71
+++ b/data/public/mime/email03/71
@@ -10,16 +10,16 @@ Received: (qmail 26945 invoked by uid 500); 10 Nov 2003 20:10:23 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 26925 invoked from network); 10 Nov 2003 20:10:23 -0000
 Message-ID: <02f101c3a7c6$c1f9e990$0100a8c0@parsecc3f76316>
 From: "Javier Ramos" <ramos@parsec.es>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <200311101624.hAAGOfo1015197@whale.cs.indiana.edu>
 Subject: Re: how to deal with extensible schemas
 Date: Mon, 10 Nov 2003 21:10:58 +0100
@@ -52,7 +52,7 @@ Javier
 
 ----- Original Message ----- 
 From: "Yogesh L. Simmhan" <ysimmhan@cs.indiana.edu>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Monday, November 10, 2003 5:24 PM
 Subject: RE: how to deal with extensible schemas
 
@@ -77,7 +77,7 @@ the
 > ________________________________________
 > From: Javier Ramos [mailto:ramos@parsec.es]
 > Sent: Monday, November 10, 2003 5:50 AM
-> To: xmlbeans-user@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: how to deal with extensible schemas
 >
 > Hi,

--- a/data/public/mime/email03/72
+++ b/data/public/mime/email03/72
@@ -9,16 +9,16 @@ Received: (qmail 91184 invoked by uid 500); 3 Oct 2003 15:31:57 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 91171 invoked from network); 3 Oct 2003 15:31:57 -0000
 Message-ID: <013801c389c3$79b021c0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <1065122063.14001.18.camel@zieg>
 Subject: Re: builtin type conversions
 Date: Fri, 3 Oct 2003 11:31:52 -0400

--- a/data/public/mime/email03/73
+++ b/data/public/mime/email03/73
@@ -10,17 +10,17 @@ Received: (qmail 62889 invoked by uid 500); 19 Sep 2003 00:21:20 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 62874 invoked from network); 19 Sep 2003 00:21:19 -0000
 Date: Fri, 19 Sep 2003 09:26:06 +0900
 X-Zimbra-Received: Fri, 19 Sep 2003 09:26:06 +0900
 From: Tetsuya Kitahata <tetsuya@apache.org>
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Getting an XMLBeans distribution onto a download site somewhere
 In-Reply-To: <017301c37e40$9be37e10$d41e11ac@lightbox>
 References: <20030919084349.B9A0.TETSUYA@apache.org>

--- a/data/public/mime/email03/74
+++ b/data/public/mime/email03/74
@@ -10,17 +10,17 @@ Received: (qmail 38885 invoked by uid 500); 23 Oct 2003 01:02:28 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 38739 invoked from network); 23 Oct 2003 01:02:27 -0000
 Subject: RE: deep equals implementation?
 From: Kevin Krouse <kkrouse@bea.com>
-To: xmlbeans-user@xml.apache.org
-In-Reply-To: <OF1B4C50E4.B7785DBF-ONCA256DC8.0004D9E2@tmca.com.au>
+To: globaladmin@testdomain.com
+In-Reply-To: globaladmin@testdomain.com
 References: <OF1B4C50E4.B7785DBF-ONCA256DC8.0004D9E2@tmca.com.au>
 Content-Type: multipart/mixed; boundary="=-QCWGDIc/laJC9qCvEURh"
 Organization: BEA Systems, INC.

--- a/data/public/mime/email03/75
+++ b/data/public/mime/email03/75
@@ -9,14 +9,14 @@ Received: (qmail 47424 invoked by uid 500); 8 Oct 2003 17:17:17 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 47405 invoked from network); 8 Oct 2003 17:17:17 -0000
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Classloader problems
 MIME-Version: 1.0
 X-Mailer: Lotus Notes Release 6.0.1 February 07, 2003

--- a/data/public/mime/email03/76
+++ b/data/public/mime/email03/76
@@ -10,19 +10,19 @@ Received: (qmail 52082 invoked by uid 500); 30 Sep 2003 14:44:57 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 52069 invoked from network); 30 Sep 2003 14:44:57 -0000
 Message-Id: <sf795eab.089@corp-gw.mantech.com>
 X-Mailer: Novell GroupWise Internet Agent 5.5.6.1
 Date: Tue, 30 Sep 2003 10:44:40 -0400
 X-Zimbra-Received: Tue, 30 Sep 2003 10:44:40 -0400
 From: "Darrell Teague" <darrell.teague@mantech.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: Re: V2 store
 Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="=_431D08FB.2445CA02"

--- a/data/public/mime/email03/77
+++ b/data/public/mime/email03/77
@@ -10,16 +10,16 @@ Received: (qmail 54047 invoked by uid 500); 22 Oct 2003 23:32:02 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 54002 invoked from network); 22 Oct 2003 23:32:01 -0000
 Sensitivity: 
 Subject: RE: deep equals implementation?
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 X-Mailer: Lotus Notes Release 5.0.8  June 18, 2001
 Message-ID: <OF27BE0517.D02F021E-ONCA256DC7.008108C4@tmca.com.au>
 From: Dmitri.Colebatch@toyota.com.au
@@ -62,10 +62,9 @@ dim
 
 "Eric Vasilik" <ericvas@bea.com> on 23/10/2003 02:31:52 AM
 
-Please respond to xmlbeans-user@xml.apache.org
+Please respond to globaladmin@testdomain.com
 
-To:    <xmlbeans-user@xml.apache.org>
-cc:
+To:    <globaladmin@testdomain.com>
 Subject:    RE: deep equals implementation?
 
 This a known limitation.  We have not yet implemented any type of deep
@@ -80,7 +79,7 @@ needs.
 From: Dmitri.Colebatch@toyota.com.au
 [mailto:Dmitri.Colebatch@toyota.com.au]
 Sent: Tuesday, October 21, 2003 10:30 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: deep equals implementation?
 
 

--- a/data/public/mime/email03/78
+++ b/data/public/mime/email03/78
@@ -9,16 +9,16 @@ Received: (qmail 60774 invoked by uid 500); 7 Oct 2003 20:35:16 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 60761 invoked from network); 7 Oct 2003 20:35:16 -0000
 Message-ID: <00fd01c38d12$826fab30$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <1065122063.14001.18.camel@zieg>
 	 <013801c389c3$79b021c0$0fa8a8c0@lightbox> <1065481386.18863.16.camel@zieg>
 Subject: Re: builtin type conversions

--- a/data/public/mime/email03/79
+++ b/data/public/mime/email03/79
@@ -9,16 +9,16 @@ Received: (qmail 63591 invoked by uid 500); 14 Sep 2003 08:04:13 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 63578 invoked from network); 14 Sep 2003 08:04:13 -0000
 Message-ID: <028001c37a96$ce19db70$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <022901c379e9$2d9387d0$0fa8a8c0@lightbox>
 	 <3F63C3BE.3020807@ozemail.com.au>
 Subject: Re: list archiving

--- a/data/public/mime/email03/8
+++ b/data/public/mime/email03/8
@@ -1,6 +1,6 @@
 Date: Sun, 29 Feb 2004 16:08:01 -0800
 X-Zimbra-Received: Sun, 29 Feb 2004 16:08:01 -0800
-To: darmo@darmo.com
+To: globaladmin@testdomain.com
 From: Phil Bates <philb@foobarbaz.com>
 Subject: Outlook...
 X-Zimbra-Object: url

--- a/data/public/mime/email03/80
+++ b/data/public/mime/email03/80
@@ -8,12 +8,12 @@ Received: from mail.apache.org (daedalus.apache.org [208.185.179.12]) by
 Received: (qmail 30524 invoked by uid 500); 3 Dec 2003 19:10:26 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 30511 invoked from network); 3 Dec 2003 19:10:26 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -28,7 +28,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: Design Questions
 Thread-Index: AcO5sWcHlL00/aetQy2rsWZbS97c7QAHaypg
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-dev@xml.apache.org>, <jsleeman@lig.net>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 03 Dec 2003 19:09:42.0717 (UTC)
 	FILETIME=[01DE86D0:01C3B9D1]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -84,7 +84,7 @@ Hope this makes sense!
 -----Original Message-----
 From: jas [mailto:jsleeman@lig.net]
 Sent: Wednesday, December 03, 2003 7:27 AM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Design Questions
 
 

--- a/data/public/mime/email03/81
+++ b/data/public/mime/email03/81
@@ -10,16 +10,16 @@ Received: (qmail 87321 invoked by uid 500); 18 Sep 2005 23:10:34 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 87307 invoked from network); 18 Sep 2005 23:10:34 -0000
 Message-ID: <014501c37e3a$0ef13e80$d41e11ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>, <cmaeda@alum.mit.edu>
+To: globaladmin@testdomain.com
 References: <002201c37e22$9ded0550$0363050a@madcat>
 Subject: Re: Future XMLBeans feature work?
 Date: Thu, 18 Sep 2005 19:10:31 -0400

--- a/data/public/mime/email03/82
+++ b/data/public/mime/email03/82
@@ -9,16 +9,16 @@ Received: (qmail 10819 invoked by uid 500); 10 Oct 2003 21:03:25 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 10802 invoked from network); 10 Oct 2003 21:03:24 -0000
 Message-ID: <D44A54C298394F4E967EC8538B1E00F10248C932@lgchexch002.lgc.com>
 From: Dominique Devienne <DDevienne@lgc.com>
-To: "'xmlbeans-user@xml.apache.org'" <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: RE: XMLBeans/Java Web Start Issues
 Date: Fri, 10 Oct 2003 16:02:49 -0500
 X-Zimbra-Received: Fri, 10 Oct 2003 16:02:49 -0500

--- a/data/public/mime/email03/83
+++ b/data/public/mime/email03/83
@@ -9,19 +9,19 @@ Received: (qmail 64050 invoked by uid 500); 1 Oct 2003 18:00:00 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 64033 invoked from network); 1 Oct 2003 17:59:59 -0000
 Message-Id: <sf7adde3.097@corp-gw.mantech.com>
 X-Mailer: Novell GroupWise Internet Agent 5.5.6.1
 Date: Wed, 01 Oct 2003 13:59:38 -0400
 X-Zimbra-Received: Wed, 01 Oct 2003 13:59:38 -0400
 From: "Darrell Teague" <darrell.teague@mantech.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: RE: Finalizers
 Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="=_09574033.0061E9C7"
@@ -107,7 +107,7 @@ ar object no longer needed finalization.  Does such a thing exist?
 -----Original Message-----
 From: Darrell Teague [mailto:darrell.teague@mantech.com]
 Sent: Wednesday, October 01, 2003 8:49 AM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Finalizers
 
 
@@ -288,7 +288,7 @@ Message-----<BR>From: Darrell Teague [<A=20
 href=3D"mailto:darrell.teague@mantech.com]">mailto:darrell.teague@mantech.c=
 om]</A><BR>Sent:=20
 Wednesday, October 01, 2003 8:49 AM<BR>To:=20
-xmlbeans-dev@xml.apache.org<BR>Subject: Re: Finalizers<BR><BR><BR>Two more =
+globaladmin@testdomain.com<BR>Subject: Re: Finalizers<BR><BR><BR>Two more =
 cents=20
 on this topic...<BR><BR>Joshua Bloch of Sun and many others (myself include=
 d)=20

--- a/data/public/mime/email03/84
+++ b/data/public/mime/email03/84
@@ -10,16 +10,16 @@ Received: (qmail 7134 invoked by uid 500); 10 Oct 2003 19:29:20 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 7121 invoked from network); 10 Oct 2003 19:29:20 -0000
 Message-ID: <03c001c38f64$c60e66c0$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <F876C2FA-FB4E-11D7-8890-000393D5A006@vrtx.com>
 Subject: Re: XMLBeans/Java Web Start Issues
 Date: Fri, 10 Oct 2003 15:29:04 -0400
@@ -60,7 +60,7 @@ David
 
 ----- Original Message ----- 
 From: "Tom Condon" <tom_condon@vrtx.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Friday, October 10, 2003 2:24 PM
 Subject: [xmlbeans-dev] XMLBeans/Java Web Start Issues
 

--- a/data/public/mime/email03/85
+++ b/data/public/mime/email03/85
@@ -14,8 +14,8 @@ List-Post: <mailto:xmlbeans-cvs@xml.apache.org>
 List-Help: <mailto:xmlbeans-cvs-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-cvs-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-cvs-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-cvs@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: globaladmin@testdomain.com
 Received: (qmail 64992 invoked from network); 30 Sep 2003 23:18:01 -0000
 Received: from unknown (HELO minotaur.apache.org) (209.237.227.194) by
 	daedalus.apache.org with SMTP; 30 Sep 2003 23:18:01 -0000
@@ -24,7 +24,7 @@ Date: 30 Sep 2003 23:18:15 -0000
 X-Zimbra-Received: 30 Sep 2003 23:18:15 -0000
 Message-ID: <20030930231815.53234.qmail@minotaur.apache.org>
 From: ericvas@apache.org
-To: xml-xmlbeans-cvs@apache.org
+To: globaladmin@testdomain.com
 Subject: cvs commit: xml-xmlbeans/v2/test/src/erictest EricTest.java
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 Content-Type: text/plain; CHARSET=us-ascii

--- a/data/public/mime/email03/86
+++ b/data/public/mime/email03/86
@@ -14,8 +14,8 @@ List-Post: <mailto:xmlbeans-cvs@xml.apache.org>
 List-Help: <mailto:xmlbeans-cvs-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-cvs-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-cvs-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-cvs@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: globaladmin@testdomain.com
 Received: (qmail 78116 invoked from network); 29 Sep 2003 19:20:20 -0000
 Received: from unknown (HELO minotaur.apache.org) (209.237.227.194) by
 	daedalus.apache.org with SMTP; 29 Sep 2003 19:20:20 -0000
@@ -24,7 +24,7 @@ Date: 29 Sep 2003 19:20:29 -0000
 X-Zimbra-Received: 29 Sep 2003 19:20:29 -0000
 Message-ID: <20030929192029.71000.qmail@minotaur.apache.org>
 From: davidbau@apache.org
-To: xml-xmlbeans-cvs@apache.org
+To: globaladmin@testdomain.com
 Subject: cvs commit: xml-xmlbeans/v2 build.xml
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
 X-Evolution-Source: imap://smith@smith.pobox.stanford.edu/

--- a/data/public/mime/email03/87
+++ b/data/public/mime/email03/87
@@ -10,12 +10,12 @@ Received: (qmail 82549 invoked by uid 500); 29 Sep 2003 17:25:20 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 82511 invoked from network); 29 Sep 2003 17:25:19 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: V2 Store discussion...
 Thread-Index: AcOGq5qFUEtSOrCbQE2XCk/CA+befwAAZuLw
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <christopher.fry@bea.com>, <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 29 Sep 2003 17:25:22.0716 (UTC)
 	FILETIME=[A9C46DC0:01C386AE]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -59,7 +59,7 @@ Any thoughts?  Any confusion about this trade off? =20
 -----Original Message-----
 From: Chris Fry [mailto:christopher.fry@bea.com]
 Sent: Monday, September 29, 2003 9:55 AM
-To: xmlbeans-dev@xml.apache.org; Eric Vasilik
+To: globaladmin@testdomain.com
 Subject: RE: V2 Store discussion...
 
 
@@ -76,8 +76,7 @@ in WS-invocations...
 > -----Original Message-----
 > From: David Bau [mailto:david.bau@bea.com]
 > Sent: Monday, September 29, 2003 8:27 AM
-> To: Eric Vasilik
-> Cc: xmlbeans-dev@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: V2 Store discussion...
 >
 >

--- a/data/public/mime/email03/88
+++ b/data/public/mime/email03/88
@@ -9,12 +9,12 @@ Received: (qmail 91068 invoked by uid 500); 16 Sep 2003 13:05:43 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 91048 invoked from network); 16 Sep 2003 13:05:42 -0000
 Message-ID: <3F670AA5.3050405@fuzzymagic.com>
 Date: Tue, 16 Sep 2003 09:05:41 -0400
@@ -24,7 +24,7 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4)
 	Gecko/20030624
 X-Accept-Language: en-us, en
 MIME-Version: 1.0
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: [PATCH] Add to ways to find javac in CodeGenUtil
 Content-Type: text/plain; charset=us-ascii; format=flowed
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email03/89
+++ b/data/public/mime/email03/89
@@ -10,13 +10,13 @@ Received: (qmail 7155 invoked by uid 500); 26 Sep 2003 18:17:17 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
-Delivered-To: moderator for xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
+Delivered-To: moderator for globaladmin@testdomain.com
 Received: (qmail 98979 invoked from network); 26 Sep 2003 17:21:26 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -32,7 +32,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: xmlbeans javadocs?
 Thread-Index: AcOEUSmOu3GOMvExQoaGVAT0WGJrcAAAO/Xg
 From: "David Remy" <dremy@bea.com>
-To: <xmlbeans-dev@xml.apache.org>, <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 26 Sep 2003 17:21:30.0572 (UTC)
 	FILETIME=[A028D0C0:01C38452]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -73,7 +73,7 @@ her build options.
 > -----Original Message-----
 > From: Sullivan, Sean C - MWT [mailto:Sullivan.Sean@menlolog.com]
 > Sent: Friday, September 26, 2003 10:11 AM
-> To: 'xmlbeans-dev@xml.apache.org'
+> To: 'globaladmin@testdomain.com'
 > Subject: xmlbeans javadocs?
 >=20
 >=20

--- a/data/public/mime/email03/9
+++ b/data/public/mime/email03/9
@@ -33,8 +33,7 @@ User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.4)
 X-Accept-Language: en-us, en
 X-Zimbra-Object: url
 MIME-Version: 1.0
-To: Simon Josefsson <jas@extundo.com>
-CC: "Kurt D. Zeilenga" <Kurt@OpenLDAP.org>, SASL WG <ietf-sasl@imc.org>
+To: globaladmin@testdomain.com
 Subject: Re: SASLprep in rfc2222bis-06
 References: <200402162041.PAA20167@ietf.org>
 	 <6.0.1.1.0.20040216200054.04c9df08@127.0.0.1>	<4031F175.1070301@isode.com>
@@ -43,7 +42,7 @@ References: <200402162041.PAA20167@ietf.org>
 	 <ilullmr84gw.fsf@latte.josefsson.org>
 	 <6.0.1.1.0.20040225140352.04ba6fb8@127.0.0.1>
 	 <iluk72a20fy.fsf@latte.josefsson.org>
-In-Reply-To: <iluk72a20fy.fsf@latte.josefsson.org>
+In-Reply-To: globaladmin@testdomain.com
 Content-Type: text/plain; charset=us-ascii; format=flowed
 Content-Transfer-Encoding: 7bit
 Sender: owner-ietf-sasl@mail.imc.org

--- a/data/public/mime/email03/90
+++ b/data/public/mime/email03/90
@@ -8,16 +8,16 @@ Received: from mail.apache.org (daedalus.apache.org [208.185.179.12]) by
 Received: (qmail 92720 invoked by uid 500); 4 Dec 2003 21:25:21 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 92697 invoked from network); 4 Dec 2003 21:25:21 -0000
 Message-ID: <014f01c3baad$1163fd60$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <20031204073221.13882.qmail@web80410.mail.yahoo.com>
 Subject: Re: Contributing to XMLBeans
 Date: Thu, 4 Dec 2003 16:24:55 -0500
@@ -56,7 +56,7 @@ David
 
 ----- Original Message ----- 
 From: "Dutta Satadip" <s-dutta@sbcglobal.net>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Thursday, December 04, 2003 2:32 AM
 Subject: [xmlbeans-dev] Contributing to XMLBeans
 

--- a/data/public/mime/email03/91
+++ b/data/public/mime/email03/91
@@ -10,12 +10,12 @@ Received: (qmail 18581 invoked by uid 500); 16 Oct 2003 21:45:30 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 18550 invoked from network); 16 Oct 2003 21:45:30 -0000
 X-Sent: 16 Oct 2003 21:45:35 GMT
 Date: Thu, 16 Oct 2003 22:48:00 +0100
@@ -24,7 +24,7 @@ Mime-Version: 1.0 (Apple Message framework v482)
 Content-Type: text/plain; charset=US-ASCII; format=flowed
 Subject: xml-bean v1 now builds on gump
 From: robert burrell donkin <rdonkin@apache.org>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Content-Transfer-Encoding: 7bit
 Message-Id: <69B5D628-0022-11D8-B8F7-003065DC754C@apache.org>
 X-Mailer: Apple Mail (2.482)

--- a/data/public/mime/email03/92
+++ b/data/public/mime/email03/92
@@ -10,16 +10,16 @@ Received: (qmail 95849 invoked by uid 500); 18 Sep 2005 23:16:48 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 95809 invoked from network); 18 Sep 2005 23:16:48 -0000
 Message-ID: <015201c37e3a$ee7bce80$d41e11ac@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 References: <012801c37e19$9ef367e0$d41e11ac@lightbox>
 	 <3F6A0808.7020901@sauria.com>
 Subject: Re: Future XMLBeans feature work?

--- a/data/public/mime/email03/93
+++ b/data/public/mime/email03/93
@@ -9,16 +9,16 @@ Received: (qmail 43201 invoked by uid 500); 21 Nov 2003 20:03:00 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 43188 invoked from network); 21 Nov 2003 20:03:00 -0000
 Message-ID: <02e901c3b06a$6f64ba00$0fa8a8c0@lightbox>
 From: "David Bau" <david.bau@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: See one, do one, teach one
 Date: Fri, 21 Nov 2003 15:02:45 -0500
 X-Zimbra-Received: Fri, 21 Nov 2003 15:02:45 -0500

--- a/data/public/mime/email03/94
+++ b/data/public/mime/email03/94
@@ -10,12 +10,12 @@ Received: (qmail 77672 invoked by uid 500); 25 Sep 2003 01:36:56 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 77659 invoked from network); 25 Sep 2003 01:36:56 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -31,7 +31,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: code to contribute: JAM
 Thread-Index: AcOC+2AOFwxO9dlkSN6FwZMkTBYCCAACSDKQ
 From: "Dr. David Remy" <dremy@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 25 Sep 2003 01:37:04.0950 (UTC)
 	FILETIME=[86675560:01C38305]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -47,7 +47,7 @@ at makes sense, David, would you be the one to work with Patrick to do this=
 -----Original Message-----
 From: Patrick Calahan [mailto:pcal@bea.com]
 Sent: Wednesday, September 24, 2003 5:24 PM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: code to contribute: JAM
 
 

--- a/data/public/mime/email03/95
+++ b/data/public/mime/email03/95
@@ -10,12 +10,12 @@ Received: (qmail 79483 invoked by uid 500); 18 Nov 2003 18:24:54 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 79469 invoked from network); 18 Nov 2003 18:24:54 -0000
 content-class: urn:content-classes:message
 Subject: RE: Failed to build with "network downloads disabled" error
@@ -32,7 +32,7 @@ Thread-Topic: Failed to build with "network downloads disabled" error
 	message.
 Thread-Index: AcOuAPi1kRB+uVAYQHCjlXVIOFoYTAAACWag
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 18 Nov 2003 18:24:59.0311 (UTC)
 	FILETIME=[463D03F0:01C3AE01]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -47,7 +47,7 @@ y be experiencing this.
 -----Original Message-----
 From: Calvin Powers [mailto:calvin@cspowers.com]
 Sent: Tuesday, November 18, 2003 10:20 AM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Failed to build with "network downloads disabled" error
 message.
 

--- a/data/public/mime/email03/96
+++ b/data/public/mime/email03/96
@@ -14,8 +14,8 @@ List-Post: <mailto:xmlbeans-cvs@xml.apache.org>
 List-Help: <mailto:xmlbeans-cvs-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-cvs-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-cvs-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-cvs@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: globaladmin@testdomain.com
 Received: (qmail 52452 invoked from network); 20 Oct 2003 19:07:25 -0000
 Received: from unknown (HELO minotaur.apache.org) (209.237.227.194) by
 	daedalus.apache.org with SMTP; 20 Oct 2003 19:07:25 -0000
@@ -24,7 +24,7 @@ Date: 20 Oct 2003 19:07:34 -0000
 X-Zimbra-Received: 20 Oct 2003 19:07:34 -0000
 Message-ID: <20031020190734.10019.qmail@minotaur.apache.org>
 From: pcal@apache.org
-To: xml-xmlbeans-cvs@apache.org
+To: globaladmin@testdomain.com
 Subject: cvs commit:
 	xml-xmlbeans/v2/src/jam/org/apache/xmlbeans/impl/jam/internal/javadoc
 	JDClassLoaderFactory.java

--- a/data/public/mime/email03/97
+++ b/data/public/mime/email03/97
@@ -10,17 +10,17 @@ Received: (qmail 30768 invoked by uid 500); 24 Sep 2003 17:42:12 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
-Delivered-To: moderator for xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
+Delivered-To: moderator for globaladmin@testdomain.com
 Received: (qmail 78974 invoked from network); 24 Sep 2003 12:31:31 -0000
 Message-ID: <D1D50F9C5151D2119FF000104BB3F9B7054DBC9E@NL-ROT-MAIL02>
 From: Michiel Verhoef <michiel.verhoef@logicacmg.com>
-To: "'xmlbeans-dev@xml.apache.org'" <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: download XMLBeans?
 Date: Wed, 24 Sep 2003 14:30:09 +0200
 X-Zimbra-Received: Wed, 24 Sep 2003 14:30:09 +0200

--- a/data/public/mime/email03/98
+++ b/data/public/mime/email03/98
@@ -9,12 +9,12 @@ Received: (qmail 27139 invoked by uid 500); 10 Nov 2003 21:19:35 -0000
 Mailing-List: contact xmlbeans-user-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-user@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-user-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-user-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-user-subscribe@xml.apache.org>
-Reply-To: xmlbeans-user@xml.apache.org
-Delivered-To: mailing list xmlbeans-user@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 27126 invoked from network); 10 Nov 2003 21:19:35 -0000
 X-MimeOLE: Produced By Microsoft Exchange V6.0.6375.0
 content-class: urn:content-classes:message
@@ -29,7 +29,7 @@ X-MS-TNEF-Correlator:
 Thread-Topic: how to deal with extensible schemas
 Thread-Index: AcOnxrTCkZUi1QbTQrCBQC+zbWeprQACWtSA
 From: "Eric Vasilik" <ericvas@bea.com>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 X-OriginalArrivalTime: 10 Nov 2003 21:19:39.0164 (UTC)
 	FILETIME=[5969ADC0:01C3A7D0]
 X-Spam-Rating: daedalus.apache.org 1.6.2 0/1000/N
@@ -45,7 +45,7 @@ XmlCursor.copyXmlContents when a cursor is position on the document.
 -----Original Message-----
 From: Javier Ramos [mailto:ramos@parsec.es]
 Sent: Monday, November 10, 2003 12:11 PM
-To: xmlbeans-user@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: how to deal with extensible schemas
 
 
@@ -67,7 +67,7 @@ Javier
 
 ----- Original Message -----=20
 From: "Yogesh L. Simmhan" <ysimmhan@cs.indiana.edu>
-To: <xmlbeans-user@xml.apache.org>
+To: globaladmin@testdomain.com
 Sent: Monday, November 10, 2003 5:24 PM
 Subject: RE: how to deal with extensible schemas
 
@@ -92,7 +92,7 @@ the
 > ________________________________________
 > From: Javier Ramos [mailto:ramos@parsec.es]
 > Sent: Monday, November 10, 2003 5:50 AM
-> To: xmlbeans-user@xml.apache.org
+> To: globaladmin@testdomain.com
 > Subject: how to deal with extensible schemas
 >
 > Hi,

--- a/data/public/mime/email03/99
+++ b/data/public/mime/email03/99
@@ -9,19 +9,19 @@ Received: (qmail 4235 invoked by uid 500); 2 Oct 2003 14:47:39 -0000
 Mailing-List: contact xmlbeans-dev-help@xml.apache.org; run by ezmlm
 Precedence: bulk
 X-No-Archive: yes
-List-Post: <mailto:xmlbeans-dev@xml.apache.org>
+List-Post: <mailto:globaladmin@testdomain.com>
 List-Help: <mailto:xmlbeans-dev-help@xml.apache.org>
 List-Unsubscribe: <mailto:xmlbeans-dev-unsubscribe@xml.apache.org>
 List-Subscribe: <mailto:xmlbeans-dev-subscribe@xml.apache.org>
-Reply-To: xmlbeans-dev@xml.apache.org
-Delivered-To: mailing list xmlbeans-dev@xml.apache.org
+Reply-To: globaladmin@testdomain.com
+Delivered-To: mailing list globaladmin@testdomain.com
 Received: (qmail 4221 invoked from network); 2 Oct 2003 14:47:39 -0000
 Message-Id: <sf7c024d.091@corp-gw.mantech.com>
 X-Mailer: Novell GroupWise Internet Agent 5.5.6.1
 Date: Thu, 02 Oct 2003 10:47:22 -0400
 X-Zimbra-Received: Thu, 02 Oct 2003 10:47:22 -0400
 From: "Darrell Teague" <darrell.teague@mantech.com>
-To: <xmlbeans-dev@xml.apache.org>
+To: globaladmin@testdomain.com
 Subject: RE: Finalizers
 Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="=_8CD2C29D.1170F847"
@@ -72,7 +72,7 @@ Have you looked at using weak references for the XML->Cursor references?
 -----Original Message-----
 From: Eric Vasilik [mailto:ericvas@bea.com]=20
 Sent: Wednesday, October 01, 2003 1:14 PM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: RE: Finalizers
 
 
@@ -121,7 +121,7 @@ particular object no longer needed finalization.  Does such a thing exist?
 -----Original Message-----
 From: Darrell Teague [mailto:darrell.teague@mantech.com]
 Sent: Wednesday, October 01, 2003 8:49 AM
-To: xmlbeans-dev@xml.apache.org
+To: globaladmin@testdomain.com
 Subject: Re: Finalizers
 
 
@@ -254,7 +254,7 @@ rsor=20
 references?<BR><BR>-----Original Message-----<BR>From: Eric Vasilik [<A=20
 href=3D"mailto:ericvas@bea.com]">mailto:ericvas@bea.com]</A> <BR>Sent: Wedn=
 esday,=20
-October 01, 2003 1:14 PM<BR>To: xmlbeans-dev@xml.apache.org<BR>Subject: RE:=
+October 01, 2003 1:14 PM<BR>To: globaladmin@testdomain.com<BR>Subject: RE:=
 =20
 Finalizers<BR><BR><BR>My plans for the next version of the store are to rem=
 ove=20
@@ -305,7 +305,7 @@ Message-----<BR>From: Darrell Teague [<A=20
 href=3D"mailto:darrell.teague@mantech.com]">mailto:darrell.teague@mantech.c=
 om]</A><BR>Sent:=20
 Wednesday, October 01, 2003 8:49 AM<BR>To:=20
-xmlbeans-dev@xml.apache.org<BR>Subject: Re: Finalizers<BR><BR><BR>Two more =
+globaladmin@testdomain.com<BR>Subject: Re: Finalizers<BR><BR><BR>Two more =
 cents=20
 on this topic...<BR><BR>Joshua Bloch of Sun and many others (myself include=
 d)=20

--- a/data/public/mime/email04/mimeHtmlOnly.txt
+++ b/data/public/mime/email04/mimeHtmlOnly.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:10:42 -0800 (PST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: subject13214016672655
 Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email04/mimeTextAndHtml.txt
+++ b/data/public/mime/email04/mimeTextAndHtml.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:10:42 -0800 (PST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: subject13214016621403
 Content-Type: multipart/alternative;
  boundary="=_169984f8-32cb-424f-b79d-befb3997c0ea"

--- a/data/public/mime/email04/mimeTextOnly.txt
+++ b/data/public/mime/email04/mimeTextOnly.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:06:47 -0800 (PST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: subject13214016725788
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email05/mime01.txt
+++ b/data/public/mime/email05/mime01.txt
@@ -1,6 +1,6 @@
 Date: Thu, 29 Mar 2012 15:56:40 -0700 (PDT)
 From: foo@testdomain.com
-To: bar@testdomain.com
+To: globaladmin@testdomain.com
 Subject: subject151615738
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email05/mime02.txt
+++ b/data/public/mime/email05/mime02.txt
@@ -1,6 +1,6 @@
 Date: Thu, 29 Mar 2012 15:56:40 -0700 (PDT)
 From: foo@testdomain.com
-To: bar@testdomain.com
+To: globaladmin@testdomain.com
 Subject: subject151111738
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email05/mime03.txt
+++ b/data/public/mime/email05/mime03.txt
@@ -1,6 +1,6 @@
 Date: Thu, 29 Mar 2012 23:05:19 -0700 (PDT)
 From: foo@testdomain.com
-To: bar@testdomain.com
+To: globaladmin@testdomain.com
 Subject: subject13330659993903
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email06/mime.txt
+++ b/data/public/mime/email06/mime.txt
@@ -1,6 +1,6 @@
 Date: Tue, 6 Nov 2012 14:53:13 -0800 (PST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: subject135219672356274
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email07/mime.txt
+++ b/data/public/mime/email07/mime.txt
@@ -3,7 +3,7 @@ Content-Type: multipart/alternative; boundary="===============1502514016=="
 MIME-Version: 1.0
 Subject: subject135232705018411
 From: YouTube Service <noreply@youtube.com>
-To: foo@example.com
+To: globaladmin@testdomain.com
 Date: Wed, 07 Nov 2012 14:41:36 -0800 (PST)
 
 

--- a/data/public/mime/email08/mime.txt
+++ b/data/public/mime/email08/mime.txt
@@ -1,6 +1,6 @@
 Date: Thu, 21 Feb 2013 13:25:27 +0400 (GMT+04:00)
 From: 4@zqa-061.eng.zimbra.com
-To: uwm01 <uwm01@zqa-061.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Message-ID: <833740842.90.1361438727782.JavaMail.root@zqa-061.eng.zimbra.com>
 In-Reply-To: <1665548816.83.1361438704884.JavaMail.root@zqa-061.eng.zimbra.com>
 Subject: Import ics using add to calendar

--- a/data/public/mime/email08/mime01.txt
+++ b/data/public/mime/email08/mime01.txt
@@ -1,6 +1,6 @@
 Date: Thu, 21 Feb 2013 13:25:27 +0400 (GMT+04:00)
 From: 4@zqa-061.eng.zimbra.com
-To: uwm01 <uwm01@zqa-061.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Message-ID: <833740842.90.1361438727782.JavaMail.root@zqa-061.eng.zimbra.com>
 In-Reply-To: <1665548816.83.1361438704884.JavaMail.root@zqa-061.eng.zimbra.com>
 Subject: Import ics using add to calendar

--- a/data/public/mime/email08/mime02.txt
+++ b/data/public/mime/email08/mime02.txt
@@ -1,6 +1,6 @@
 Date: Tue, 10 Aug 2010 07:22:15 -0700 (PDT)
 From: Tony X <testuser@test.com>
-To: testuser@test.com
+To: globaladmin@testdomain.com
 Subject: add to calendar using ics link
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8

--- a/data/public/mime/email08/mime03.txt
+++ b/data/public/mime/email08/mime03.txt
@@ -1,6 +1,6 @@
 Date: Mon, 1 Jul 2013 00:42:35 -0700 (PDT)
 From: uwm01@zqa-062.eng.zimbra.com
-To: uwm02 <uwm02@zqa-062.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Message-ID: <1216464744.48.1372664555113.JavaMail.zimbra@zqa-062.eng.zimbra.com>
 In-Reply-To: <258809959.34.1372664526352.JavaMail.zimbra@zqa-062.eng.zimbra.com>
 Subject: separate window invite ics attachment

--- a/data/public/mime/email08/mime04.txt
+++ b/data/public/mime/email08/mime04.txt
@@ -1,6 +1,6 @@
 Date: Sun, 30 Jun 2013 23:49:08 -0700 (PDT)
 From: uwm01@zqa-062.eng.zimbra.com
-To: uwm02 <uwm02@zqa-062.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Message-ID: <1706954645.51.1372661348979.JavaMail.zimbra@zqa-062.eng.zimbra.com>
 In-Reply-To: <1957871804.38.1372661314031.JavaMail.zimbra@zqa-062.eng.zimbra.com>
 References: <1957871804.38.1372661314031.JavaMail.zimbra@zqa-062.eng.zimbra.com>
@@ -36,7 +36,7 @@ Content-Disposition: attachment
 
 Date: Sun, 30 Jun 2013 23:48:34 -0700 (PDT)
 From: uwm01@zqa-062.eng.zimbra.com
-To: uwm02 <uwm02@zqa-062.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Message-ID: <1957871804.38.1372661314031.JavaMail.zimbra@zqa-062.eng.zimbra.com>
 In-Reply-To: <1585015001.29.1372661294341.JavaMail.zimbra@zqa-062.eng.zimbra.com>
 Subject: add to calendar using rfc822 attachment

--- a/data/public/mime/email08/mime05.txt
+++ b/data/public/mime/email08/mime05.txt
@@ -1,6 +1,6 @@
 Date: Thu, 21 Feb 2013 13:25:27 +0400 (GMT+04:00)
 From: 4@zqa-061.eng.zimbra.com
-To: uwm01 <uwm01@zqa-061.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Message-ID: <833740842.90.13611438727782.JavaMail.root@zqa-061.eng.zimbra.com>
 In-Reply-To: <1665548816.83.13611438704884.JavaMail.root@zqa-061.eng.zimbra.com>
 Subject: Importing ics using add to calendar

--- a/data/public/mime/email08/mime06.txt
+++ b/data/public/mime/email08/mime06.txt
@@ -1,6 +1,6 @@
 Date: Mon, 1 Jul 2013 00:42:35 -0700 (PDT)
 From: uwm01@zqa-062.eng.zimbra.com
-To: uwm02 <uwm02@zqa-062.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Message-ID: <1216464744.48.11372664555113.JavaMail.zimbra@zqa-062.eng.zimbra.com>
 In-Reply-To: <258809959.34.11372664526352.JavaMail.zimbra@zqa-062.eng.zimbra.com>
 Subject: new window invite ics attachment

--- a/data/public/mime/email09/mime.txt
+++ b/data/public/mime/email09/mime.txt
@@ -1,6 +1,6 @@
 Date: Tue, 5 Mar 2013 12:56:56 -0800 (PST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: subject03431362517016470
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email10/mimeHtmlOnly1.txt
+++ b/data/public/mime/email10/mimeHtmlOnly1.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:10:42 -0800 (PST)
 From: admin@testdomain.com
-To: admin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: 1 html mail
 Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email10/mimeHtmlOnly2.txt
+++ b/data/public/mime/email10/mimeHtmlOnly2.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:10:42 -0800 (PST)
 From: admin@testdomain.com
-To: admin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: 2 html mail
 Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email10/mimeHtmlOnly3.txt
+++ b/data/public/mime/email10/mimeHtmlOnly3.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:10:42 -0800 (PST)
 From: admin@testdomain.com
-To: admin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: 3 html mail
 Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email10/mimeHtmlOnly4.txt
+++ b/data/public/mime/email10/mimeHtmlOnly4.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:10:42 -0800 (PST)
 From: admin@testdomain.com
-To: admin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: 4 html mail
 Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email10/mimeTextOnly1.txt
+++ b/data/public/mime/email10/mimeTextOnly1.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:06:47 -0800 (PST)
 From: admin@testdomain.com
-To: admin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: 1 plain mail
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email10/mimeTextOnly2.txt
+++ b/data/public/mime/email10/mimeTextOnly2.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:06:47 -0800 (PST)
 From: admin@testdomain.com
-To: admin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: 2 plain mail
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email10/mimeTextOnly3.txt
+++ b/data/public/mime/email10/mimeTextOnly3.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:06:47 -0800 (PST)
 From: admin@testdomain.com
-To: admin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: 3 plain mail
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email10/mimeTextOnly4.txt
+++ b/data/public/mime/email10/mimeTextOnly4.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2011 17:06:47 -0800 (PST)
 From: admin@testdomain.com
-To: admin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: 4 plain mail
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit

--- a/data/public/mime/email11/mime00.txt
+++ b/data/public/mime/email11/mime00.txt
@@ -1,6 +1,6 @@
 Date: Mon, 3 Jun 2013 11:45:04 -0700 (PDT)
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: Re: ReadMore13674340693102
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
@@ -22,7 +22,7 @@ s proceeded through the airline industry upturn in the late 1970s.[11][12]
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: vmwde1@zqa-062.eng.zimbra.com
+An: globaladmin@testdomain.com
 Gesendet: Montag, 3. Juni 2013 11:44:52
 Betreff: Re: read more
 
@@ -46,8 +46,8 @@ d two or three engines, with possible configurations including over-wing en=
 gines and a T-tail.[3]
 
 ----- Original Message -----
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, June 3, 2013 11:44:33 AM
 Subject: Re: read more
 
@@ -61,7 +61,7 @@ itors have included the Airbus A300, A310, and A330-200, while a successor,=
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: vmwde1@zqa-062.eng.zimbra.com
+An: globaladmin@testdomain.com
 Gesendet: Montag, 3. Juni 2013 11:44:18
 Betreff: Re: read more
 
@@ -77,8 +77,8 @@ he most frequently used airliner for transatlantic flights between North Am=
 erica and Europe.
 
 ----- Original Message -----
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, June 3, 2013 11:44:01 AM
 Subject: Re: read more
 
@@ -95,7 +95,7 @@ s-Royce RB211 turbofans.
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: "vmwde1" <vmwde1@zqa-062.eng.zimbra.com>
+An: "vmwde1" <globaladmin@testdomain.com>
 Gesendet: Montag, 3. Juni 2013 11:43:11
 Betreff: read more
 

--- a/data/public/mime/email11/mime01.txt
+++ b/data/public/mime/email11/mime01.txt
@@ -1,6 +1,6 @@
 Date: Mon, 3 Jun 2013 11:43:11 -0700 (PDT)
 From: vmwen2@zqa-062.eng.zimbra.com
-To: vmwde1 <vmwde1@zqa-062.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: ReadMore13674340693103
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8

--- a/data/public/mime/email11/mime02.txt
+++ b/data/public/mime/email11/mime02.txt
@@ -1,6 +1,6 @@
 Date: Mon, 3 Jun 2013 11:44:01 -0700 (PDT)
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: Re: ReadMore13674340693103
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
@@ -19,7 +19,7 @@ s-Royce RB211 turbofans.
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: "vmwde1" <vmwde1@zqa-062.eng.zimbra.com>
+An: "vmwde1" <globaladmin@testdomain.com>
 Gesendet: Montag, 3. Juni 2013 11:43:11
 Betreff: read more
 

--- a/data/public/mime/email11/mime03.txt
+++ b/data/public/mime/email11/mime03.txt
@@ -1,6 +1,6 @@
 Date: Mon, 3 Jun 2013 11:44:18 -0700 (PDT)
 From: vmwen2@zqa-062.eng.zimbra.com
-To: vmwde1@zqa-062.eng.zimbra.com
+To: globaladmin@testdomain.com
 Subject: Re: ReadMore13674340693103
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
@@ -18,8 +18,8 @@ he most frequently used airliner for transatlantic flights between North Am=
 erica and Europe.
 
 ----- Original Message -----
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, June 3, 2013 11:44:01 AM
 Subject: Re: read more
 
@@ -36,7 +36,7 @@ s-Royce RB211 turbofans.
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: "vmwde1" <vmwde1@zqa-062.eng.zimbra.com>
+An: "vmwde1" <globaladmin@testdomain.com>
 Gesendet: Montag, 3. Juni 2013 11:43:11
 Betreff: read more
 

--- a/data/public/mime/email11/mime04.txt
+++ b/data/public/mime/email11/mime04.txt
@@ -1,6 +1,6 @@
 Date: Mon, 3 Jun 2013 11:44:33 -0700 (PDT)
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: Re: ReadMore13674340693103
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
@@ -16,7 +16,7 @@ itors have included the Airbus A300, A310, and A330-200, while a successor,=
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: vmwde1@zqa-062.eng.zimbra.com
+An: globaladmin@testdomain.com
 Gesendet: Montag, 3. Juni 2013 11:44:18
 Betreff: Re: read more
 
@@ -32,8 +32,8 @@ he most frequently used airliner for transatlantic flights between North Am=
 erica and Europe.
 
 ----- Original Message -----
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, June 3, 2013 11:44:01 AM
 Subject: Re: read more
 
@@ -50,7 +50,7 @@ s-Royce RB211 turbofans.
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: "vmwde1" <vmwde1@zqa-062.eng.zimbra.com>
+An: "vmwde1" <globaladmin@testdomain.com>
 Gesendet: Montag, 3. Juni 2013 11:43:11
 Betreff: read more
 

--- a/data/public/mime/email11/mime05.txt
+++ b/data/public/mime/email11/mime05.txt
@@ -1,6 +1,6 @@
 Date: Mon, 3 Jun 2013 11:44:52 -0700 (PDT)
 From: vmwen2@zqa-062.eng.zimbra.com
-To: vmwde1@zqa-062.eng.zimbra.com
+To: globaladmin@testdomain.com
 Subject: Re: ReadMore13674340693103
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
@@ -26,8 +26,8 @@ d two or three engines, with possible configurations including over-wing en=
 gines and a T-tail.[3]
 
 ----- Original Message -----
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, June 3, 2013 11:44:33 AM
 Subject: Re: read more
 
@@ -41,7 +41,7 @@ itors have included the Airbus A300, A310, and A330-200, while a successor,=
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: vmwde1@zqa-062.eng.zimbra.com
+An: globaladmin@testdomain.com
 Gesendet: Montag, 3. Juni 2013 11:44:18
 Betreff: Re: read more
 
@@ -57,8 +57,8 @@ he most frequently used airliner for transatlantic flights between North Am=
 erica and Europe.
 
 ----- Original Message -----
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, June 3, 2013 11:44:01 AM
 Subject: Re: read more
 
@@ -75,7 +75,7 @@ s-Royce RB211 turbofans.
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: "vmwde1" <vmwde1@zqa-062.eng.zimbra.com>
+An: "vmwde1" <globaladmin@testdomain.com>
 Gesendet: Montag, 3. Juni 2013 11:43:11
 Betreff: read more
 

--- a/data/public/mime/email11/mime06.txt
+++ b/data/public/mime/email11/mime06.txt
@@ -1,6 +1,6 @@
 Date: Mon, 3 Jun 2013 11:45:04 -0700 (PDT)
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: Re: ReadMore13674340693103
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
@@ -22,7 +22,7 @@ s proceeded through the airline industry upturn in the late 1970s.[11][12]
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: vmwde1@zqa-062.eng.zimbra.com
+An: globaladmin@testdomain.com
 Gesendet: Montag, 3. Juni 2013 11:44:52
 Betreff: Re: read more
 
@@ -46,8 +46,8 @@ d two or three engines, with possible configurations including over-wing en=
 gines and a T-tail.[3]
 
 ----- Original Message -----
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, June 3, 2013 11:44:33 AM
 Subject: Re: read more
 
@@ -61,7 +61,7 @@ itors have included the Airbus A300, A310, and A330-200, while a successor,=
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: vmwde1@zqa-062.eng.zimbra.com
+An: globaladmin@testdomain.com
 Gesendet: Montag, 3. Juni 2013 11:44:18
 Betreff: Re: read more
 
@@ -77,8 +77,8 @@ he most frequently used airliner for transatlantic flights between North Am=
 erica and Europe.
 
 ----- Original Message -----
-From: vmwde1@zqa-062.eng.zimbra.com
-To: vmwen2@zqa-062.eng.zimbra.com
+From: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, June 3, 2013 11:44:01 AM
 Subject: Re: read more
 
@@ -95,7 +95,7 @@ s-Royce RB211 turbofans.
 
 ----- Urspr=C3=BCngliche Mail -----
 Von: vmwen2@zqa-062.eng.zimbra.com
-An: "vmwde1" <vmwde1@zqa-062.eng.zimbra.com>
+An: "vmwde1" <globaladmin@testdomain.com>
 Gesendet: Montag, 3. Juni 2013 11:43:11
 Betreff: read more
 

--- a/data/public/mime/email12/mime01.txt
+++ b/data/public/mime/email12/mime01.txt
@@ -1,6 +1,6 @@
 Date: Tue, 18 Jun 2013 09:59:58 -0700 (PDT)
 From: foo@foo.com
-To: bar@bar.com
+To: globaladmin@testdomain.com
 Subject: subject13715117780534
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email12/mime02.txt
+++ b/data/public/mime/email12/mime02.txt
@@ -1,6 +1,6 @@
 Date: Tue, 18 Jun 2013 10:20:14 -0700 (PDT)
 From: foo@foo.com
-To: bar@bar.com
+To: globaladmin@testdomain.com
 Subject: subject13715024766995
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email12/mime03.txt
+++ b/data/public/mime/email12/mime03.txt
@@ -1,6 +1,6 @@
 Date: Tue, 18 Jun 2013 10:20:40 -0700 (PDT)
 From: foo@foo.com
-To: bar@bar.com
+To: globaladmin@testdomain.com
 Subject: subject13715024846237
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email12/mime04.txt
+++ b/data/public/mime/email12/mime04.txt
@@ -1,6 +1,6 @@
 Date: Tue, 18 Jun 2013 10:22:28 -0700 (PDT)
 From: foo@foo.com
-To: bar@bar.com
+To: globaladmin@testdomain.com
 Subject: subject13715020881915
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email13/external image.txt
+++ b/data/public/mime/email13/external image.txt
@@ -1,6 +1,6 @@
 Date: Mon, 3 Nov 2014 01:45:50 -0800 (PST)
 From: uwm01@zqa-062.eng.vmware.com
-To: uwm02 <uwm02@zqa-062.eng.vmware.com>
+To: globaladmin@testdomain.com
 Message-ID: <496126020.226.1415007950478.JavaMail.zimbra@zqa-062.eng.vmware.com>
 Subject: external image testing
 MIME-Version: 1.0

--- a/data/public/mime/email13/inline image.txt
+++ b/data/public/mime/email13/inline image.txt
@@ -1,6 +1,6 @@
 Date: Tue, 17 Sep 2013 00:17:23 -0700 (PDT)
 From: uwm01@zqa-062.eng.vmware.com
-To: uwm02 <uwm02@zqa-062.eng.vmware.com>
+To: globaladmin@testdomain.com
 Subject: inline image testing
 MIME-Version: 1.0
 Content-Type: multipart/alternative; 

--- a/data/public/mime/email14/mime.txt
+++ b/data/public/mime/email14/mime.txt
@@ -1,6 +1,6 @@
 Date: Tue, 5 Mar 2013 12:56:56 -0800 (PST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: subject13977785775182543
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email15/mime.txt
+++ b/data/public/mime/email15/mime.txt
@@ -1,6 +1,6 @@
 Date: Tue, 5 Mar 2013 12:56:56 -0800 (PST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: subject1397778577518254677
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email16/mime.txt
+++ b/data/public/mime/email16/mime.txt
@@ -1,8 +1,7 @@
 ﻿From: "User 1" <user1@testdomain.com>
-To: "'User 2'" <user2@testdomain.com>,
-	"User 3" <user3@testdomain.com>
+To: globaladmin@testdomain.com
 References: <1460921948.730077.1340312105003.JavaMail.root@testdomain.com> <979016627.730884.1340313033566.JavaMail.root@testdomain.com>
-In-Reply-To: <979016627.730884.1340313033566.JavaMail.root@testdomain.com>
+In-Reply-To: globaladmin@testdomain.com
 Subject: ZCS 8 triage
 Date: Mon, 25 Jun 2012 12:20:34 -0700
 Message-ID: <11d9ee62.00000ff0.00000050@zimbra-PC7632>
@@ -61,9 +60,7 @@ Hopefully the list will be quite short.  I’ll send out an email next Monday.
 
 From: Kevin Henrikson [mailto:kevinh@vmware.com]
 Sent: Thursday, June 21, 2012 2:11 PM
-To: Jeff Wagner; Jeff Flanigan; Todd Richmond; Brian P. Peterson; Ellen 
-Shen; Matt Rhoades; Bill Hwang; Sandesh Joseph Almeida
-Cc: Jon Dybik; Lavanya Shastri; John Robb
+To: globaladmin@testdomain.com
 Subject: zcs 8 triage
 
 
@@ -1810,8 +1807,7 @@ style=3D'font-size:10.0pt;font-family:"Tahoma","sans-serif"'>From:</span>=
 Kevin Henrikson [mailto:kevinh@vmware.com] <br><b>Sent:</b> Thursday, =
 June 21, 2012 2:11 PM<br><b>To:</b> Jeff Wagner; Jeff Flanigan; Todd =
 Richmond; Brian P. Peterson; Ellen Shen; Matt Rhoades; Bill Hwang; =
-Sandesh Joseph Almeida<br><b>Cc:</b> Jon Dybik; Lavanya Shastri; John =
-Robb<br><b>Subject:</b> zcs 8 triage<o:p></o:p></span></p></div></div><p =
+Sandesh Joseph Almeida<br><b><br><b>Subject:</b> zcs 8 triage<o:p></o:p></span></p></div></div><p =
 class=3DMsoNormal><o:p>&nbsp;</o:p></p><div><p class=3DMsoNormal =
 style=3D'margin-bottom:12.0pt'><span style=3D'font-family:"Trebuchet =
 MS","sans-serif";color:black'><br>Hey guys I ran the ZCS -&gt; =

--- a/data/public/mime/email16/mime02.txt
+++ b/data/public/mime/email16/mime02.txt
@@ -1,6 +1,6 @@
 Date: Fri, 19 Feb 2016 13:20:34 +0530 (IST)
 From: enus14558676574843@testdomain.com
-To: xyz@testdomain.com
+To: globaladmin@testdomain.com
 Subject: remove attachment from conversation view
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email17/mime.txt
+++ b/data/public/mime/email17/mime.txt
@@ -1,6 +1,6 @@
 Date: Sat, 20 Feb 2016 22:48:29 -0600 (CST)
 From: Offline Account <test@zimbratest.com>
-To: offline <test@zimbratest.com>
+To: globaladmin@testdomain.com
 Subject: subjectAttachment
 MIME-Version: 1.0
 Content-Type: multipart/mixed; 

--- a/data/public/mime/email18/AutomaticExternalImageDisplayMime.txt
+++ b/data/public/mime/email18/AutomaticExternalImageDisplayMime.txt
@@ -1,7 +1,6 @@
 Date: Wed, 30 Mar 2016 11:47:09 +0400 (GMT+04:00)
 From: j2@zqa-061.eng.zimbra.com
-To: j1 <j1@zqa-061.eng.zimbra.com>
-Cc: j3 <j3@zqa-061.eng.zimbra.com>
+To: globaladmin@testdomain.com
 Subject: Display external image preference check
 MIME-Version: 1.0
 Content-Type: multipart/alternative; 

--- a/data/public/mime/email18/mime.txt
+++ b/data/public/mime/email18/mime.txt
@@ -34,7 +34,7 @@ Date: Wed, 20 Feb 2013 05:44:59 +0000
 X-Mailer: Chilkat Software Inc (http://www.chilkatsoft.com)
 X-Priority: 3 (Normal)
 Subject: Print2PDF Error
-To: servers@testdomain.com
+To: globaladmin@testdomain.com
 From: servers@testdomain.com
 Content-Type: multipart/mixed;
 	boundary="-----_chilkat_24d_07e5_c2694143.76aafb15_.MIX"

--- a/data/public/mime/email19/multilineHTMLcontent.txt
+++ b/data/public/mime/email19/multilineHTMLcontent.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2015 17:10:42 -0800 (PST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: subject13214016725788
 MIME-Version: 1.0
 Content-Type: multipart/alternative; 

--- a/data/public/mime/email19/multilineTextcontent.txt
+++ b/data/public/mime/email19/multilineTextcontent.txt
@@ -1,6 +1,6 @@
 Date: Tue, 15 Nov 2015 17:10:42 -0800 (PST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: subject13214016777777
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8

--- a/data/public/mime/email20/CalendarHTMLBody.txt
+++ b/data/public/mime/email20/CalendarHTMLBody.txt
@@ -1,6 +1,6 @@
 Date: Mon, 7 Nov 2016 13:17:52 +0530 (IST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: multiline HTML body
 MIME-Version: 1.0
 Content-Type: multipart/alternative; 

--- a/data/public/mime/email20/CalendarPlainTextBody.txt
+++ b/data/public/mime/email20/CalendarPlainTextBody.txt
@@ -1,6 +1,6 @@
 Date: Mon, 7 Nov 2016 13:17:52 +0530 (IST)
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: multiline plain text body
 MIME-Version: 1.0
 Content-Type: multipart/alternative; 

--- a/data/public/mime/externalImage01/externalimage01.txt
+++ b/data/public/mime/externalImage01/externalimage01.txt
@@ -1,5 +1,5 @@
 From: foo@example.com
-To: bar@example.com
+To: globaladmin@testdomain.com
 Subject: externalimage01
 Date: Mon, 7 May 2012 13:51:53 -0700 (PDT)
 MIME-Version: 1.0

--- a/data/public/mime/externalImage01/externalimage02.txt
+++ b/data/public/mime/externalImage01/externalimage02.txt
@@ -28,7 +28,7 @@ Received: from sc9-mailhost2.vmware.com (unknown [10.113.161.72])
 	for <jwagner@zimbra.com>; Mon, 27 Feb 2012 03:13:13 -0800 (PST)
 Received: by sc9-mailhost2.vmware.com (Postfix)
 	id A8836B00DB; Mon, 27 Feb 2012 03:13:13 -0800 (PST)
-Delivered-To: jwagner@vmware.com
+Delivered-To: globaladmin@testdomain.com
 Received: from proofpoint-master.vmware.com (sc9-proofpoint-agent-1.vmware.com [10.113.208.31])
 	by sc9-mailhost2.vmware.com (Postfix) with ESMTP id A23E5B00C8
 	for <jwagner@vmware.com>; Mon, 27 Feb 2012 03:13:13 -0800 (PST)
@@ -69,8 +69,8 @@ DKIM-Signature: v=1; a=rsa-sha256; c=simple/simple; d=socialcast.com;
 Date: Mon, 27 Feb 2012 06:13:11 -0500
 From: Andre van der Werff <share@socialcast.com>
 Sender: do-not-reply@socialcast.com
-Reply-To: share@socialcast.com
-To: jwagner@dwer.com
+Reply-To: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Subject: external image test
 Mime-Version: 1.0
 Content-Type: multipart/alternative;

--- a/data/public/mime/jsErrorOnClickingAddToCalendarInNewWindow_Bug49734.txt
+++ b/data/public/mime/jsErrorOnClickingAddToCalendarInNewWindow_Bug49734.txt
@@ -19,7 +19,7 @@ Received: from testdomain.com (testdomain.com [10.18.97.160])
 	for <att@testdomain.com>; Wed, 11 Aug 2010 10:17:09 -0700 (PDT)
 Date: Wed, 11 Aug 2010 10:17:09 -0700 (PDT)
 From: admin@testdomain.com
-To: att@testdomain.com
+To: globaladmin@testdomain.com
 Message-ID: <14386466.8.1281547029321.JavaMail.root@qa60>
 In-Reply-To: <30856257.5.1281547028431.JavaMail.root@qa60>
 Subject: ics attachment from new window

--- a/data/public/mime/largeconversation_mime.txt
+++ b/data/public/mime/largeconversation_mime.txt
@@ -32,10 +32,9 @@ Received: from mbs01-zcs.zimbra.com (mbs01-zcs.zimbra.com [10.113.162.14])
 	Wed,  3 Apr 2013 23:01:33 -0700 (PDT)
 Date: Wed, 3 Apr 2013 23:01:32 -0700 (PDT)
 From: Sandesh Almeida <salmeida@testdomain.com>
-To: Zimbra QE <qa-zimbra@testdomain.com>
-Cc: Matt Rhoades <matt@testdomain.com>
+To: globaladmin@testdomain.com
 Message-ID: <2021142545.190551.1365055292797.JavaMail.zimbra@testdomain.com>
-In-Reply-To: <209816838.42541.1364580964944.JavaMail.root@testdomain.com>
+In-Reply-To: globaladmin@testdomain.com
 References: <142241036.458404.1359633409329.JavaMail.root@testdomain.com> <1575703429.169292.1361418954422.JavaMail.root@testdomain.com> <1463829497.3751.1362050443603.JavaMail.root@testdomain.com> <936447979.189764.1363067791935.JavaMail.root@testdomain.com> <406787213.365523.1363930040985.JavaMail.root@testdomain.com> <2139629384.248179.1364322238505.JavaMail.root@testdomain.com> <1398171235.265600.1364329954623.JavaMail.root@testdomain.com> <209816838.42541.1364580964944.JavaMail.root@testdomain.com>
 Subject: Re: 2013 H1 Goal - RESOLVED BUGS
 MIME-Version: 1.0
@@ -128,7 +127,7 @@ Sandesh
 ----- Original Message -----
 
 From: "Matt Rhoades" <matt@testdomain.com> 
-To: "Zimbra QE" <qa-zimbra@testdomain.com> 
+To: globaladmin@testdomain.com
 Sent: Friday, March 29, 2013 11:46:05 PM 
 Subject: Re: 2013 H1 Goal - RESOLVED BUGS 
 
@@ -192,8 +191,7 @@ Edit this report
 
 
 From: "Matt Rhoades" <matt@testdomain.com> 
-To: "Zimbra QE" <qa-zimbra@testdomain.com> 
-Cc: "Bill Hwang" <bhwang@testdomain.com>, "Sandesh Almeida" <salmeida@testdomain.com> 
+To: globaladmin@testdomain.com
 Sent: Tuesday, 26 March, 2013 1:32:34 PM 
 Subject: Re: 2013 H1 Goal - RESOLVED BUGS 
 
@@ -211,8 +209,7 @@ As a team, we've come a long way from having thousands of backlogged bugs in the
 
 <blockquote>
 From: "Sandesh Almeida" <salmeida@testdomain.com> 
-To: "Zimbra QE" <qa-zimbra@testdomain.com> 
-Cc: "Matt Rhoades" <matt@testdomain.com>, "Bill Hwang" <bhwang@testdomain.com> 
+To: globaladmin@testdomain.com
 Sent: Tuesday, 26 March, 2013 11:23:58 AM 
 Subject: Re: 2013 H1 Goal - RESOLVED BUGS 
 
@@ -317,8 +314,7 @@ Sandesh
 ----- Original Message -----
 
 From: "Sandesh Almeida" <salmeida@testdomain.com> 
-To: "Zimbra QE" <qa-zimbra@testdomain.com> 
-Cc: "Matt Rhoades" <matt@testdomain.com>, "Bill Hwang" <bhwang@testdomain.com> 
+To: globaladmin@testdomain.com
 Sent: Friday, March 22, 2013 10:57:21 AM 
 Subject: Re: 2013 H1 Goal - RESOLVED BUGS 
 
@@ -427,8 +423,7 @@ Sandesh
 ----- Original Message -----
 
 From: "Sandesh Almeida" <salmeida@testdomain.com> 
-To: "Zimbra QE" <qa-zimbra@testdomain.com> 
-Cc: "Matt Rhoades" <matt@testdomain.com>, "Bill Hwang" <bhwang@testdomain.com> 
+To: globaladmin@testdomain.com
 Sent: Tuesday, March 12, 2013 11:26:32 AM 
 Subject: Re: 2013 H1 Goal - RESOLVED BUGS 
 
@@ -2170,7 +2165,7 @@ t:normal;font-style:normal;text-decoration:none;font-family:Helvetica,Arial=
 ,sans-serif;font-size:12pt;" data-mce-style=3D"color: #000; font-weight: no=
 rmal; font-style: normal; text-decoration: none; font-family: Helvetica,Ari=
 al,sans-serif; font-size: 12pt;"><b>From: </b>"Matt Rhoades" &lt;matt@zimbr=
-a.com&gt;<br><b>To: </b>"Zimbra QE" &lt;qa-zimbra@testdomain.com&gt;<br><b>Sent=
+a.com&gt;<br><b>To: globaladmin@testdomain.com<br><b>Sent=
 : </b>Friday, March 29, 2013 11:46:05 PM<br><b>Subject: </b>Re: 2013 H1 Goa=
 l - RESOLVED BUGS<br><div><br></div><div style=3D"font-family: Verdana; fon=
 t-size: 10pt; color: #000099" data-mce-style=3D"font-family: Verdana; font-=
@@ -3233,9 +3228,7 @@ e:normal;text-decoration:none;font-family:Helvetica,Arial,sans-serif;font-s=
 ize:12pt;" data-mce-style=3D"border-left: 2px solid #1010FF; margin-left: 5=
 px; padding-left: 5px; color: #000; font-weight: normal; font-style: normal=
 ; text-decoration: none; font-family: Helvetica,Arial,sans-serif; font-size=
-: 12pt;"><b>From: </b>"Matt Rhoades" &lt;matt@testdomain.com&gt;<br><b>To: </b>=
-"Zimbra QE" &lt;qa-zimbra@testdomain.com&gt;<br><b>Cc: </b>"Bill Hwang" &lt;bhw=
-ang@testdomain.com&gt;, "Sandesh Almeida" &lt;salmeida@testdomain.com&gt;<br><b>Sen=
+: 12pt;"><b>From: </b>"Matt Rhoades" &lt;matt@testdomain.com&gt;<br><b>To: globaladmin@testdomain.com<br><b><br><b>Sen=
 t: </b>Tuesday, 26 March, 2013 1:32:34 PM<br><b>Subject: </b>Re: 2013 H1 Go=
 al - RESOLVED BUGS<br><div><br></div><div style=3D"font-family: Verdana; fo=
 nt-size: 10pt; color: #000099" data-mce-style=3D"font-family: Verdana; font=
@@ -3253,9 +3246,7 @@ ion:none;font-family:Helvetica,Arial,sans-serif;font-size:12pt;" data-mce-s=
 tyle=3D"border-left: 2px solid #1010FF; margin-left: 5px; padding-left: 5px=
 ; color: #000; font-weight: normal; font-style: normal; text-decoration: no=
 ne; font-family: Helvetica,Arial,sans-serif; font-size: 12pt;"><b>From: </b=
->"Sandesh Almeida" &lt;salmeida@testdomain.com&gt;<br><b>To: </b>"Zimbra QE" &l=
-t;qa-zimbra@testdomain.com&gt;<br><b>Cc: </b>"Matt Rhoades" &lt;matt@testdomain.com=
-&gt;, "Bill Hwang" &lt;bhwang@testdomain.com&gt;<br><b>Sent: </b>Tuesday, 26 Ma=
+>"Sandesh Almeida" &lt;salmeida@testdomain.com&gt;<br><b>To: globaladmin@testdomain.com<br><b>Sent: </b>Tuesday, 26 Ma=
 rch, 2013 11:23:58 AM<br><b>Subject: </b>Re: 2013 H1 Goal - RESOLVED BUGS<b=
 r><div><br></div><div style=3D"font-family: verdana,helvetica,sans-serif; f=
 ont-size: 10pt; color: #000000" data-mce-style=3D"font-family: verdana,helv=
@@ -5589,9 +5580,7 @@ yle=3D"color:#000;font-weight:normal;font-style:normal;text-decoration:none=
 ;font-family:Helvetica,Arial,sans-serif;font-size:12pt;" data-mce-style=3D"=
 color: #000; font-weight: normal; font-style: normal; text-decoration: none=
 ; font-family: Helvetica,Arial,sans-serif; font-size: 12pt;"><b>From: </b>"=
-Sandesh Almeida" &lt;salmeida@testdomain.com&gt;<br><b>To: </b>"Zimbra QE" &lt;=
-qa-zimbra@testdomain.com&gt;<br><b>Cc: </b>"Matt Rhoades" &lt;matt@testdomain.com&g=
-t;, "Bill Hwang" &lt;bhwang@testdomain.com&gt;<br><b>Sent: </b>Friday, March 22=
+Sandesh Almeida" &lt;salmeida@testdomain.com&gt;<br><b>To: globaladmin@testdomain.com<br><b>Sent: </b>Friday, March 22=
 , 2013 10:57:21 AM<br><b>Subject: </b>Re: 2013 H1 Goal - RESOLVED BUGS<br><=
 div><br></div><div style=3D"font-family: verdana,helvetica,sans-serif; font=
 -size: 10pt; color: #000000" data-mce-style=3D"font-family: verdana,helveti=
@@ -8059,8 +8048,7 @@ ns-serif;font-size:12pt;" data-mce-style=3D"color: #000; font-weight: norma=
 l; font-style: normal; text-decoration: none; font-family: Helvetica,Arial,=
 sans-serif; font-size: 12pt;"><b>From: </b>"Sandesh Almeida" &lt;salmeida@z=
 imbra.com&gt;<br><b>To: </b>"Zimbra QE" &lt;qa-zimbra@testdomain.com&gt;<br><b>=
-Cc: </b>"Matt Rhoades" &lt;matt@testdomain.com&gt;, "Bill Hwang" &lt;bhwang@zim=
-bra.com&gt;<br><b>Sent: </b>Tuesday, March 12, 2013 11:26:32 AM<br><b>Subje=
+<br><b>Sent: </b>Tuesday, March 12, 2013 11:26:32 AM<br><b>Subje=
 ct: </b>Re: 2013 H1 Goal - RESOLVED BUGS<br><div><br></div><div style=3D"fo=
 nt-family: verdana,helvetica,sans-serif; font-size: 10pt; color: #000000" d=
 ata-mce-style=3D"font-family: verdana,helvetica,sans-serif; font-size: 10pt=

--- a/data/public/mime/msgShowsBlank_Bug42127.txt
+++ b/data/public/mime/msgShowsBlank_Bug42127.txt
@@ -24,7 +24,7 @@ Received: from corp.zimbra.com (mail-archive.zimbra.com [207.126.229.142])
 	by testdomain.com (Postfix) with ESMTP id 1835778401
 	for <candace@testdomain.com>; Mon, 26 Oct 2009 16:41:47 -0700 (PDT)
 From: "Mark Nichols" <mnichols@testdomain.com>
-To: candace@testdomain.com
+To: globaladmin@testdomain.com
 Date: Mon, 26 Oct 2009 16:41:46 -0700 (PDT)
 Subject: Fwd: Bad Link to 6.0 User Guide on Zimbra Site
 In-Reply-To: <63722BBB75A5AC489D42D6EEFBF7B3FED4A4C8@ASHS00053.amers.itestdomain.com>
@@ -66,9 +66,7 @@ Content-Type: text/html; charset=us-ascii
 style="font-family: Times New Roman; font-size: 12pt; color: rgb(0, 0, 0);"
 ><span><br><br><div><div>Mark Nichols<br>Yahoo!/Zimbra Professional
 Services</div></div><br></span><br>----- Forwarded Message -----<br>From:
-"Julie Watson" &lt;jawatson@testdomain.com&gt;<br>To: "Mark Nichols (Zimbra)"
-&lt;mnichols@testdomain.com&gt;<br>Cc: "Lisa Vaughn"
-&lt;lcvaughn@testdomain.com&gt;, "Karen Kirby" &lt;kkirby@testdomain.com&gt;<br
+"Julie Watson" &lt;jawatson@testdomain.com&gt;<br>To: globaladmin@testdomain.com<br><br
 >Sent: Monday, October 26, 2009 2:20:19 PM<br>Subject: Bad Link to 6.0 User
 Guide on Zimbra Site<br><br>
 

--- a/data/public/mime/notAbletoViewRfc822Msg_Bug40561.txt
+++ b/data/public/mime/notAbletoViewRfc822Msg_Bug40561.txt
@@ -24,8 +24,7 @@ Received: from dogfood.zimbra.com (dogfood.zimbra.com [207.126.229.140])
 	Wed, 26 Aug 2009 08:54:19 -0700 (PDT)
 Date: Wed, 26 Aug 2009 08:54:18 -0700 (PDT)
 From: Raja Rao <raja.rao@testdomain.com>
-To: Juan Bocanegra <juan.bocanegra@testdomain.com>
-Cc: se@testdomain.com, Jason Bryan <jbryan@testdomain.com>
+To: globaladmin@testdomain.com
 Message-ID: <853467217.3141251302058811.JavaMail.root@dogfood.zimbra.com>
 In-Reply-To: <75735487.3091251301972578.JavaMail.root@dogfood.zimbra.com>
 Subject: Re: **CORP UPGRADE 8/25**
@@ -59,8 +58,7 @@ http://www.youtube.com/watch?v=ZiJG6fW3leQ
 
 ----- "Juan Bocanegra" <juan.bocanegra@testdomain.com> wrote: 
 | From: "Juan Bocanegra" <juan.bocanegra@testdomain.com> 
-| To: "Jason Bryan" <jbryan@testdomain.com> 
-| Cc: se@testdomain.com, "Raja Rao (raja@testdomain.com)" <raja@testdomain.com> 
+| To: globaladmin@testdomain.com
 | Sent: Wednesday, August 26, 2009 7:52:42 AM 
 | Subject: Re: **CORP UPGRADE 8/25** 
 | 
@@ -232,9 +230,7 @@ br>raja<br><br><font style=3D"color: rgb(102, 102, 102);" size=3D"1">What k=
 ind of world do YOU want?<br>http://www.youtube.com/watch?v=3DZiJG6fW3leQ</=
 font><br></div></div></div></div></div></div><br></span><br>----- "Juan Boc=
 anegra" &lt;juan.bocanegra@testdomain.com&gt; wrote:
-<br>| From: "Juan Bocanegra" &lt;juan.bocanegra@testdomain.com&gt;<br>| To: "Ja=
-son Bryan" &lt;jbryan@testdomain.com&gt;<br>| Cc: se@testdomain.com, "Raja Rao (raj=
-a@testdomain.com)" &lt;raja@testdomain.com&gt;<br>| Sent: Wednesday, August 26, 200=
+<br>| From: "Juan Bocanegra" &lt;juan.bocanegra@testdomain.com&gt;<br>| To: globaladmin@testdomain.com<br>| Sent: Wednesday, August 26, 200=
 9 7:52:42 AM<br>| Subject: Re: **CORP UPGRADE 8/25**<br>|<br>| <style>p { m=
 argin: 0; }</style><div style=3D"font-family: Times New Roman; font-size: 1=
 2pt; color: rgb(0, 0, 0);">| Sorry, I meant to say anything for the account=
@@ -630,7 +626,7 @@ Content-Disposition: attachment
 Date: Mon, 17 Aug 2009 17:20:26 -0700 (PDT)
 From: raja.rao@testdomain.com
 Sender: rrao@testdomain.com
-To: Quanah Gibson-Mount <quanah@testdomain.com>, Ramesh May <ramesh.may@testdomain.com>
+To: globaladmin@testdomain.com
 Message-ID: <969601365.14241250554826177.JavaMail.root@dogfood.zimbra.com>
 In-Reply-To: <705023160.14221250554801408.JavaMail.root@dogfood.zimbra.com>
 Subject: Broadsoft zimlet for demo account on dogfood

--- a/data/public/mime/parsingErrorWhileAcceptingInvite_Bug38564.txt
+++ b/data/public/mime/parsingErrorWhileAcceptingInvite_Bug38564.txt
@@ -23,7 +23,7 @@ Received: from cfdevws02.imt.testdomain.com (cfdevws02.imt.testdomain.com [129.8
 	Wed, 3 Sep 2008 10:29:07 -0500
 Date: Wed, 3 Sep 2008 10:29:07 -0500 (CDT)
 From: mabraham@testdomain.com
-To: mydev@testdomain.com
+To: globaladmin@testdomain.com
 Message-ID: <28849117.9461220455747839.JavaMail.jrun@cfdevws02.imt.testdomain.com>
 Subject: now there is a change . . . Just sending off the correction for the
  event I just reg'd you for

--- a/data/public/mime/unableToOpenMessage_Bug45852.txt
+++ b/data/public/mime/unableToOpenMessage_Bug45852.txt
@@ -20,7 +20,7 @@ Received: from catfood.zimbra.com (catfood.zimbra.com [10.113.63.60])
 	for <mlo@testdomain.com>; Thu,  1 Apr 2010 16:04:54 -0700 (PDT)
 Date: Thu, 1 Apr 2010 16:05:02 -0700 (PDT)
 From: Maria Lo <mlo@testdomain.com>
-To: mlo@testdomain.com
+To: globaladmin@testdomain.com
 Message-ID: <1434244237.8527.1270163102708.JavaMail.root@catfood.zimbra.com>
 Subject: Fwd: attached messages
 MIME-Version: 1.0
@@ -58,9 +58,8 @@ Received: from corp.zimbra.com (corp.zimbra.com [10.113.63.58])
 	Thu,  1 Apr 2010 14:12:27 -0700 (PDT)
 Date: Thu, 1 Apr 2010 14:26:59 -0700 (PDT)
 From: Rick King <rking@testdomain.com>
-Reply-To: support@testdomain.com
-To: Jiho Hahm <jhahm@testdomain.com>
-Cc: support-team@testdomain.com, calendar-team@testdomain.com, support@testdomain.com
+Reply-To: globaladmin@testdomain.com
+To: globaladmin@testdomain.com
 Message-ID: <703314951.134882.1270157219121.JavaMail.root@corp.zimbra.com>
 In-Reply-To: <16255275.20.1269900233146.JavaMail.jhahm@spike.local>
 Subject: Re: SF: Case 00051542:  - Timezone conversion 24 hour error
@@ -83,8 +82,7 @@ Zimbra Support Team
 
 ----- Original Message -----
 From: "Jiho Hahm" <jhahm@testdomain.com>
-To: support@testdomain.com
-Cc: support-team@testdomain.com, calendar-team@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 6:04:01 PM
 Subject: Re: SF: Case 00051542:  - Timezone conversion 24 hour error
 
@@ -95,8 +93,7 @@ Thanks for the data.  It sounds like a JSP client issue.  Can someone from clien
 ----- Original Message -----
 
 From: "Rick King" <rking@testdomain.com>
-To: "Jiho Hahm" <jhahm@testdomain.com>
-Cc: support-team@testdomain.com, calendar-team@testdomain.com, support@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 2:31:05 PM
 Subject: Re: SF: Case 00051542: - Timezone conversion 24 hour error
 
@@ -122,8 +119,7 @@ Zimbra Support Team
 
 ----- Original Message -----
 From: "Jiho Hahm" <jhahm@testdomain.com>
-To: support@testdomain.com
-Cc: support-team@testdomain.com, calendar-team@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 5:10:14 PM
 Subject: Re: SF: Case 00051542: - Timezone conversion 24 hour error
 
@@ -137,9 +133,7 @@ Rick, can you find out a few things for me?
 ----- Original Message -----
 
 From: "Rick King" <rking@testdomain.com>
-To: "Jiho Hahm" <jhahm@testdomain.com>
-Cc: support-team@testdomain.com, calendar-team@testdomain.com,
-support@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 1:47:15 PM
 Subject: Re: SF: Case 00051542: - Timezone conversion 24 hour error
 
@@ -155,8 +149,7 @@ Zimbra Support Team
 
 ----- Original Message -----
 From: "Jiho Hahm" <jhahm@testdomain.com>
-To: support@testdomain.com
-Cc: support-team@testdomain.com, calendar-team@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 2:29:24 PM
 Subject: Re: SF: Case 00051542: - Timezone conversion 24 hour error
 
@@ -169,8 +162,7 @@ showing the wrong date.
 ----- Original Message -----
 
 From: "Rick King" <rking@testdomain.com>
-To: calendar-team@testdomain.com
-Cc: support-team@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 1:11:52 PM
 Subject: Fwd: SF: Case 00051542: - Timezone conversion 24 hour error
 
@@ -250,8 +242,7 @@ Received: from dogfood.zimbra.com (dogfood.zimbra.com [10.113.63.59])
 	Mon, 29 Mar 2010 15:03:15 -0700 (PDT)
 Date: Mon, 29 Mar 2010 15:04:01 -0700 (PDT)
 From: Jiho Hahm <jhahm@testdomain.com>
-To: support@testdomain.com
-Cc: support-team@testdomain.com, calendar-team@testdomain.com
+To: globaladmin@testdomain.com
 Message-ID: <16255275.20.1269900233146.JavaMail.jhahm@spike.local>
 In-Reply-To: <1954326971.96982.1269898265355.JavaMail.root@corp.zimbra.com>
 Subject: Re: SF: Case 00051542:  - Timezone conversion 24 hour error
@@ -267,8 +258,7 @@ Thanks for the data.  It sounds like a JSP client issue.  Can someone from clien
 ----- Original Message -----
 
 From: "Rick King" <rking@testdomain.com>
-To: "Jiho Hahm" <jhahm@testdomain.com>
-Cc: support-team@testdomain.com, calendar-team@testdomain.com, support@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 2:31:05 PM
 Subject: Re: SF: Case 00051542: - Timezone conversion 24 hour error
 
@@ -294,8 +284,7 @@ Zimbra Support Team
 
 ----- Original Message -----
 From: "Jiho Hahm" <jhahm@testdomain.com>
-To: support@testdomain.com
-Cc: support-team@testdomain.com, calendar-team@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 5:10:14 PM
 Subject: Re: SF: Case 00051542: - Timezone conversion 24 hour error
 
@@ -309,9 +298,7 @@ Rick, can you find out a few things for me?
 ----- Original Message -----
 
 From: "Rick King" <rking@testdomain.com>
-To: "Jiho Hahm" <jhahm@testdomain.com>
-Cc: support-team@testdomain.com, calendar-team@testdomain.com,
-support@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 1:47:15 PM
 Subject: Re: SF: Case 00051542: - Timezone conversion 24 hour error
 
@@ -327,8 +314,7 @@ Zimbra Support Team
 
 ----- Original Message -----
 From: "Jiho Hahm" <jhahm@testdomain.com>
-To: support@testdomain.com
-Cc: support-team@testdomain.com, calendar-team@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 2:29:24 PM
 Subject: Re: SF: Case 00051542: - Timezone conversion 24 hour error
 
@@ -341,8 +327,7 @@ showing the wrong date.
 ----- Original Message -----
 
 From: "Rick King" <rking@testdomain.com>
-To: calendar-team@testdomain.com
-Cc: support-team@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Monday, March 29, 2010 1:11:52 PM
 Subject: Fwd: SF: Case 00051542: - Timezone conversion 24 hour error
 

--- a/data/public/mime/url01/invalid_url.txt
+++ b/data/public/mime/url01/invalid_url.txt
@@ -1,5 +1,5 @@
 From: foo@foo.com 
-To: foo@foo.com 
+To: globaladmin@testdomain.com 
 Subject: subject12976223025009
 MIME-Version: 1.0 
 Content-Type: text/plain; charset=utf-8 

--- a/data/public/mime/url01/valid_url.txt
+++ b/data/public/mime/url01/valid_url.txt
@@ -1,5 +1,5 @@
 From: foo@foo.com 
-To: foo@foo.com 
+To: globaladmin@testdomain.com 
 Subject: subject12955323015009
 MIME-Version: 1.0 
 Content-Type: text/plain; charset=utf-8 

--- a/data/public/mime/viewAttachment_Bug37352.txt
+++ b/data/public/mime/viewAttachment_Bug37352.txt
@@ -36,7 +36,7 @@ X-Barracuda-BBL-IP: 130.207.185.140
 X-Barracuda-RBL-IP: 130.207.185.140
 Message-Id: <5260EE25-58D7-4E26-9E41-A152345A441B@testdomain.com>
 From: Matt Sanders <msanders@testdomain.com>
-To: msanders Sanders <msanders@testdomain.com>
+To: globaladmin@testdomain.com
 Content-Type: multipart/mixed; boundary=Apple-Mail-216--304106344
 X-ASG-Orig-Subj: Invitation to Review for the 2009 Convergence Innovation Competition
 Subject: Invitation to Review for the 2009 Convergence Innovation Competition

--- a/data/public/mime/viewEntireMessage_Bug39246.txt
+++ b/data/public/mime/viewEntireMessage_Bug39246.txt
@@ -1,10 +1,5 @@
 From: <matt@testdomain.com>
-To: "'Raja Rao'" <raja.rao@testdomain.com>,
-	"Bill Hwang" <bhwang@testdomain.com>
-Cc: "'suryakant kanada'" <suryakant@testdomain.com>,
-	"'krishnakumar'" <krishnakumar@testdomain.com>,
-	"'Jitesh Sojitra'" <jsojitra@testdomain.com>,
-	"'Prashant Jaiswal'" <pjaiswal@testdomain.com>
+To: globaladmin@testdomain.com
 References: <000001c8002a$743b2a00$fa810a0a@testdomain.com> <1139275496.182791190831291532.JavaMail.root@dogfood.zimbra.com>
 In-Reply-To: <1139275496.182791190831291532.JavaMail.root@dogfood.zimbra.com>
 Subject: Bug39246
@@ -50,8 +45,7 @@ Is the P4 sync server up and running in SF?
 
 From: Raja Rao [mailto:raja.rao@testdomain.com]
 Sent: Wednesday, September 26, 2007 11:28 AM
-To: krishnakumar; Jitesh Sojitra; Prashant Jaiswal
-Cc: suryakant kanada; matt
+To: globaladmin@testdomain.com
 Subject: QTP update:
 
 
@@ -91,7 +85,7 @@ on a btn but the btn is Disabled.
 
 ----- Original Message -----
 From: QTPResultEmail@dogfood.zimbra.com
-To: qa-automation@testdomain.com
+To: globaladmin@testdomain.com
 Sent: Wednesday, September 26, 2007 3:46:11 AM (GMT-0800) 
 America/Los_Angeles
 Subject: QTPResult_FULL_FF2.0(main 5.0.0_RC1.1_1532.RHEL4.NETWORK qa32 
@@ -2689,7 +2683,6 @@ style=3D'font-size:10.0pt;font-family:"Tahoma","sans-serif"'> Raja Rao
 [mailto:raja.rao@testdomain.com] <br>
 <b>Sent:</b> Wednesday, September 26, 2007 11:28 AM<br>
 <b>To:</b> krishnakumar; Jitesh Sojitra; Prashant Jaiswal<br>
-<b>Cc:</b> suryakant kanada; matt<br>
 <b>Subject:</b> QTP update:<o:p></o:p></span></p>
 
 </div>
@@ -2749,7 +2742,7 @@ btn but the btn is Disabled.<br>
 <br>
 ----- Original Message -----<br>
 From: QTPResultEmail@dogfood.zimbra.com<br>
-To: qa-automation@testdomain.com<br>
+To: globaladmin@testdomain.com<br>
 Sent: Wednesday, September 26, 2007 3:46:11 AM (GMT-0800) =
 America/Los_Angeles<br>
 Subject: QTPResult_FULL_FF2.0(main 5.0.0_RC1.1_1532.RHEL4.NETWORK qa32 =


### PR DESCRIPTION
ZCS-4436: Public AWS server won't have relayhost so mailq stucks at mail delivery to uknown user

- Modified mail delivery To: user to avoid mailq issue especially for public server like AWS
- Used globaladmin@testdomain.com which would be created automatically for selenium suite

Note: If any particular mime gives an issue or test fails then will take a look separately considering mass changes.