### PR TITLE
ZCS-11905: Exclude/deprecate classic client testcases which are migrated from old Selenium to latest TestCafe

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -57,7 +57,7 @@ buildServer=http://zre-matrix.eng.zimbra.com
 driveServer=http://zqa-257.eng.zimbra.com
 
 # Browser drivers
-chromeDriverURL=https://chromedriver.storage.googleapis.com/103.0.5060.53
+chromeDriverURL=https://chromedriver.storage.googleapis.com/104.0.5112.79
 geckoDriverURL=https://github.com/mozilla/geckodriver/releases/download/v0.31.0
 edgeDriverURL=https://msedgedriver.azureedge.net/103.0.1264.37/edgedriver_win64.zip
 

--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -86,6 +86,7 @@ public class ExecuteHarnessMain {
 	public static String hostname;
 	public static String zimbraServer;
 	public static String zimbraVersion = null;
+	public static int zimbraMajorVersion = 0;
 	public static String cmdVersion = null;
 	public static Boolean isNGEnabled = false;
 	public static Boolean isChatConfigured = false;
@@ -286,8 +287,15 @@ public class ExecuteHarnessMain {
 	}
 
 	protected List<XmlSuite> getXmlSuiteList() throws HarnessException {
+		// Exclude/deprecate tests which are migrated from Selenium to TestCafe
+		List<String> zimbraMajorVersionList = Arrays.asList(zimbraVersion.split("\\.")[0]);
+		zimbraMajorVersion = Integer.parseInt(zimbraMajorVersionList.get(0));
+		if (zimbraMajorVersion >= 9) {
+			excludeGroups.add("testcafe");
+		}
+
 		// Add network or foss based on the server version
-		if (ConfigProperties.zimbraGetVersionString().toLowerCase().contains("network")) {
+		if (zimbraVersion.contains("network")) {
 			excludeGroups.add("foss");
 		} else {
 			excludeGroups.add("network");

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/CreateAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/CreateAccount.java
@@ -34,7 +34,7 @@ public class CreateAccount extends AdminCore {
 
 	@Bugs (ids = "100779")
 	@Test (description = "Create a basic account using New->Account",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateAccount_01() throws HarnessException {
 		String accountLastname = "lastname" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/DeleteAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/DeleteAccount.java
@@ -38,7 +38,7 @@ public class DeleteAccount extends AdminCore {
 
 
 	@Test (description = "Delete a basic account -- Manage Account View",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteAccount_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -114,7 +114,7 @@ public class DeleteAccount extends AdminCore {
 
 
 	@Test (description = "Delete a basic account - Search List View",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteAccount_03() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/EditAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/EditAccount.java
@@ -38,7 +38,7 @@ public class EditAccount extends AdminCore {
 
 
 	@Test (description = "Edit Account name  - Manage Account View",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void EditAccount_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/CreateCos.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/CreateCos.java
@@ -37,7 +37,7 @@ public class CreateCos extends AdminCore {
 
 	@Bugs (ids = "100779")
 	@Test (description = "Create a basic COS",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateCos_01() throws HarnessException {
 		// Create a new cos in the Admin Console

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/CreateDomain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/CreateDomain.java
@@ -37,7 +37,7 @@ public class CreateDomain extends AdminCore {
 
 	@Bugs (ids = "58795")
 	@Test (description = "Create basic domain",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateDomain_01() throws HarnessException {
 		// Create a new domain in the Admin Console

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/DeleteDomain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/DeleteDomain.java
@@ -37,7 +37,7 @@ public class DeleteDomain extends AdminCore {
 
 
 	@Test (description = "Verify delete domain operation --  Manage Domain List View",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteDomain_01() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/login/BasicLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/login/BasicLogin.java
@@ -35,7 +35,7 @@ public class BasicLogin extends AdminCore {
 
 
 	@Test (description = "Login to the Admin Console",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void BasicLogin_01() throws HarnessException {
 		// Login

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/CreateMailHtml.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/CreateMailHtml.java
@@ -35,7 +35,7 @@ public class CreateMailHtml extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Send a mail using HTML editor",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateMailHtml_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/CreateFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/CreateFolder.java
@@ -17,6 +17,7 @@
 package com.zimbra.qa.selenium.projects.ajax.tests.mail.folders;
 
 import org.testng.annotations.*;
+
 import com.zimbra.qa.selenium.framework.items.*;
 import com.zimbra.qa.selenium.framework.items.FolderItem.*;
 import com.zimbra.qa.selenium.framework.ui.*;
@@ -35,7 +36,7 @@ public class CreateFolder extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Create a new folder by clicking 'new folder' on folder tree",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateFolder_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/tags/CreateTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/tags/CreateTag.java
@@ -31,7 +31,7 @@ public class CreateTag extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Create a new tag by clicking 'new tag' on folder tree",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateTag_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Login.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Login.java
@@ -41,7 +41,7 @@ public class Login extends AjaxCore {
 
 
 	@Test (description = "Login to the Ajax Client",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void Login_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Logout.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/main/login/Logout.java
@@ -29,7 +29,7 @@ public class Logout extends AjaxCore {
 
 
 	@Test (description = "Logout of the Ajax Client",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void Logout_01() throws HarnessException {
 


### PR DESCRIPTION
- Don't run Ajax client testcases which are migrated from old Selenium to latest TestCafe to avoid running same tests at both place and sticking to single tool.
- Introduced special group 'testcafe' which will exclude tests if zimbra version 9+, we will see 8.8.x later.
- This is just a start and already added framework in TestCafe. Long term plan to use TestCafe single tool but requires high level of efforts and dedicated resources just to do this activity as we have 2000 testcases for Admin and Ajax classic client project in selenium.
- 'testcafe' group testcases won't run in selenium and save execution time.
- Updated chrome driver version.

TestCafe classic client framework and tests:
https://github.com/ZimbraOS/zm-x-web/tree/master/tests/testcafe/tests/classic

Please see migration epic:
[ZCS-11906](https://jira.corp.synacor.com/browse/ZCS-11906) - Migrate Ajax and Admin Testcases from old Selenium to latest TestCafe.