### PR TITLE
ZCS-4916: Fixed failing test cases related to SMIME

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/core/AjaxCore.java
@@ -153,12 +153,15 @@ public class AjaxCore {
 			ExecuteHarnessMain.isDLRightGranted = true;
 		}
 
-		// Disable zimbraSmimeOCSPEnabled attribute for S/MIME
+		// Disable zimbraSmimeOCSPEnabled attribute for S/MIME	
 		if (!ExecuteHarnessMain.isSmimeOcspDisabled
 				&& this.getClass().getName().contains(ExecuteHarnessMain.SeleniumBasePackage + ".projects.ajax.tests.network.zimlets.smime")) {
 			StafIntegration.logInfo = "Disable zimbraSmimeOCSPEnabled attribute for S/MIME using CLI utility";
 			logger.info(StafIntegration.logInfo);
 			CommandLineUtility.runCommandOnZimbraServer(ConfigProperties.getStringProperty("server.host"), "zmprov mcf zimbraSmimeOCSPEnabled FALSE");
+			for (int i=0; i<ExecuteHarnessMain.storeServers.size(); i++) {
+				CommandLineUtility.runCommandOnZimbraServer(ExecuteHarnessMain.storeServers.get(i), "zmprov ms '" + ExecuteHarnessMain.storeServers.get(i) + "' zimbraSmimeOCSPEnabled FALSE" );
+			}
 			ExecuteHarnessMain.isSmimeOcspDisabled = true;
 		}
 


### PR DESCRIPTION
Fixed below test cases:
1.com.zimbra.qa.selenium.projects.ajax.tests.network.zimlets.smime.mail.QuickReplySignedEncryptedMail.QuickForwardSignedAndEncryptedMail_02 [L1, smoke, network]
2.com.zimbra.qa.selenium.projects.ajax.tests.network.zimlets.smime.mail.QuickReplySignedEncryptedMail.QuickReplySignedMail_01 [L1, smoke, network]
3.com.zimbra.qa.selenium.projects.ajax.tests.network.zimlets.smime.mail.SendSignedMail.SendSignedMail_01 [L0, sanity, network]