### PR TITLE
ZCS-11905: STAF execution gives version issue due to null value

### DIFF
--- a/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
+++ b/src/java/com/zimbra/qa/selenium/framework/core/ExecuteHarnessMain.java
@@ -288,7 +288,7 @@ public class ExecuteHarnessMain {
 
 	protected List<XmlSuite> getXmlSuiteList() throws HarnessException {
 		// Exclude/deprecate tests which are migrated from Selenium to TestCafe
-		List<String> zimbraMajorVersionList = Arrays.asList(zimbraVersion.split("\\.")[0]);
+		List<String> zimbraMajorVersionList = Arrays.asList(ConfigProperties.zimbraGetVersionString().toLowerCase().split("\\.")[0]);
 		zimbraMajorVersion = Integer.parseInt(zimbraMajorVersionList.get(0));
 		if (zimbraMajorVersion >= 9) {
 			excludeGroups.add("testcafe");


### PR DESCRIPTION
Execution through Java works fine but STAF gives an issue due to different execution order.

```
STAF pnq-jsojitra SERVICE ADD SERVICE SELENIUM LIBRARY JSTAF EXECUTE c:/selenium/zm-selenium/build/dist/ZimbraSeleniumSTAF/jars/ZimbraSeleniumSTAF.jar

jitesh.sojitra@pnq-jsojitra MINGW64 /
$ STAF pnq-jsojitra SELENIUM EXECUTE ROOT c:/selenium/zm-selenium/build/dist/ZimbraSeleniumSTAF JARFILE c:/selenium/zm-selenium/build/dist/ZimbraSeleniumSTAF/jars/ZimbraSelenium.jar PATTERN selenium.projects.admin.tests.accounts.CreateAccount GROUP always GROUP smoke CONFIG c:/selenium/zm-selenium/build/dist/ZimbraSeleniumSTAF/conf/config.properties HOST pnq-jsojitra LOG c:/selenium/zm-selenium/build/dist/ZimbraSeleniumSTAF/Results/20161410ajax/ LOG4j c:/selenium/zm-selenium/build/dist/ZimbraSeleniumSTAF/conf/log4j.properties
Error submitting request, RC: 38
Additional info
---------------
java.lang.NullPointerException: Cannot invoke "String.split(String)" because "com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain.zimbraVersion" is null
        at com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain.getXmlSuiteList(ExecuteHarnessMain.java:291)
        at com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain.executeTests(ExecuteHarnessMain.java:486)
        at com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain.executeSelenium(ExecuteHarnessMain.java:449)
        at com.zimbra.qa.selenium.framework.core.ExecuteHarnessMain.execute(ExecuteHarnessMain.java:398)
        at com.zimbra.qa.selenium.staf.StafIntegration.handleExecute(StafIntegration.java:271)
        at com.zimbra.qa.selenium.staf.StafIntegration.acceptRequest(StafIntegration.java:117)
        at com.ibm.staf.service.STAFServiceHelper.callService(STAFServiceHelper.java:349)
```