### PR TITLE
ZCS-12660: Add testcafe group in selenium for migrated testcases

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/AddAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/AddAlias.java
@@ -37,7 +37,7 @@ public class AddAlias extends AdminCore {
 
 
 	@Test (description = "Edit account - Add Alias at account level ",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void AddAlias_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/DeleteAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/DeleteAccount.java
@@ -76,7 +76,7 @@ public class DeleteAccount extends AdminCore {
 
 
 	@Test (description = "Delete a basic account - Manage Account View/Right Click Menu",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteAccount_02() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -155,7 +155,7 @@ public class DeleteAccount extends AdminCore {
 	}
 
 	@Test (description = "Delete a basic account - Search List View/Right Click Menu",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteAccount_04() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/EditAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/EditAccount.java
@@ -77,7 +77,7 @@ public class EditAccount extends AdminCore {
 
 
 	@Test (description = "Edit account name -- right click",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void EditAccount_02() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -117,7 +117,7 @@ public class EditAccount extends AdminCore {
 
 
 	@Test (description = "Edit a basic account - Search List View",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditAccount_03() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -164,7 +164,7 @@ public class EditAccount extends AdminCore {
 
 
 	@Test (description = "Edit a basic account - Search List View",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditAccount_04() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/GetAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/GetAccount.java
@@ -36,7 +36,7 @@ public class GetAccount extends AdminCore {
 
 
 	@Test (description = "Verify created account is displayed in UI -- Manage Account View.",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void GetAccount_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -68,7 +68,7 @@ public class GetAccount extends AdminCore {
 
 
 	@Test (description = "Verify created account is displayed in UI -- Search list view",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void GetAccount_02() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/NavigateAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/NavigateAccount.java
@@ -31,7 +31,7 @@ public class NavigateAccount extends AdminCore {
 
 
 	@Test (description = "Navigate to Accounts",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateAccount_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageAccounts.zVerifyHeader(PageManageAccounts.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/adminextensions/DeployAdminExtensions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/adminextensions/DeployAdminExtensions.java
@@ -38,7 +38,7 @@ public class DeployAdminExtensions extends AdminCore {
 
 	@Bugs (ids = "ZCS-1059")
 	@Test (description = "Deploy admin extension",
-			groups = { "bhr", "non-zimbrax" })
+			groups = { "bhr", "non-zimbrax", "testcafe" })
 
 	public void DeployAdminExtension_01() throws HarnessException {
 		// Create file item

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/adminextensions/NavigateAdminExtensions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/adminextensions/NavigateAdminExtensions.java
@@ -31,7 +31,7 @@ public class NavigateAdminExtensions extends AdminCore {
 
 
 	@Test (description = "Navigate to Admin Extensions",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateAdminExtensions_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageAdminExtensions.zVerifyHeader(PageManageAdminExtensions.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/adminextensions/UndeployAdminExtensions.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/adminextensions/UndeployAdminExtensions.java
@@ -33,7 +33,7 @@ public class UndeployAdminExtensions extends AdminCore {
 
 
 	@Test (description = "Deploy admin extension",
-			groups = { "bhr", "non-zimbrax" })
+			groups = { "bhr", "non-zimbrax", "testcafe" })
 
 	public void UndeployAdminExtensions_01() throws HarnessException {
 		String adminExtensionName = "de_dieploegers_admin_vacation";

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/advancedstatistics/NavigateAdvancedStatistics.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/advancedstatistics/NavigateAdvancedStatistics.java
@@ -31,7 +31,7 @@ public class NavigateAdvancedStatistics extends AdminCore {
 
 	
 	@Test (description = "Navigate to Advanced Statistics",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 	
 	public void NavigateAdvancedStatistics_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageAdvancedStatistics.zVerifyHeader(PageManageAdvancedStatistics.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/CreateAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/CreateAlias.java
@@ -35,7 +35,7 @@ public class CreateAlias extends AdminCore {
 
 
 	@Test (description = "Create a basic alias",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateAlias_01() throws HarnessException {
 		AccountItem target = new AccountItem("tc" + ConfigProperties.getUniqueString(),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/DeleteAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/DeleteAlias.java
@@ -38,7 +38,7 @@ public class DeleteAlias extends AdminCore {
 
 
 	@Test (description = "Verify delete alias operation  -- Manage alias View",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteAlias_01() throws HarnessException {
 		AccountItem target = new AccountItem("tc" + ConfigProperties.getUniqueString(), ConfigProperties.getStringProperty("testdomain"));
@@ -85,7 +85,7 @@ public class DeleteAlias extends AdminCore {
 
 
 	@Test (description = "Verify delete alias operation-- Manage alias View/Right Click Menu",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteAlias_02() throws HarnessException {
 		AccountItem target = new AccountItem("tc" + ConfigProperties.getUniqueString(), ConfigProperties.getStringProperty("testdomain"));
@@ -132,7 +132,7 @@ public class DeleteAlias extends AdminCore {
 
 
 	@Test (description = "Verify delete alias operation - Search list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteAlias_03() throws HarnessException {
 		AccountItem target = new AccountItem("tc" + ConfigProperties.getUniqueString(), ConfigProperties.getStringProperty("testdomain"));
@@ -182,7 +182,7 @@ public class DeleteAlias extends AdminCore {
 
 
 	@Test (description = "Verify delete alias operation - Search list view/Right Click menu.",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteAlias_04() throws HarnessException {
 		AccountItem target = new AccountItem("tc" + ConfigProperties.getUniqueString(), ConfigProperties.getStringProperty("testdomain"));

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/GetAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/GetAlias.java
@@ -36,7 +36,7 @@ public class GetAlias extends AdminCore {
 
 
 	@Test (description = "Verify alias creation operation -- Manage alias View",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetAlias_01() throws HarnessException {
 		AccountItem target = new AccountItem("tc" + ConfigProperties.getUniqueString(),
@@ -72,7 +72,7 @@ public class GetAlias extends AdminCore {
 
 
 	@Test (description = "Verify created alias is present in the list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void GetAlias_02() throws HarnessException {
 		AccountItem target = new AccountItem("tc" + ConfigProperties.getUniqueString(),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/NavigateAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/NavigateAlias.java
@@ -31,7 +31,7 @@ public class NavigateAlias extends AdminCore {
 
 
 	@Test (description = "Navigate to Aliases",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateAlias_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageAliases.zVerifyHeader(PageManageAliases.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/antispamantivirusactivity/NavigateAntiSpamAntiVirus.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/antispamantivirusactivity/NavigateAntiSpamAntiVirus.java
@@ -31,7 +31,7 @@ public class NavigateAntiSpamAntiVirus extends AdminCore {
 
 
 	@Test (description = "Navigate to Anti-Spam/Anti-Virus Activity",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateAnitSpamAntiVirus_01() throws HarnessException {
 		ZAssert.assertTrue(

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/certificates/NavigateCertificates.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/certificates/NavigateCertificates.java
@@ -31,7 +31,7 @@ public class NavigateCertificates extends AdminCore {
 
 
 	@Test (description = "Navigate to Certificates",
-			groups = { "smoke", "non-zimbrax" })
+			groups = { "smoke", "non-zimbrax", "testcafe" })
 
 	public void NavigateCertificates_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageCertificates.zVerifyHeader(PageManageCertificates.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/certificates/ViewCertificate.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/certificates/ViewCertificate.java
@@ -33,7 +33,7 @@ public class ViewCertificate extends AdminCore {
 
 
 	@Test (description = "Navigate to Certificates",
-			groups = { "bhr", "non-zimbrax" })
+			groups = { "bhr", "non-zimbrax", "testcafe" })
 
 	public void ViewCertificate_01() throws HarnessException {
 		// Go to "Home --> Configure --> Certificates"

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/clientupload/NavigateClientUpload.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/clientupload/NavigateClientUpload.java
@@ -31,7 +31,7 @@ public class NavigateClientUpload extends AdminCore {
 
 
 	@Test (description = "Navigate to Client Upload",
-			groups = { "smoke", "non-zimbrax" })
+			groups = { "smoke", "non-zimbrax", "testcafe" })
 
 	public void NavigateClientUpload_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageClientUpload.zVerifyHeader(PageManageClientUpload.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/DeleteCos.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/DeleteCos.java
@@ -40,7 +40,7 @@ public class DeleteCos extends AdminCore {
 
 
 	@Test (description = "Verify delete cos operation -- Manage cos view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteCos_01() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -76,7 +76,7 @@ public class DeleteCos extends AdminCore {
 
 
 	@Test (description = "Verify delete cos operation -- Manage COS list view/Right click menu",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteCos_02() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -206,7 +206,7 @@ public class DeleteCos extends AdminCore {
 
 
 	@Test (description = "Verify Delete COS operation via tree menu is disabled in search results",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteCos_05() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -232,7 +232,7 @@ public class DeleteCos extends AdminCore {
 
 
 	@Test (description = "Verify Delete COS operation via context option is disabled inn search results",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteCos_06() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/EditCos.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/EditCos.java
@@ -38,7 +38,7 @@ public class EditCos extends AdminCore {
 
 
 	@Test (description = "Edit Cos name  - Manage Cos View",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditCos_01() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -77,7 +77,7 @@ public class EditCos extends AdminCore {
 
 
 	@Test (description = "Edit cos name -- right click",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditCos_02() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -119,7 +119,7 @@ public class EditCos extends AdminCore {
 
 
 	@Test (description = "Edit Cos name  - Search Cos View",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditCos_03() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -167,7 +167,7 @@ public class EditCos extends AdminCore {
 
 
 	@Test (description = "Edit cos name -- right click",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditCos_04() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/GetCos.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/GetCos.java
@@ -34,7 +34,7 @@ public class GetCos extends AdminCore {
 
 
 	@Test (description = "Verify created cos is displayed in UI - Manage COS list view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetCos_01() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -55,7 +55,7 @@ public class GetCos extends AdminCore {
 
 
 	@Test (description = "Verify created cos is displayed in UI - Search list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void GetCos_02() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/NavigateCos.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/NavigateCos.java
@@ -31,7 +31,7 @@ public class NavigateCos extends AdminCore {
 
 
 	@Test (description = "Navigate to Cos",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateCos_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageCOS.zVerifyHeader(PageManageCOS.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/CreateDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/CreateDistributionList.java
@@ -37,7 +37,7 @@ public class CreateDistributionList extends AdminCore {
 
 
 	@Test (description = "Create a basic DL",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateDistributionList_01() throws HarnessException {
 		this.startingPage.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/DeleteDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/DeleteDistributionList.java
@@ -36,7 +36,7 @@ public class DeleteDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify delete operation for distribution list - Manage distribution list view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteDistributionList_01() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -77,7 +77,7 @@ public class DeleteDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify delete operation for distribution list -- Manage distribution list/Right Click Menu",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteDistributionList_02() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/GetDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/GetDistributionList.java
@@ -35,7 +35,7 @@ public class GetDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify created dl is present in the list view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetDistributionList_01() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -68,7 +68,7 @@ public class GetDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify created admin dl is present in the list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void GetDistributionList_02() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -102,7 +102,7 @@ public class GetDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify created dynamic admin dl is present in the list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void GetDistributionList_03() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -137,7 +137,7 @@ public class GetDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify created dl is present in the list view  - Search view",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void GetDistributionList_04() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/NavigateDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/NavigateDistributionList.java
@@ -31,7 +31,7 @@ public class NavigateDistributionList extends AdminCore {
 
 
 	@Test (description = "Navigate to DL",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateDistributionList_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageDistributionList.zVerifyHeader(PageManageDistributionLists.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/DeleteDomain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/DeleteDomain.java
@@ -74,7 +74,7 @@ public class DeleteDomain extends AdminCore {
 
 
 	@Test (description = "Verify delete domain operation",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteDomain_02() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP
@@ -110,7 +110,7 @@ public class DeleteDomain extends AdminCore {
 
 
 	@Test (description = "Verify delete domain alias operation - Manage Domain list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteDomain_03() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");
@@ -164,7 +164,7 @@ public class DeleteDomain extends AdminCore {
 
 
 	@Test (description = "Verify delete domain alias operation - Manage Domain list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteDomain_04() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/EditDomain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/EditDomain.java
@@ -38,7 +38,7 @@ public class EditDomain extends AdminCore {
 
 
 	@Test (description = "Verify edit domain operation --  Manage Domain List View",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditDomain_01() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP
@@ -76,7 +76,7 @@ public class EditDomain extends AdminCore {
 
 
 	@Test (description = "Verify edit domain operation",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditDomain_02() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP
@@ -113,7 +113,7 @@ public class EditDomain extends AdminCore {
 
 
 	@Test (description = "Edit domain name  - Search list View",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void Editdomain_03() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP
@@ -157,7 +157,7 @@ public class EditDomain extends AdminCore {
 
 
 	@Test (description = "Edit domain name -- right click",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void Editdomain_04() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/GetDomain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/GetDomain.java
@@ -36,7 +36,7 @@ public class GetDomain extends AdminCore {
 
 
 	@Test (description = "Verify created domain is present in the domain list view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetDomain_01() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP
@@ -68,7 +68,7 @@ public class GetDomain extends AdminCore {
 
 
 	@Test (description = "Verify get domain alias operation",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void GetDomain_02() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");
@@ -113,7 +113,7 @@ public class GetDomain extends AdminCore {
 
 
 	@Test (description = "Search created domain",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void GetDomain_03() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP
@@ -148,7 +148,7 @@ public class GetDomain extends AdminCore {
 
 
 	@Test (description = "Verify get domain alias operation - Search list view",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void GetDomain_04() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/NavigateDomain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/NavigateDomain.java
@@ -31,7 +31,7 @@ public class NavigateDomain extends AdminCore {
 
 
 	@Test (description = "Navigate to Domain",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateDomain_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageDomains.zVerifyHeader(PageManageDomains.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/downloads/DownloadsTab.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/downloads/DownloadsTab.java
@@ -49,7 +49,7 @@ public class DownloadsTab extends AdminCore {
 	};
 
 	@Test (description = "Verify the Downloads Tab contains the correct download links",
-			groups = { "smoke", "non-zimbrax" })
+			groups = { "smoke", "non-zimbrax", "testcafe" })
 
 	public void DownloadsTab_01() throws HarnessException {
 		for ( String locator : downloadLinkLocators ) {
@@ -74,7 +74,7 @@ public class DownloadsTab extends AdminCore {
 
 	@Bugs (ids = "100755")
 	@Test (description = "Verify the downloads links are accessible",
-			groups = { "smoke", "non-zimbrax" })
+			groups = { "smoke", "non-zimbrax", "testcafe" })
 
 	public void DownloadsTab_02() throws HarnessException {
 		List<String> locators = new ArrayList<String>();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/downloads/NavigateDownloads.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/downloads/NavigateDownloads.java
@@ -35,7 +35,7 @@ public class NavigateDownloads extends AdminCore {
 
 
 	@Test (description = "Navigate to Downloads",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateDownloads_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageDownloads.zVerifyHeader(PageDownloads.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/NavigateGlobalSettings.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/NavigateGlobalSettings.java
@@ -31,7 +31,7 @@ public class NavigateGlobalSettings extends AdminCore {
 
 
 	@Test (description = "Navigate to Global Settings",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateGlobalSettings_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageGlobalSettings.zVerifyHeader(PageManageGlobalSettings.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/VerifyMaximumSizeOfaFileUpload.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/VerifyMaximumSizeOfaFileUpload.java
@@ -33,7 +33,7 @@ public class VerifyMaximumSizeOfaFileUpload extends AdminCore {
 
 	@Bugs (ids = "81323")
 	@Test (description = "Verify field text in Global Settings > General Information = Maximum size of a file uploaded from the desktop (KB):",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void VerifyMaximumSizeOfaFileUpload_01() throws HarnessException {
 		String fileUploadMaxSizeLabel = "Maximum size of a file uploaded from the desktop (KB):";

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/login/BasicLogin.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/login/BasicLogin.java
@@ -47,7 +47,7 @@ public class BasicLogin extends AdminCore {
 
 
 	@Test (description = "Login to the Admin Console as a different Admin Account",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void BasicLogin_02() throws HarnessException {
 		// Create a new AdminAccount

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/mailqueues/NavigateMailQueues.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/mailqueues/NavigateMailQueues.java
@@ -31,7 +31,7 @@ public class NavigateMailQueues extends AdminCore {
 
 
 	@Test (description = "Navigate to Mail Queues",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateMailQueues_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageMailQueues.zVerifyHeader(PageManageMailQueues.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/messagecount/NavigateMessageCount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/messagecount/NavigateMessageCount.java
@@ -31,7 +31,7 @@ public class NavigateMessageCount extends AdminCore {
 
 
 	@Test (description = "Navigate to Message Count",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateMessageCount_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageMessageCount.zVerifyHeader(PageManageMessageCount.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/messagevolume/NavigateMessageVolume.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/messagevolume/NavigateMessageVolume.java
@@ -31,7 +31,7 @@ public class NavigateMessageVolume extends AdminCore {
 
 
 	@Test (description = "Navigate to Message Volume",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateMessageVolume_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageMessageVolume.zVerifyHeader(PageManageMessageVolume.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/migration/NavigateAccountMigration.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/migration/NavigateAccountMigration.java
@@ -31,7 +31,7 @@ public class NavigateAccountMigration extends AdminCore {
 
 
 	@Test (description = "Navigate to Account Migration",
-			groups = { "smoke", "non-zimbrax" })
+			groups = { "smoke", "non-zimbrax", "testcafe" })
 
 	public void NavigateAccountMigration_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageAccountMigration.zVerifyHeader(PageManageAccountMigration.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/navigation/HelpLinks.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/navigation/HelpLinks.java
@@ -32,7 +32,7 @@ public class HelpLinks extends AdminCore {
 
 
 	@Test (description = "Verify Help Center links",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void HelpLinks_01() throws HarnessException {
 		// Navigate to Help > Help links

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/navigation/HomePageLinks.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/navigation/HomePageLinks.java
@@ -38,7 +38,7 @@ public class HomePageLinks extends AdminCore {
 
 
 	@Test (description = "Navigate to Install certificate wizard",
-			groups = { "smoke", "non-zimbrax" })
+			groups = { "smoke", "non-zimbrax", "testcafe" })
 
 	public void NavigateHomePageLinks_01() throws HarnessException {
 		WizardInstallCertificate wizard = (WizardInstallCertificate) app.zPageManageCertificates
@@ -53,7 +53,7 @@ public class HomePageLinks extends AdminCore {
 
 
 	@Test (description = "Navigate to Configure default COS",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateHomePageLinks_02() throws HarnessException {
 		app.zPageMain.sClickAt(Locators.HomeConfigureDefaultCos, "");
@@ -64,7 +64,7 @@ public class HomePageLinks extends AdminCore {
 
 
 	@Test (description = "Navigate to create Domain wizard",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateHomePageLinks_03() throws HarnessException {
 		// Navigate back to home page
@@ -80,7 +80,7 @@ public class HomePageLinks extends AdminCore {
 
 
 	@Test (description = "Navigate to Configure GAL wizard",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateHomePageLinks_04() throws HarnessException {
 		// Navigate back to Home page
@@ -97,7 +97,7 @@ public class HomePageLinks extends AdminCore {
 
 
 	@Test (description = "Navigate to Configure Authentication wizard",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateHomePageLinks_05() throws HarnessException {
 		// Navigate back to Home page
@@ -113,7 +113,7 @@ public class HomePageLinks extends AdminCore {
 
 
 	@Test (description = "Navigate to create account wizard",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateHomePageLinks_06() throws HarnessException {
 		// Navigate back to Home page
@@ -129,7 +129,7 @@ public class HomePageLinks extends AdminCore {
 
 
 	@Test (description = "Navigate to Configure manage accounts",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateHomePageLinks_07() throws HarnessException {
 		// Navigate back to Home page
@@ -141,7 +141,7 @@ public class HomePageLinks extends AdminCore {
 
 
 	@Test (description = "Navigate to migration and co Existance wizard",
-			groups = { "smoke", "non-zimbrax" })
+			groups = { "smoke", "non-zimbrax", "testcafe" })
 
 	public void NavigateHomePageLinks_08() throws HarnessException {
 		// Navigate Back to Home page

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/CreateResource.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/CreateResource.java
@@ -35,7 +35,7 @@ public class CreateResource extends AdminCore {
 
 
 	@Test (description = "Create a basic Location resource",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateResource_01() throws HarnessException {
 		ResourceItem resource = new ResourceItem();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/DeleteResource.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/DeleteResource.java
@@ -38,7 +38,7 @@ public class DeleteResource extends AdminCore {
 
 
 	@Test (description = "Verify delete resource operation -- Manage resource View -- Location",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteResource_01() throws HarnessException {
 		this.startingPage.zNavigateTo();
@@ -88,7 +88,7 @@ public class DeleteResource extends AdminCore {
 
 
 	@Test (description = "Verify delete resource operation -- Manage resource View -- Equipment",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteResource_02() throws HarnessException {
 		this.startingPage.zNavigateTo();
@@ -138,7 +138,7 @@ public class DeleteResource extends AdminCore {
 
 
 	@Test (description = "Verify delete resource operation -- Manage resource View/Right Click Menu -- Location",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteResource_03() throws HarnessException {
 		this.startingPage.zNavigateTo();
@@ -188,7 +188,7 @@ public class DeleteResource extends AdminCore {
 
 
 	@Test (description = "Verify delete resource operation -- Manage resource View/Right Click Menu -- Equipment",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteResource_04() throws HarnessException {
 		// Create a new resource in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/GetResource.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/GetResource.java
@@ -36,7 +36,7 @@ public class GetResource extends AdminCore {
 
 
 	@Test (description = "Verify get resource operation -- Manage resource View -- Location",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void GetResource_01() throws HarnessException {
 		// Create a new resource in the Admin Console using SOAP
@@ -71,7 +71,7 @@ public class GetResource extends AdminCore {
 
 
 	@Test (description = "Search resource",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetResource_02() throws HarnessException {
 		// Create a new resource in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/NavigateResource.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/NavigateResource.java
@@ -31,7 +31,7 @@ public class NavigateResource extends AdminCore {
 
 
 	@Test (description = "Navigate to Resource",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateResource_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageResources.zVerifyHeader(PageManageResources.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/retentionpolicy/CreateRetentionPolicy.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/retentionpolicy/CreateRetentionPolicy.java
@@ -34,7 +34,7 @@ public class CreateRetentionPolicy extends AdminCore {
 
 
 	@Test (description = "Create retention policy",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateRetentionPolicy_01() throws HarnessException {
 		final String policyName = "test_policy" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/retentionpolicy/DeleteRetentionPolicy.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/retentionpolicy/DeleteRetentionPolicy.java
@@ -34,7 +34,7 @@ public class DeleteRetentionPolicy extends AdminCore {
 
 
 	@Test (description = "Delete retention policy",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteRetentionPolicy_01() throws HarnessException {
 		final String policyName = "test_policy" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/retentionpolicy/EditRetentionPolicy.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/retentionpolicy/EditRetentionPolicy.java
@@ -35,7 +35,7 @@ public class EditRetentionPolicy extends AdminCore {
 
 
 	@Test (description = "Edit retention policy",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditRetentionPolicy_01() throws HarnessException {
 		final String policyName = "test_policy" + ConfigProperties.getUniqueString();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/GlobalHomeSearch.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/GlobalHomeSearch.java
@@ -41,7 +41,7 @@ public class GlobalHomeSearch extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of COS",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void HomeSearchFunctionalityCOS_01() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -78,7 +78,7 @@ public class GlobalHomeSearch extends AdminCore {
 
 	@Bugs (ids = "96768")
 	@Test (description = "Verify search functionality of Account",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void HomeSearchFunctionalityAccount_02() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -114,7 +114,7 @@ public class GlobalHomeSearch extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of Resource",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void HomeSearchFunctionalityResource_03() throws HarnessException {
 		// Create a new resource in the Admin Console using SOAP
@@ -154,7 +154,7 @@ public class GlobalHomeSearch extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of DL",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void HomeSearchFunctionalityDL_04() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -191,7 +191,7 @@ public class GlobalHomeSearch extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of Alias",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void HomeSearchFunctionalityAlias_05() throws HarnessException {
 		AccountItem target = new AccountItem("tc" + ConfigProperties.getUniqueString(), ConfigProperties.getStringProperty("testdomain"));
@@ -230,7 +230,7 @@ public class GlobalHomeSearch extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of domain",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void HomeSearchFunctionalityDomain_06() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/NavigateSearch.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/NavigateSearch.java
@@ -31,7 +31,7 @@ public class NavigateSearch extends AdminCore {
 
 
 	@Test (description = "Navigate to Search",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateSearch_01() throws HarnessException {
 		// Verify navigation path -- "Home --> Search --> Search --> All Results"
@@ -65,7 +65,7 @@ public class NavigateSearch extends AdminCore {
 
 
 	@Test (description = "Navigate to Search",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateSearch_02() throws HarnessException {
 		// Verify navigation path -- "Home --> Search --> Search Options --> Basci Attributes"
@@ -127,7 +127,7 @@ public class NavigateSearch extends AdminCore {
 
 
 	@Test (description = "Navigate to Search",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateSearch_03() throws HarnessException {
 		// Verify navigation path -- "Home --> Search --> Saved Searches --> Inactive Accounts (90 days)"

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/SearchFunctionality.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/SearchFunctionality.java
@@ -37,7 +37,7 @@ public class SearchFunctionality extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of all results",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void SearchFunctionality_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -69,7 +69,7 @@ public class SearchFunctionality extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of accounts",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void SearchFunctionality_02() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -102,7 +102,7 @@ public class SearchFunctionality extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of DL",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void SearchFunctionality_03() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -135,7 +135,7 @@ public class SearchFunctionality extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of Domain",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void SearchFunctionality_04() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP
@@ -167,7 +167,7 @@ public class SearchFunctionality extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of locked out accounts",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void SearchFunctionality_05() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -200,7 +200,7 @@ public class SearchFunctionality extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of non-active accounts",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void SearchFunctionality_06() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -233,7 +233,7 @@ public class SearchFunctionality extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of admin accounts",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void SearchFunctionality_07() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -286,7 +286,7 @@ public class SearchFunctionality extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of closed accounts",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void SearchFunctionality_08() throws HarnessException {
 		// Create a new closed account in the Admin Console using SOAP
@@ -319,7 +319,7 @@ public class SearchFunctionality extends AdminCore {
 
 
 	@Test (description = "Verify search functionality of maintenance accounts",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void SearchFunctionality_09() throws HarnessException {
 		// Create a new maintenance account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/distributionlists/DeleteDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/distributionlists/DeleteDistributionList.java
@@ -36,7 +36,7 @@ public class DeleteDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify delete operation for distribution list - Search distribution list view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteDistributionList_01() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -80,7 +80,7 @@ public class DeleteDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify delete operation for distribution list - Search distribution list view/Right Click Menu.",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteDistributionList_02() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/domains/DeleteDomain.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/domains/DeleteDomain.java
@@ -36,7 +36,7 @@ public class DeleteDomain extends AdminCore {
 
 
 	@Test (description = "Verify delete domain operation is absent from leftclick > gear icon --  Search List View",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteDomain_01() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP
@@ -65,7 +65,7 @@ public class DeleteDomain extends AdminCore {
 
 
 	@Test (description = " Verify delete domain operation is disabled -- Search List View/Right Click Menu",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteDomain_02() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP
@@ -92,7 +92,7 @@ public class DeleteDomain extends AdminCore {
 
 
 	@Test (description = "Verify delete domain alias operation is disabled- Search list view.",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteDomain_03() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");
@@ -133,7 +133,7 @@ public class DeleteDomain extends AdminCore {
 
 
 	@Test (description = "Verify delete domain alias operation is disabled- Search list view.",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteDomain_04() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/resources/DeleteResource.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/resources/DeleteResource.java
@@ -38,7 +38,7 @@ public class DeleteResource extends AdminCore {
 
 
 	@Test (description = "Verify delete resource operation -- Search List View -- Location",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteResource_01() throws HarnessException {
 		this.startingPage.zNavigateTo();
@@ -90,7 +90,7 @@ public class DeleteResource extends AdminCore {
 
 
 	@Test (description = "Verify delete resource operation -- Search List View -- Equipment",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteResource_02() throws HarnessException {
 		// Create a new resource in the Admin Console using SOAP
@@ -140,7 +140,7 @@ public class DeleteResource extends AdminCore {
 
 
 	@Test (description = "Verify delete resource operation -- Search List View/Right Click Menu -- Location",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteResource_03() throws HarnessException {
 		this.startingPage.zNavigateTo();
@@ -192,7 +192,7 @@ public class DeleteResource extends AdminCore {
 
 
 	@Test (description = "Verify delete resource operation -- Search List View/Right Click Menu -- Equipment",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteResource_04() throws HarnessException {
 		this.startingPage.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/servers/EditServer.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/servers/EditServer.java
@@ -39,7 +39,7 @@ public class EditServer extends AdminCore {
 
 	@Bugs (ids = "ZCS-8706")
 	@Test (description = "Edit Server from gear menu option",
-			groups = { "bhr-application-bug" })
+			groups = { "bhr-application-bug", "testcafe" })
 
 	public void EditServer_01() throws HarnessException {
 		String storeServer = ExecuteHarnessMain.storeServers.get(0);

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/servers/NavigateServers.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/servers/NavigateServers.java
@@ -30,7 +30,7 @@ public class NavigateServers extends AdminCore {
 	}
 
 	@Test (description = "Navigate to Servers",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateServers_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageServers.zVerifyHeader(PageManageServers.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/serverstatistics/NavigateServerStatistics.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/serverstatistics/NavigateServerStatistics.java
@@ -31,7 +31,7 @@ public class NavigateServerStatistics extends AdminCore {
 
 
 	@Test (description = "Navigate to Server Statistics",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateServerStatistics_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageServerStatistics.zVerifyHeader(PageManageServerStatistics.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/serverstatus/NavigateServerStatus.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/serverstatus/NavigateServerStatus.java
@@ -31,7 +31,7 @@ public class NavigateServerStatus extends AdminCore {
 
 
 	@Test (description = "Navigate to Server Status",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateServerStatus_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageServerStatus.zVerifyHeader(PageManageServerStatus.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/softwareupdates/NavigateSoftwareUpdates.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/softwareupdates/NavigateSoftwareUpdates.java
@@ -31,7 +31,7 @@ public class NavigateSoftwareUpdates extends AdminCore {
 
 
 	@Test (description = "Navigate to Software Updates",
-			groups = { "smoke", "non-zimbrax" })
+			groups = { "smoke", "non-zimbrax", "testcafe" })
 
 	public void NavigateAccountMigration_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageSoftwareUpdates.zVerifyHeader(PageManageSoftwareUpdates.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/zimlets/DeployZimlet.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/zimlets/DeployZimlet.java
@@ -38,7 +38,7 @@ public class DeployZimlet extends AdminCore {
 
 
 	@Test (description = "Deploy Zimlet",
-			groups = { "bhr", "non-zimbrax" })
+			groups = { "bhr", "non-zimbrax", "testcafe" })
 
 	public void DeployZimlet_01() throws HarnessException {
 		// Create file item

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/zimlets/NavigateZimlets.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/zimlets/NavigateZimlets.java
@@ -31,7 +31,7 @@ public class NavigateZimlets extends AdminCore {
 
 
 	@Test (description = "Navigate to Zimlets",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void NavigateZimlets_01() throws HarnessException {
 		ZAssert.assertTrue(app.zPageManageZimlets.zVerifyHeader(PageManageZimlets.Locators.HOME),

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/CreateDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/CreateDocument.java
@@ -118,7 +118,7 @@ public class CreateDocument extends EnableBriefcaseFeature {
 
 	@Bugs (ids = "81299")
 	@Test (description = "Create document using New menu pulldown menu - verify through SOAP & RestUtil",
-			groups = { "bhr", "non-msedge" })
+			groups = { "bhr", "non-msedge", "testcafe" })
 
 	public void CreateDocument_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/DeleteDocument.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/document/DeleteDocument.java
@@ -112,7 +112,7 @@ public class DeleteDocument extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Create document through SOAP - delete using Delete Key & verify through GUI",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteDocument_02() throws HarnessException {
 
@@ -164,7 +164,7 @@ public class DeleteDocument extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Create document through SOAP - delete using Right Click context menu & verify through GUI",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteDocument_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DeleteFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/DeleteFile.java
@@ -42,7 +42,7 @@ public class DeleteFile extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Upload file through RestUtil - delete & verify through GUI",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteFile_01() throws HarnessException {
 
@@ -86,7 +86,7 @@ public class DeleteFile extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Upload file through RestUtil - delete using Delete Key & check trash",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteFile_02() throws HarnessException {
 
@@ -143,7 +143,7 @@ public class DeleteFile extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Upload file through RestUtil - delete using Right Click context menu",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteFile_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/MoveFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/MoveFile.java
@@ -42,7 +42,7 @@ public class MoveFile extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Upload file through RestUtil - move & verify through GUI",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void MoveFile_01() throws HarnessException {
 
@@ -104,7 +104,7 @@ public class MoveFile extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Move File using 'm' keyboard shortcut",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void MoveFile_02() throws HarnessException {
 		ZimbraAccount account = app.zGetActiveAccount();
@@ -176,7 +176,7 @@ public class MoveFile extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Upload file through RestUtil - move using Right Click Context Menu & verify through GUI",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void MoveFile_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UploadFile.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/file/UploadFile.java
@@ -74,7 +74,7 @@ public class UploadFile extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Upload file through GUI - verify through GUI",
-			groups = { "smoke", "upload" })
+			groups = { "smoke", "upload", "testcafe" })
 
 	public void UploadFile_02() throws HarnessException {
 
@@ -113,7 +113,7 @@ public class UploadFile extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Upload file through RestUtil - verify through SOAP",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void UploadFile_03() throws HarnessException {
 		ZimbraAccount account = app.zGetActiveAccount();

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/CreateFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/CreateFolder.java
@@ -37,7 +37,7 @@ public class CreateFolder extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Create a new folder by clicking 'Create a new briefcase' on folders tree",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateFolder_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/DeleteFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/DeleteFolder.java
@@ -34,7 +34,7 @@ public class DeleteFolder extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Delete a briefcase sub-folder - Right click, Delete",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteFolder_01() throws HarnessException {
 
@@ -71,7 +71,7 @@ public class DeleteFolder extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Delete a a top level briefcase folder - Right click, Delete",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteFolder_02() throws HarnessException {
 
@@ -111,7 +111,7 @@ public class DeleteFolder extends EnableBriefcaseFeature {
 
 	@Bugs (ids = "80600")
 	@Test (description = "Delete a briefcase sub-folder from list view and hitting toolbar delete button",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteFolder_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/EditProperties.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/folders/EditProperties.java
@@ -34,7 +34,7 @@ public class EditProperties extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Edit Properties - Rename folder using context menu",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditProperties_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/CreateTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/CreateTag.java
@@ -33,7 +33,7 @@ public class CreateTag extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Create a new tag by clicking 'new tag' on folder tree",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateTag_01() throws HarnessException {
 
@@ -59,7 +59,7 @@ public class CreateTag extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Create a new tag using keyboard shortcuts",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void CreateTag_02() throws HarnessException {
 
@@ -98,7 +98,7 @@ public class CreateTag extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Create a new tag using context menu on a tag",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void CreateTag_03() throws HarnessException {
 
@@ -141,7 +141,7 @@ public class CreateTag extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Create a new tag using briefcase app New -> New Tag",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void CreateTag_04() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/DeleteTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/DeleteTag.java
@@ -34,7 +34,7 @@ public class DeleteTag extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Delete a tag - Right click, Delete",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DeleteTag_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/RenameTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/briefcase/tags/RenameTag.java
@@ -35,7 +35,7 @@ public class RenameTag extends EnableBriefcaseFeature {
 
 
 	@Test (description = "Rename a tag - Right click, Rename",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void RenameTag_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/toaster/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/toaster/CreateAppointment.java
@@ -32,7 +32,7 @@ public class CreateAppointment extends AjaxCore {
 	
 	
 	@Test (description = "Verify Toaster message on Create Appointment",
-			groups = { "bhr" } )
+			groups = { "bhr", "testcafe" } )
 	
 	public void Toaster_CreateAppointment_01() throws HarnessException {
 		

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/CreateAppointment.java
@@ -45,7 +45,7 @@ public class CreateAppointment extends AjaxCore {
 
 
 	@Test (description = "Create a basic appointment without an attendee in day view",
-			groups = { "smoke" } )
+			groups = { "smoke", "testcafe" } )
 
 	public void CreateAppointment_01() throws HarnessException {
 
@@ -75,7 +75,7 @@ public class CreateAppointment extends AjaxCore {
 
 
 	@Test (description = "Create appointment with all the fields and verify it in day view",
-			groups = { "sanity" } )
+			groups = { "sanity", "testcafe" } )
 
 	public void CreateAppointment_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/DeleteAppointment.java
@@ -43,7 +43,7 @@ public class DeleteAppointment extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "Delete an appointment using Delete toolbar button in day view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteAppointment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/GetAppointment.java
@@ -38,7 +38,7 @@ public class GetAppointment extends AjaxCore {
 	
 	@Bugs (ids = "69132")
 	@Test (description = "View a basic appointment in day view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 	
 	public void GetAppointment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/ModifyAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/day/singleday/ModifyAppointment.java
@@ -48,7 +48,7 @@ public class ModifyAppointment extends AjaxCore {
 	
 	@Bugs (ids = "69132")
 	@Test (description = "Modify appointment with subject & body and verify it in day view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 	
 	public void ModifyAppointment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/list/GetAppointment.java
@@ -42,7 +42,7 @@ public class GetAppointment extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "View a basic appointment in the list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 	
 	public void GetAppointment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/singleday/SingleDayAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/month/singleday/SingleDayAppointment.java
@@ -43,7 +43,7 @@ public class SingleDayAppointment extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "Verify the display of a basic appointment in the month view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void SingleDayAppointment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/CreateAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/CreateAppointment.java
@@ -36,7 +36,7 @@ public class CreateAppointment extends AjaxCore {
 
 
 	@Test (description = "Create a basic appointment without an attendee",
-			groups = { "bhr" } )
+			groups = { "bhr", "testcafe" } )
 
 	public void CreateAppointment_01() throws HarnessException {
 
@@ -66,7 +66,7 @@ public class CreateAppointment extends AjaxCore {
 
 
 	@Test (description = "Create appointment with all the fields and verify it",
-			groups = { "bhr" } )
+			groups = { "bhr", "testcafe" } )
 
 	public void CreateAppointment_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/DeleteAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/DeleteAppointment.java
@@ -36,7 +36,7 @@ public class DeleteAppointment extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "Delete an appointment using Delete toolbar button",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteAppointment_01() throws HarnessException {
 
@@ -81,7 +81,7 @@ public class DeleteAppointment extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "Delete an appointment using context menu",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteAppointment_02() throws HarnessException {
 
@@ -132,7 +132,7 @@ public class DeleteAppointment extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "Delete an appointment using delete keyboard shortcut key",
-			groups = { "sanity" },
+			groups = { "sanity", "testcafe" },
 			dataProvider = "DataProviderShortcutKeys")
 
 	public void DeleteAppointment_03(String name, int keyEvent) throws HarnessException {

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/GetAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/GetAppointment.java
@@ -32,7 +32,7 @@ public class GetAppointment extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "View a basic appointment in the work week view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetAppointment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/ModifyAppointment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/appointments/views/workweek/singleday/ModifyAppointment.java
@@ -40,7 +40,7 @@ public class ModifyAppointment extends AjaxCore {
 	
 	@Bugs (ids = "69132")
 	@Test (description = "Modify appointment with subject & body and verify it",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void ModifyAppointment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/CreateCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/CreateCalendar.java
@@ -36,7 +36,7 @@ public class CreateCalendar extends AjaxCore {
 
 
 	@Test (description = "Create a new calendar by clicking 'new folder' on folder tree",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateCalendar_01() throws HarnessException {
 
@@ -58,7 +58,7 @@ public class CreateCalendar extends AjaxCore {
 
 
 	@Test (description = "Create a new calendar using keyboard shortcuts",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void CreateCalendar_02() throws HarnessException {
 
@@ -81,7 +81,7 @@ public class CreateCalendar extends AjaxCore {
 
 
 	@Test (description = "Create a new folder using context menu from root folder",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void CreateCalendar_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/DeleteCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/DeleteCalendar.java
@@ -32,7 +32,7 @@ public class DeleteCalendar extends AjaxCore {
 
 
 	@Test (description = "Delete a calendar - Right click, Delete",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteCalendar_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/GetCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/folders/GetCalendar.java
@@ -34,7 +34,7 @@ public class GetCalendar extends AjaxCore {
 
 
 	@Test (description = "Get a calendar (under USER_ROOT)",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetCalendar_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/CancelMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/CancelMeeting.java
@@ -39,7 +39,7 @@ public class CancelMeeting extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "Cancel meeting using Delete toolbar button",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CancelMeeting_01() throws HarnessException {
 
@@ -111,7 +111,7 @@ public class CancelMeeting extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "Cancel meeting using delete keyboard shortcut key",
-			groups = { "sanity"},
+			groups = { "sanity", "testcafe" },
 			dataProvider = "DataProviderShortcutKeys")
 
 	public void CancelMeeting_02(String name, int keyEvent) throws HarnessException {
@@ -234,7 +234,7 @@ public class CancelMeeting extends AjaxCore {
 
 	@Bugs (ids = "69132")
 	@Test (description = "Cancel appointment without modifying cancellation message content",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void CancelMeeting_04() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/MoveMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/MoveMeeting.java
@@ -35,7 +35,7 @@ public class MoveMeeting extends AjaxCore {
 
 
 	@Test (description = "Move meeting invite using toolbar menu as organizer",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void MoveMeeting_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/create/CreateMeeting.java
@@ -40,7 +40,7 @@ public class CreateMeeting extends AjaxCore {
 
 	@Bugs (ids = "95899,95900,46442")
 	@Test (description = "Create basic meeting invite with one attendee",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateMeeting_01() throws HarnessException {
 
@@ -99,7 +99,7 @@ public class CreateMeeting extends AjaxCore {
 
 
 	@Test (description = "Verify new appointment creation is based on mail compose preference set to TEXT",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateMeeting_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/modify/ModifyByAddingAttendees.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/modify/ModifyByAddingAttendees.java
@@ -37,7 +37,7 @@ public class ModifyByAddingAttendees extends AjaxCore {
 
 	@Bugs (ids = "77590,77588,77364")
 	@Test (description = "Modify meeting by adding more attendee and send updates only to added/removed attendees",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void ModifyMeetingByAddingAttendees_01() throws HarnessException {
 
@@ -103,7 +103,7 @@ public class ModifyByAddingAttendees extends AjaxCore {
 
 	@Bugs (ids = "77590,77588,77364")
 	@Test (description = "Modify meeting by adding more attendee and send updates to all attendees",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void ModifyMeetingByAddingAttendees_02() throws HarnessException {
 
@@ -191,7 +191,7 @@ public class ModifyByAddingAttendees extends AjaxCore {
 
 	@Bugs (ids = "56295")
 	@Test (description = "Add an attendee to an existing appointment and send modified invite to all",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void ModifyMeetingByAddingAttendees_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/modify/ModifyByChangingTime.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/modify/ModifyByChangingTime.java
@@ -35,7 +35,7 @@ public class ModifyByChangingTime extends AjaxCore {
 
 	@Bugs (ids = "102759")
 	@Test (description = "Rescheduled appointments do not show the correct time in the summary",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void ModifyByChangingTime_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/modify/ModifyCalendar.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/calendar/meetings/organizer/singleday/modify/ModifyCalendar.java
@@ -37,7 +37,7 @@ public class ModifyCalendar extends AjaxCore {
 
 	@Bugs (ids = "102771")
 	@Test (description = "Modify meeting calendar",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void ModifyMeetingCalendar_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/CreateContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/CreateContact.java
@@ -41,7 +41,7 @@ public class CreateContact extends AjaxCore {
 
 
 	@Test (description = "Create a basic contact item by click New in page Addressbook ",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void ClickContact_01() throws HarnessException {
 
@@ -74,7 +74,7 @@ public class CreateContact extends AjaxCore {
 	}
 
 	@Test (description = "Create a basic contact item by use PullDown Menu->Contacts",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void CreateContactFromPulldownMenu_02() throws HarnessException {
 
@@ -194,7 +194,7 @@ public class CreateContact extends AjaxCore {
 
 
 	@Test (description = "Create a contact item with all attributes",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void CreateContactWithAllAttributes_06() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/DeleteContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/DeleteContact.java
@@ -39,7 +39,7 @@ public class DeleteContact extends AjaxCore  {
 
 
 	@Test (description = "Delete a contact item",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void ClickDeleteOnToolbar_01() throws HarnessException {
 
@@ -78,7 +78,7 @@ public class DeleteContact extends AjaxCore  {
 
 
 	@Test (description = "Delete a contact item selected with checkbox",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteContactSelectedWithCheckbox_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/MoveContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/MoveContact.java
@@ -34,7 +34,7 @@ public class MoveContact extends AjaxCore {
 
 
 	@Test (description = "Move a contact item to sub addressbook by click tool bar Move",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void MoveContact_01() throws HarnessException {
 
@@ -66,7 +66,7 @@ public class MoveContact extends AjaxCore {
 
 
 	@Test (description = "Move a contact item to sub addressbook by click shortcut m",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void MoveContact_02() throws HarnessException {
 
@@ -102,7 +102,7 @@ public class MoveContact extends AjaxCore {
 
 
 	@Test (description = "Move a contact item to sub addressbook by click Move on context menu",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void MoveContact_03() throws HarnessException {
 
@@ -139,7 +139,7 @@ public class MoveContact extends AjaxCore {
 
 
 	@Test (description = "Move a contact item to trash folder by expand Move dropdown on toolbar, then select Trash",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void MoveContact_04() throws HarnessException {
 
@@ -166,7 +166,7 @@ public class MoveContact extends AjaxCore {
 
 
 	@Test (description = "Move a contact item to Emailed Contacts by expand Move dropdown on toolbar, then select Trash",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void MoveContact_05() throws HarnessException {
 
@@ -193,7 +193,7 @@ public class MoveContact extends AjaxCore {
 
 
 	@Test (description = "Move a contact item to sub addressbook. Click toolbar Edit then Location",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void MoveContact_06() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/ViewContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/contacts/ViewContact.java
@@ -86,7 +86,7 @@ public class ViewContact extends AjaxCore  {
 
 	// Last, First
 	@Test (description = "View a contact, file as Last, First",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void FileAsLastFirst_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/CreateFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/CreateFolder.java
@@ -32,7 +32,7 @@ public class CreateFolder extends AjaxCore {
 
 
 	@Test (description = "Create a new folder by clicking 'new folder' on folder tree",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void ClickNewFolderOnFolderTree_01() throws HarnessException {
 
@@ -52,7 +52,7 @@ public class CreateFolder extends AjaxCore {
 
 
 	@Test (description = "Create a new folder using context menu from root folder",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void ClickContextMenuNewAddressbook_02() throws HarnessException {
 
@@ -75,7 +75,7 @@ public class CreateFolder extends AjaxCore {
 
 
 	@Test (description = "Create a new folder using context menu from root folder",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateSubFolderUnderContactsClickContextMenuNewAddressbook_03() throws HarnessException {
 
@@ -102,7 +102,7 @@ public class CreateFolder extends AjaxCore {
 
 
 	@Test (description = "Create a new folder using   New -> New Addressbook",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void ClickMenuNewNewAddressbook_04() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/DeleteFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/DeleteFolder.java
@@ -34,7 +34,7 @@ public class DeleteFolder extends AjaxCore {
 
 
 	@Test (description = "Delete a top level addressbook - Right click, Delete",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteTopLevelFolderFromContextmenu_01() throws HarnessException {
 
@@ -61,7 +61,7 @@ public class DeleteFolder extends AjaxCore {
 
 
 	@Test (description = "Delete a sub folder - Right click, Delete",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteSubFolderFromContextmenu_02() throws HarnessException {
 
@@ -118,7 +118,7 @@ public class DeleteFolder extends AjaxCore {
 
 	@Bugs (ids = "103601")
 	@Test (description = "Delete an addressbook folder- Use shortcut Del",
-			groups = { "application-bug"})
+			groups = { "application-bug" })
 
 	public void UseShortcutDel_04() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/RenameFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/folders/RenameFolder.java
@@ -33,7 +33,7 @@ public class RenameFolder extends AjaxCore {
 
 
 	@Test (description = "Rename a folder - Context menu -> Rename",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void SelectFolderRenameOnContextMenu_01() throws HarnessException {
 
@@ -67,7 +67,7 @@ public class RenameFolder extends AjaxCore {
 
 
 	@Test (description = "Rename a sub folder - Context menu -> Rename",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void SelectSubFolderRenameOnContextMenu_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/CreateTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/CreateTag.java
@@ -32,7 +32,7 @@ public class CreateTag extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Create a new tag by clicking 'new tag' on folder tree",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateTag_01() throws HarnessException {
 
@@ -56,7 +56,7 @@ public class CreateTag extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Create a new tag using keyboard shortcuts",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void CreateTag_02() throws HarnessException {
 
@@ -82,7 +82,7 @@ public class CreateTag extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Create a new tag using context menu from a tag",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void CreateTag_03() throws HarnessException {
 
@@ -122,7 +122,7 @@ public class CreateTag extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Create a new tag using mail app New -> New Tag",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateTag_04() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/DeleteTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/DeleteTag.java
@@ -32,7 +32,7 @@ public class DeleteTag extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Delete a tag - Right click, Delete",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteTag_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/RenameTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/tags/RenameTag.java
@@ -33,7 +33,7 @@ public class RenameTag extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Rename a tag - Right click, Rename",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void RenameTag_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/CreateContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/CreateContact.java
@@ -35,7 +35,7 @@ public class CreateContact extends AjaxCore {
 
 
 	@Test (description = "Create a basic contact item by click New in page Addressbook and verify toast message",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void CreateContact_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/CreateContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/CreateContactGroup.java
@@ -36,7 +36,7 @@ public class CreateContactGroup extends AjaxCore {
 
 
 	@Test (description = "Create a basic contact group with 2 addresses.  New -> Contact Group and verify toast message",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void CreateContactGroup_01() throws HarnessException {
 
@@ -70,7 +70,7 @@ public class CreateContactGroup extends AjaxCore {
 
 
 	@Test (description = "Create a contact group with existing contacts and verify toast message",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void CreateContactGroup_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/DeleteContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/DeleteContact.java
@@ -40,7 +40,7 @@ public class DeleteContact extends AjaxCore {
 
 
 	@Test (description = "Delete a contact item from toolbar and verify toast message",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void DeleteContact_01() throws HarnessException {
 
@@ -73,7 +73,7 @@ public class DeleteContact extends AjaxCore {
 
 
 	@Test (description = "Delete a contact item selected with checkbox and  verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteContact_02() throws HarnessException {
 
@@ -112,7 +112,7 @@ public class DeleteContact extends AjaxCore {
 	}
 
 	@Test (description = "Delete a contact item using keyboard short cut Del and verify toast mesg",
-			groups = { "functional"}, dataProvider = "DataProviderDeleteKeys")
+			groups = { "functional-skip" }, dataProvider = "DataProviderDeleteKeys")
 
 	public void DeleteContact_03(String name, Keys keyEvent) throws HarnessException {
 
@@ -145,7 +145,7 @@ public class DeleteContact extends AjaxCore {
 
 
 	@Test (description = "Right click then click delete and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteContact_04() throws HarnessException {
 
@@ -175,7 +175,7 @@ public class DeleteContact extends AjaxCore {
 
 
 	@Test (description = "Delete multiple contact items and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteContact_05() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/DeleteContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/DeleteContactGroup.java
@@ -41,7 +41,7 @@ public class DeleteContactGroup extends AjaxCore {
 
 
 	@Test (description = "Delete a contact group by click Delete button on toolbar and verify toast message",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void DeleteContactGroup_01() throws HarnessException {
 
@@ -87,7 +87,7 @@ public class DeleteContactGroup extends AjaxCore {
 
 
 	@Test (description = "Delete a contact group selected by checkbox by click Delete button on toolbar and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteContactGroup_03() throws HarnessException {
 
@@ -107,7 +107,7 @@ public class DeleteContactGroup extends AjaxCore {
 
 
 	@Test (description = "Delete a contact group use shortcut Del and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteContactGroup_04() throws HarnessException {
 
@@ -132,7 +132,7 @@ public class DeleteContactGroup extends AjaxCore {
 
 	@Bugs (ids = "78829")
 	@Test (description = "Delete multiple contact groups at once and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteContactGroup_05() throws HarnessException {
 
@@ -160,7 +160,7 @@ public class DeleteContactGroup extends AjaxCore {
 
 
 	@Test (description = "Delete contact + contact group at once and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteContactGroup_06() throws HarnessException {
 
@@ -187,7 +187,7 @@ public class DeleteContactGroup extends AjaxCore {
 
 
 	@Test (description = "Move a contact group to folder Trash by expand Move dropdown then select Trash and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteContactGroup_07() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/EditContact.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/EditContact.java
@@ -33,7 +33,7 @@ public class EditContact extends AjaxCore {
 
 
 	@Test (description = "Edit a contact item, click Edit on toolbar and verify toast message",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void EditContact_01() throws HarnessException {
 
@@ -71,7 +71,7 @@ public class EditContact extends AjaxCore {
 
 
 	@Test (description = "Edit a contact item, Right click then click Edit and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void EditContact_02() throws HarnessException {
 
@@ -107,7 +107,7 @@ public class EditContact extends AjaxCore {
 
 
 	@Test (description = "Edit a contact item, double click the contact and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void EditContact_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/EditContactGroup.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/contacts/toaster/EditContactGroup.java
@@ -36,7 +36,7 @@ public class EditContactGroup extends AjaxCore {
 
 	@Bugs (ids = "97157")
 	@Test (description = "Edit a contact group by click Edit on Toolbar button and verify toast message",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void EditContactGroup_01() throws HarnessException {
 
@@ -77,7 +77,7 @@ public class EditContactGroup extends AjaxCore {
 
 	@Bugs (ids = "97157")
 	@Test (description = "Edit a contact group by click Edit Group on Context Menu and verify toast message",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void EditContactGroup_02() throws HarnessException {
 
@@ -114,7 +114,7 @@ public class EditContactGroup extends AjaxCore {
 
 	@Bugs (ids = "97157")
 	@Test (description = "Edit a contact group by double click on the contact group and verify toast message  ",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void EditContactGroup_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToBriefcase.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/AddToBriefcase.java
@@ -42,7 +42,7 @@ public class AddToBriefcase extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Add JPG attachment to Briefcase when viewing email in the current window",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void AddToBriefcase_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/GetAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/attachments/GetAttachment.java
@@ -39,7 +39,7 @@ public class GetAttachment extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Receive a message with one attachment",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetAttachment_01() throws HarnessException {
 
@@ -119,7 +119,7 @@ public class GetAttachment extends SetGroupMailByMessagePreference {
 
 	@Bugs (ids = "60769")
 	@Test (description = "Receive a message with an inline attachment",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetAttachment_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/CreateMailWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/attachments/CreateMailWithAttachment.java
@@ -38,7 +38,7 @@ public class CreateMailWithAttachment extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Send a mail by adding attachment",
-			groups = { "smoke", "upload" })
+			groups = { "smoke", "upload", "testcafe" })
 
 	public void CreateMailWithAttachment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/CreateMailWithInlineImageAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/compose/inlineimage/CreateMailWithInlineImageAttachment.java
@@ -36,7 +36,7 @@ public class CreateMailWithInlineImageAttachment extends SetGroupMailByMessagePr
 
 
 	@Test (description = "Send a mail by adding inline image attachment",
-			groups = { "smoke", "upload" })
+			groups = { "smoke", "upload", "testcafe" })
 
 	public void CreateMailWithInlineImageAttachment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/conversations/DeleteConversation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/conversation/conversations/DeleteConversation.java
@@ -35,7 +35,7 @@ public class DeleteConversation extends SetGroupMailByConversationPreference {
 
 
 	@Test (description = "Delete a conversation",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteConversation_01() throws HarnessException {
 
@@ -101,7 +101,7 @@ public class DeleteConversation extends SetGroupMailByConversationPreference {
 	}
 
 	@Test (description = "Delete a conversation by selecting and typing 'delete' keyboard",
-			groups = { "sanity" },
+			groups = { "sanity", "testcafe" },
 			dataProvider = "DataProviderDeleteKeys")
 
 	public void DeleteConversation_03(String name, Keys keyEvent) throws HarnessException {
@@ -130,7 +130,7 @@ public class DeleteConversation extends SetGroupMailByConversationPreference {
 
 
 	@Test (description = "Delete a conversation by selecting and typing '.t' shortcut",
-			groups = { "functional" } )
+			groups = { "functional-skip" } )
 
 	public void DeleteConversation_04() throws HarnessException {
 
@@ -198,7 +198,7 @@ public class DeleteConversation extends SetGroupMailByConversationPreference {
 
 
 	@Test (description = "Delete a mail using context menu delete button",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteConversation_06() throws HarnessException {
 
@@ -425,7 +425,7 @@ public class DeleteConversation extends SetGroupMailByConversationPreference {
 
 	@Bugs (ids = "82704")
 	@Test (description = "Delete a conversation (1 message) that receives a new message : Right click -> Delete",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteConversation_10() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/CreateFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/CreateFolder.java
@@ -54,7 +54,7 @@ public class CreateFolder extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Create a new folder using keyboard shortcuts",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void CreateFolder_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/DeleteFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/DeleteFolder.java
@@ -31,7 +31,7 @@ public class DeleteFolder extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Delete a folder - Right click, Delete",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteFolder_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/GetFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/GetFolder.java
@@ -33,7 +33,7 @@ public class GetFolder extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Get a folder",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetFolder_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/RenameFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/folders/RenameFolder.java
@@ -36,7 +36,7 @@ public class RenameFolder extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Rename a folder - Context menu -> Rename",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void RenameFolder_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DeleteMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/DeleteMail.java
@@ -39,7 +39,7 @@ public class DeleteMail extends SetGroupMailByMessagePreference {
 
 	@Bugs (ids = "98054")
 	@Test (description = "Delete a mail using toolbar delete button",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteMail_01() throws HarnessException {
 
@@ -137,7 +137,7 @@ public class DeleteMail extends SetGroupMailByMessagePreference {
 	}
 
 	@Test (description = "Delete a mail by selecting and typing 'delete' keyboard",
-			groups = { "sanity" },
+			groups = { "sanity", "testcafe" },
 			dataProvider = "DataProviderDeleteKeys")
 
 	public void DeleteMail_03(String name, Keys keyEvent) throws HarnessException {
@@ -184,7 +184,7 @@ public class DeleteMail extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Delete a mail by selecting and typing '.t' shortcut",
-			groups = { "functional" } )
+			groups = { "functional-skip" } )
 
 	public void DeleteMail_04() throws HarnessException {
 
@@ -312,7 +312,7 @@ public class DeleteMail extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Delete a mail using context menu delete button",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DeleteMail_06() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/GetMail.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/GetMail.java
@@ -36,7 +36,7 @@ public class GetMail extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Receive a mail",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetMail_01() throws HarnessException {
 
@@ -118,7 +118,7 @@ public class GetMail extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Receive an html mail - verify mail contents",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetMail_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/MoveMessage.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/mail/mail/MoveMessage.java
@@ -45,7 +45,7 @@ public class MoveMessage extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Move a mail by selecting message, then clicking toolbar 'Move' button",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void MoveMail_01() throws HarnessException {
 
@@ -96,7 +96,7 @@ public class MoveMessage extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Move a mail by selecting message, then click 'm' shortcut",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void MoveMail_02() throws HarnessException {
 
@@ -154,7 +154,7 @@ public class MoveMessage extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Move a mail by using 'move to trash' shortcut '.t'",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void MoveMail_03() throws HarnessException {
 
@@ -197,7 +197,7 @@ public class MoveMessage extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Move a mail by using 'move to inbox' shortcut '.i'",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void MoveMail_04() throws HarnessException {
 
@@ -256,7 +256,7 @@ public class MoveMessage extends SetGroupMailByMessagePreference {
 
 
 	@Test (description = "Move a mail by using Move -> New folder",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void MoveMail_05() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/CreateHtmlTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/CreateHtmlTask.java
@@ -56,7 +56,7 @@ public class CreateHtmlTask extends AjaxCore {
 
 
 	@Test (description = "Create Simple Html task through GUI - verify through soap",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateHtmlTask_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/CreateTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/CreateTask.java
@@ -46,7 +46,7 @@ public class CreateTask extends AjaxCore {
 
 
 	@Test (description = "Create Simple task through GUI - verify through soap",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateTask_01() throws HarnessException {
 
@@ -106,7 +106,7 @@ public class CreateTask extends AjaxCore {
 
 
 	@Test (description = "Create task using New menu pulldown  - verify through SOAP",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateTask_03() throws HarnessException {
 
@@ -166,7 +166,7 @@ public class CreateTask extends AjaxCore {
 
 
 	@Test (description = "Create Tasks, using 'Right Click' Mail subject -> 'Create Task'-Verify through Soap",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateTask_05() throws HarnessException {
 
@@ -209,7 +209,7 @@ public class CreateTask extends AjaxCore {
 
 
 	@Test (description = "Create Simple task with attachment through RestUtil - verify through GUI",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateTask_06() throws HarnessException {
 
@@ -315,7 +315,7 @@ public class CreateTask extends AjaxCore {
 	}
 
 	@Test (description = "Create a task with different priorities high/normal/low",
-			groups = { "bhr"},	dataProvider = "DataProvidePriorities")
+			groups = { "bhr", "testcafe" },	dataProvider = "DataProvidePriorities")
 
 	public void CreateTask_08(Button option, String verify) throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/DeleteTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/DeleteTask.java
@@ -43,7 +43,7 @@ public class DeleteTask extends AjaxCore {
 
 
 	@Test (description = "Delete a task using toolbar delete button",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteTask_01() throws HarnessException {
 
@@ -158,7 +158,7 @@ public class DeleteTask extends AjaxCore {
 	}
 
 	@Test (description = "Delete a task by selecting and typing 'delete' keyboard",
-			groups = { "bhr"},
+			groups = { "bhr", "testcafe" },
 			dataProvider = "DataProviderDeleteKeys")
 
 	public void DeleteTask_03(String name, Keys keyEvent) throws HarnessException {
@@ -216,7 +216,7 @@ public class DeleteTask extends AjaxCore {
 
 	@Bugs (ids = "56467")
 	@Test (description = "Delete a task by selecting and typing '.t' shortcut",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteTask_04() throws HarnessException {
 
@@ -373,7 +373,7 @@ public class DeleteTask extends AjaxCore {
 
 
 	@Test (description = "Delete a task using context menu delete button",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteTask_06() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/EditTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/EditTask.java
@@ -52,7 +52,7 @@ public class EditTask extends AjaxCore{
 
 
 	@Test (description = "Create task through SOAP - edit subject and verify through GUI",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditTask_01() throws HarnessException {
 
@@ -134,7 +134,7 @@ public class EditTask extends AjaxCore{
 
 	@Bugs (ids = "64647")
 	@Test (description = "Create task through SOAP - edit due date >> Refresh task >>verify Due Date in list view through GUI",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditTask_02() throws HarnessException {
 
@@ -191,7 +191,7 @@ public class EditTask extends AjaxCore{
 
 
 	@Test (description = "Create task through SOAP - Edit task using Right Click Context Menu & verify through GUI",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditTask_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/GetTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/GetTask.java
@@ -44,7 +44,7 @@ public class GetTask extends AjaxCore {
 
 
 	@Test (description = "View a simple task",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void GetTask_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/HardDeleteTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/HardDeleteTask.java
@@ -44,7 +44,7 @@ public class HardDeleteTask extends AjaxCore {
 
 	@Bugs (ids = "61625")
 	@Test (description = "Hard-delete a task by selecting and typing 'shift-del' shortcut",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void HardDeleteTask_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/MoveTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/MoveTask.java
@@ -44,7 +44,7 @@ public class MoveTask extends AjaxCore {
 
 
 	@Test (description = "Create task through SOAP - move & verify through GUI",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void MoveTask_01() throws HarnessException {
 
@@ -125,7 +125,7 @@ public class MoveTask extends AjaxCore {
 
 
 	@Test (description = "Move a task by selecting task, then click 'm' shortcut",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void MoveTask_02() throws HarnessException {
 
@@ -209,7 +209,7 @@ public class MoveTask extends AjaxCore {
 
 
 	@Test (description = "Create task through SOAP - move using Right Click Context Menu & verify through GUI",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void MoveTask_03() throws HarnessException {
 
@@ -294,7 +294,7 @@ public class MoveTask extends AjaxCore {
 
 
 	@Test (description = "Move a task by using Move -> New folder & verify through GUI",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void MoveTask_04() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/attachments/CreateTaskWithAttachment.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/attachments/CreateTaskWithAttachment.java
@@ -44,7 +44,7 @@ public class CreateTaskWithAttachment extends SetGroupMailByMessagePreference {
 
 	@Bugs (ids = "104231")
 	@Test (description = "Create task with attachment",
-			groups = { "smoke", "upload" })
+			groups = { "smoke", "upload", "testcafe" })
 
 	public void CreateTaskWithAttachment_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/folders/CreateTaskFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/folders/CreateTaskFolder.java
@@ -50,7 +50,7 @@ public class CreateTaskFolder extends AjaxCore {
 
 
 	@Test (description = "Create a new tasklist by clicking 'Create a new task' on task folders tree",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateTaskFolder_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/folders/DeleteTaskFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/folders/DeleteTaskFolder.java
@@ -42,7 +42,7 @@ public class DeleteTaskFolder extends AjaxCore {
 
 
 	@Test (description = "Delete Task list - right click delete",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteTaskFolder_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/folders/RenameTaskFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/folders/RenameTaskFolder.java
@@ -48,7 +48,7 @@ public class RenameTaskFolder extends AjaxCore {
 
 
 	@Test (description = "Rename Task list -right click Rename",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void RenameTaskFolder_01() throws HarnessException {
 
@@ -129,7 +129,7 @@ public class RenameTaskFolder extends AjaxCore {
 
 
 	@Test (description = "Rename Task list -right click Edit, Change name(Context menu -> Edit)",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void RenameTaskFolder_03() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/CreateTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/CreateTag.java
@@ -33,7 +33,7 @@ public class CreateTag extends AjaxCore {
 
 
 	@Test (description = "Create a new tag by clicking 'new tag' on Task page",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateTag_01() throws HarnessException {
 
@@ -56,7 +56,7 @@ public class CreateTag extends AjaxCore {
 
 
 	@Test (description = "Create a new tag using keyboard shortcuts on Task page",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateTag_02() throws HarnessException {
 
@@ -87,7 +87,7 @@ public class CreateTag extends AjaxCore {
 
 
 	@Test (description = "Create a new tag using context menu from a tag",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateTag_03() throws HarnessException {
 
@@ -127,7 +127,7 @@ public class CreateTag extends AjaxCore {
 
 
 	@Test (description = "Create a new tag using task app New -> Tag",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateTag_04() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/DeleteTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/DeleteTag.java
@@ -43,7 +43,7 @@ public class DeleteTag extends AjaxCore {
 
 
 	@Test (description = "Delete a tag - Right click, Delete",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void DeleteTag_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/RenameTag.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/RenameTag.java
@@ -35,7 +35,7 @@ public class RenameTag extends AjaxCore {
 
 
 	@Test (description = "Rename a tag - Right click, Rename",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void RenameTag_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/TagTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/TagTask.java
@@ -39,7 +39,7 @@ public class TagTask extends AjaxCore{
 
 
 	@Test (description = "Tag a Task using Toolbar -> Tag -> New Tag",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void TagTask_01() throws HarnessException {
 		FolderItem taskFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Tasks);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/UnTagTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/tags/UnTagTask.java
@@ -33,7 +33,7 @@ public class UnTagTask extends AjaxCore {
 
 
 	@Test (description = "Remove a tag from a Document using Toolbar -> Tag -> Remove Tag",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void UnTagTask_01() throws HarnessException {
 		FolderItem taskFolder = FolderItem.importFromSOAP(app.zGetActiveAccount(), SystemFolder.Tasks);

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/CreateTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/CreateTask.java
@@ -41,7 +41,7 @@ public class CreateTask extends AjaxCore {
 
 
 	@Test (description = "Verify Toaster message on Create Task",
-			groups = { "bhr" })
+			groups = { "bhr-skip" })
 
 	public void CreateTask_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/DeleteTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/DeleteTask.java
@@ -43,7 +43,7 @@ public class DeleteTask extends AjaxCore {
 
 
 	@Test (description = "Delete a task using toolbar delete button and Verify Toast message through GUI",
-			groups = { "bhr" })
+			groups = { "bhr-skip" })
 
 	public void DeleteTaskToast_01() throws HarnessException {
 
@@ -88,7 +88,7 @@ public class DeleteTask extends AjaxCore {
 
 
 	@Test (description = "Delete a task using checkbox and toolbar delete button-Verify Toast message through GUI",
-			groups = { "bhr" })
+			groups = { "bhr-skip" })
 
 	public void DeleteTaskToast_02() throws HarnessException {
 
@@ -141,7 +141,7 @@ public class DeleteTask extends AjaxCore {
 	}
 
 	@Test (description = "Delete a task by selecting and typing 'delete' keyboard-Verify Toast message through GUI",
-			groups = { "functional"},
+			groups = { "functional-skip" },
 			dataProvider = "DataProviderDeleteKeys")
 
 	public void DeleteTaskToast_03(String name, Keys keyEvent) throws HarnessException {
@@ -190,7 +190,7 @@ public class DeleteTask extends AjaxCore {
 
 	@Bugs (ids = "56467")
 	@Test (description = "Delete a task by selecting and typing '.t' shortcut : Verify Toast message through GUI",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteTaskToast_04() throws HarnessException {
 
@@ -236,7 +236,7 @@ public class DeleteTask extends AjaxCore {
 
 
 	@Test (description = "Delete multiple tasks (3) by select and toolbar delete : Verify Toast message through GUI",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteTaskToast_05() throws HarnessException {
 
@@ -322,7 +322,7 @@ public class DeleteTask extends AjaxCore {
 
 
 	@Test (description = "Delete a task using context menu delete button:Verify Toast message through GUI",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void DeleteTaskToast_06() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/EditTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/EditTask.java
@@ -47,7 +47,7 @@ public class EditTask extends AjaxCore{
 
 
 	@Test (description = "Unchecked Attachment from edit window and - verify Toast message",
-			groups = { "bhr" })
+			groups = { "bhr-skip" })
 
 	public void EditTaskToast_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/MoveTask.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/tasks/toaster/MoveTask.java
@@ -39,7 +39,7 @@ public class MoveTask extends AjaxCore {
 
 
 	@Test (description = "Verify Toaster message on moving Task",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void MoveTask_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/conversation/ArchiveConversation.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/conversation/ArchiveConversation.java
@@ -31,7 +31,7 @@ public class ArchiveConversation extends ArchiveZimletByConversationTest {
 
 
 	@Test (description = "Archive a conversation",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void ArchiveConversation_01() throws HarnessException {
 
@@ -59,7 +59,7 @@ public class ArchiveConversation extends ArchiveZimletByConversationTest {
 
 	@Bugs (ids = "89122")
 	@Test (description = "Archive a single message in a conversation",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void ArchiveConversation_02() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/conversation/SetArchiveFolder.java
+++ b/src/java/com/zimbra/qa/selenium/projects/ajax/tests/zimlets/archive/conversation/SetArchiveFolder.java
@@ -31,7 +31,7 @@ public class SetArchiveFolder extends SetGroupMailByConversationPreference {
 
 
 	@Test (description = "On clicking 'Archive', client should prompt to set the archive folder",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void SetArchiveFolder_01() throws HarnessException {
 


### PR DESCRIPTION
- Add "testcafe" group for TestCafe migrated tests which won't run in Selenium to avoid duplicate.

- New framework, admin console and classic web client testcases added in TestCafe:
https://github.com/ZimbraOS/zm-frontend-automation/pull/1
https://github.com/ZimbraOS/zm-frontend-automation/pull/2
https://github.com/ZimbraOS/zm-frontend-automation/pull/3
https://github.com/ZimbraOS/zm-frontend-automation/pull/4