### PR TITLE
ZCS-4436: Adding non-aws group, excluded tests which restarts server and fixed testcases

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -28,7 +28,7 @@ browser=chrome
 
 # Zimbra server settings
 server.scheme=https
-server.host=zqa-232.eng.zimbra.com
+server.host=zqa-206.eng.zimbra.com
 server.user=root
 server.password=zimbra
 

--- a/conf/config.properties
+++ b/conf/config.properties
@@ -28,7 +28,7 @@ browser=chrome
 
 # Zimbra server settings
 server.scheme=https
-server.host=zqa-206.eng.zimbra.com
+server.host=zqa-232.eng.zimbra.com
 server.user=root
 server.password=zimbra
 

--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -84,6 +84,7 @@ public class ExecuteHarnessMain {
 	public static String testTotalMinutes;
 	protected AbsTab startingPage = null;
 
+	public static String hostname;
 	public static String zimbraVersion = null;
 	public static Boolean isNGEnabled = false;
 	public static Boolean isDLRightGranted = false;
@@ -289,11 +290,18 @@ public class ExecuteHarnessMain {
 			excludeGroups.add("network");
 		}
 
+		// Upload file through file explorer
 		if (OperatingSystem.isWindows() == false || ConfigProperties.getStringProperty("browser").contains("edge")) {
 			excludeGroups.add("upload");
 			excludeGroups.add("non-msedge");
 		}
 
+		// Server restart
+		if (!ConfigProperties.getStringProperty("server.host").endsWith(".zimbra.com")) {
+			excludeGroups.add("non-aws");
+		}
+
+		// NG modules
 		if (CommandLineUtility.runCommandOnZimbraServer(ConfigProperties.getStringProperty("server.host"), "zmprov gs "
 				+ ExecuteHarnessMain.storeServers.get(0)
 				+ " zimbraNetworkModulesNGEnabled | grep -i 'zimbraNetworkModulesNGEnabled' | cut -d : -f 2 | tr -d '[:blank:]'")
@@ -1334,6 +1342,13 @@ public class ExecuteHarnessMain {
 		// Selenium service
 		SeleniumService seleniumService = new SeleniumService();
 
+		// Hostname
+		try {
+			hostname = InetAddress.getLocalHost().getHostName();
+		} catch (UnknownHostException e) {
+			e.printStackTrace();
+		}
+
 		// Harness log
 		StafIntegration.sHarnessLogFileFolderPath = testoutputfoldername + "/debug/projects";
 		StafIntegration.sHarnessLogFilePath = StafIntegration.sHarnessLogFileFolderPath + "/" + StafIntegration.sHarnessLogFileName;
@@ -1355,8 +1370,6 @@ public class ExecuteHarnessMain {
 			logger.info(StafIntegration.logInfo);
 			Files.write(StafIntegration.pHarnessLogFilePath, Arrays.asList(StafIntegration.logInfo),
 					Charset.forName("UTF-8"), StandardOpenOption.APPEND);
-
-
 
 			// Get total zimbra servers
 			logger.info("Get total zimbra servers...");

--- a/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeleniumObject.java
+++ b/src/java/com/zimbra/qa/selenium/framework/ui/AbsSeleniumObject.java
@@ -837,13 +837,11 @@ public abstract class AbsSeleniumObject {
 
 	// Refreshes UI till loading completes successfully
 	public void zRefreshMainUI() throws HarnessException {
-		logger.info("Refresh UI");
+		logger.info("Refresh main UI");
 		webDriver().navigate().refresh();
-
 		zHandleAlert();
 
 		if (ConfigProperties.getAppType().toString().equals("AJAX")) {
-
 			if (ConfigProperties.getStringProperty("server.host").contains("zimbra.com")) {
 				zWaitTillElementPresent(
 						com.zimbra.qa.selenium.projects.ajax.pages.mail.PageMail.Locators.zMailZimletsPane);
@@ -852,11 +850,9 @@ public abstract class AbsSeleniumObject {
 			}
 
 		} else if (ConfigProperties.getAppType().name().equals("ADMIN")) {
-
 			boolean loginPagePresent = false, mainUIPresent = false;
 
 			SleepUtil.sleepSmall();
-
 			for (int i = 0; i <= 15; i++) {
 				if (webDriver().getTitle().contains("502 Bad Gateway") || webDriver().getTitle().contains("404 - Not Found")) {
 					webDriver().get(webDriver().getCurrentUrl());

--- a/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
+++ b/src/java/com/zimbra/qa/selenium/framework/util/ZimbraAccount.java
@@ -331,12 +331,14 @@ public class ZimbraAccount {
 	@SuppressWarnings("serial")
 	private static final Map<String, String> accountAttrs = new HashMap<String, String>() {
 		{
-			if (ConfigProperties.getStringProperty("server.host").contains(".eng.")) {
+			// Timezone
+			if (ExecuteHarnessMain.hostname.contains("zqa")) {
 				put("zimbraPrefTimeZoneId", "America/Chicago");
 			} else {
 				put("zimbraPrefTimeZoneId", "Asia/Kolkata");
 			}
 
+			// Calendar view
 			if (Calendar.getInstance().get(Calendar.DAY_OF_WEEK) == Calendar.SATURDAY
 					|| Calendar.getInstance().get(Calendar.DAY_OF_WEEK) == Calendar.SUNDAY) {
 				put("zimbraPrefCalendarInitialView", "week");

--- a/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/core/AdminCore.java
@@ -100,8 +100,7 @@ public class AdminCore {
 		logger.info("BeforeSuite: start");
 
 		// For coverage ?mode=mjsf&gzip=false
-		if (ConfigProperties.getStringProperty(ConfigProperties.getLocalHost() + ".coverage.enabled",
-				ConfigProperties.getStringProperty("coverage.enabled")).contains("true") == true) {
+		if (ConfigProperties.getStringProperty("coverage.enabled").contains("true") == true) {
 			try {
 				CommandLineUtility.runCommandOnZimbraServer(ExecuteHarnessMain.proxyServers.get(0),
 						"zmprov mcf +zimbraHttpThrottleSafeIPs " + InetAddress.getLocalHost().getHostAddress());

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/certificates/InstallSelfSignedCertificate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/certificates/InstallSelfSignedCertificate.java
@@ -47,7 +47,7 @@ public class InstallSelfSignedCertificate extends AdminCore {
 	 */
 
 	@Test (description = "Install self-signed certificate", priority=5,
-			groups = { "smoke", "L1" })
+			groups = { "smoke", "L1", "non-aws" })
 
 	public void InstallSelfSignedCertificate_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/login/LoginWithCsrfTokenCheckDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/login/LoginWithCsrfTokenCheckDisabled.java
@@ -35,7 +35,7 @@ public class LoginWithCsrfTokenCheckDisabled extends AdminCore {
 
 
 	@Test (description = "Login to the admin console after disabling csrf check", priority=5,
-			groups = { "smoke", "L1" })
+			groups = { "smoke", "L1", "non-aws" })
 
 	public void LoginWithCsrfTokenCheckDisabled_01() throws HarnessException {
 		try {
@@ -82,6 +82,7 @@ public class LoginWithCsrfTokenCheckDisabled extends AdminCore {
 					"zmmailboxdctl restart");
 
 			app.zPageMain.zRefreshMainUI();
+
 			// Open the base URL
 			app.zPageLogin.sOpen(ConfigProperties.getBaseURL());
 			app.zPageLogin.zLogin(gAdmin);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/attributes/ZimbraHelpAdvancedURL.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/attributes/ZimbraHelpAdvancedURL.java
@@ -23,7 +23,6 @@ import com.zimbra.qa.selenium.framework.ui.Button;
 import com.zimbra.qa.selenium.framework.util.CommandLineUtility;
 import com.zimbra.qa.selenium.framework.util.ConfigProperties;
 import com.zimbra.qa.selenium.framework.util.HarnessException;
-import com.zimbra.qa.selenium.framework.util.SleepUtil;
 import com.zimbra.qa.selenium.framework.util.ZAssert;
 import com.zimbra.qa.selenium.framework.util.ZimbraAccount;
 import com.zimbra.qa.selenium.framework.util.ZimbraAdminAccount;
@@ -98,7 +97,7 @@ public class ZimbraHelpAdvancedURL extends AjaxCore {
 			}
 
 			// Check the URL
-			ZAssert.assertTrue(tempURL.contains("/helpUrl/help/adv/advhelp.html"),	"Product Help URL is not as set in zimbraHelpAdvancedURL");
+			ZAssert.assertTrue(tempURL.contains("/helpUrl/help/adv/advhelp.html"), "Product Help URL is not as set in zimbraHelpAdvancedURL");
 
 		} finally {
 
@@ -107,28 +106,6 @@ public class ZimbraHelpAdvancedURL extends AjaxCore {
 					.soapSend("<ModifyDomainRequest xmlns='urn:zimbraAdmin'>" + "<id>" + domainID + "</id>"
 							+ "<a n='zimbraHelpAdvancedURL'>" + url + "</a>" + "<a n='zimbraVirtualHostname'>" + ""
 							+ "</a>" + "</ModifyDomainRequest>");
-
-			// Restart zimbra services
-			CommandLineUtility.runCommandOnZimbraServer(ZimbraAccount.AccountZCS().zGetAccountStoreHost(),
-					"zmmailboxdctl restart");
-
-			SleepUtil.sleepVeryLong();
-			for (int i = 0; i <= 10; i++) {
-				app.zPageLogin.zRefreshMainUI();
-				if (app.zPageLogin.sIsElementPresent("css=input[class^='ZLoginButton']") == true ||
-						app.zPageLogin.sIsElementPresent("css=div[id$='parent-ZIMLET'] td[id$='ZIMLET_textCell']") == true) {
-					break;
-				} else {
-					SleepUtil.sleepLong();
-					if (i == 5) {
-						CommandLineUtility.runCommandOnZimbraServer(ZimbraAccount.AccountZCS().zGetAccountStoreHost(),
-								"zmmailboxdctl restart");
-						SleepUtil.sleepVeryLong();
-					}
-					continue;
-				}
-			}
-
 		}
 	}
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/LoginWithCsrfTokenCheckDisabled.java
@@ -34,7 +34,7 @@ public class LoginWithCsrfTokenCheckDisabled extends AjaxCore {
 
 
 	@Test (description = "Login to the webclient after disabling csrf check", priority=5,
-			groups = { "smoke", "L0" })
+			groups = { "smoke", "L0", "non-aws" })
 
 	public void LoginWithCsrfTokenCheckDisabled_01() throws HarnessException {
 		try {


### PR DESCRIPTION
ZCS-4436: Adding non-aws group, excluded tests which restarts server and fixed testcases

- Introduced non-aws group
- Excluded server restart tests for AWS (if someone else is using AWS server or any other automation is running on)
- Fixed Login_05 testcases which was skipped for one zimbra mail URL