### PR TITLE
Fixed failing L0 and L1 test cases in selenium automation run

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainConversationView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainConversationView.java
@@ -39,7 +39,7 @@ public class TrustedDomainConversationView extends AjaxCore {
 		super.startingAccountPreferences = new HashMap<String, String>() {{
 			put("zimbraPrefGroupMailBy", "conversation");
 			put("zimbraPrefMessageViewHtmlPreferred", "TRUE");
-			put("zimbraPrefMailTrustedSenderList", "testdoamin.com");
+			put("zimbraPrefMailTrustedSenderList", "testdomain.com");
 		} };
 	}
 
@@ -66,7 +66,7 @@ public class TrustedDomainConversationView extends AjaxCore {
 
 		// Verify domain through soap- GetPrefsRequest
 		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference("zimbraPrefMailTrustedSenderList");
-		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdoamin.com"), "Verify doamin is present /Pref/TrustedAddr");
+		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdomain.com"), "Verify doamin is present /Pref/TrustedAddr");
 
 		// Inject the external image message(s)
 		injectMessage(app.zGetActiveAccount(), mimeFile);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainMessageView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedDomainMessageView.java
@@ -35,7 +35,7 @@ public class TrustedDomainMessageView extends AjaxCore {
 		super.startingAccountPreferences = new HashMap<String, String>() {{
 			put("zimbraPrefGroupMailBy", "message");
 			put("zimbraPrefMessageViewHtmlPreferred", "TRUE");
-			put("zimbraPrefMailTrustedSenderList", "testdoamin.com");
+			put("zimbraPrefMailTrustedSenderList", "testdomain.com");
 		}};
 	}
 
@@ -62,7 +62,7 @@ public class TrustedDomainMessageView extends AjaxCore {
 
 		// Verify domain through soap- GetPrefsRequest
 		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference("zimbraPrefMailTrustedSenderList");
-		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdoamin.com"), "Verify doamin is present /Pref/TrustedAddr");
+		ZAssert.assertTrue(PrefMailTrustedAddr.equals("testdomain.com"), "Verify doamin is present /Pref/TrustedAddr");
 
 		// Inject the external image message(s)
 		injectMessage(app.zGetActiveAccount(), mimeFile);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedEmailAddressMessageView.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/preferences/trustedaddresses/TrustedEmailAddressMessageView.java
@@ -35,7 +35,7 @@ public class TrustedEmailAddressMessageView extends AjaxCore {
 		super.startingAccountPreferences = new HashMap<String, String>() {{
 			put("zimbraPrefGroupMailBy", "message");
 			put("zimbraPrefMessageViewHtmlPreferred", "TRUE");
-			put("zimbraPrefMailTrustedSenderList", "admintest@testdoamin.com");
+			put("zimbraPrefMailTrustedSenderList", "admintest@testdomain.com");
 		}};
 	}
 
@@ -62,7 +62,7 @@ public class TrustedEmailAddressMessageView extends AjaxCore {
 
 		// Verify Email id through soap GetPrefsRequest
 		String PrefMailTrustedAddr = ZimbraAccount.AccountZCS().getPreference("zimbraPrefMailTrustedSenderList");
-		ZAssert.assertTrue(PrefMailTrustedAddr.equals("admintest@testdoamin.com"), "Verify Email address is present /Pref/TrustedAddr");
+		ZAssert.assertTrue(PrefMailTrustedAddr.equals("admintest@testdomain.com"), "Verify Email address is present /Pref/TrustedAddr");
 
 		// Inject the external image message(s)
 		injectMessage(app.zGetActiveAccount(), mimeFile);


### PR DESCRIPTION
Fixed domain name in the test cases TrustedDomainConversationView_01 , TrustedDomainMsgView_01(), TrustedEmailAddressMessageView_01()