### PR TITLE
ZCS-11906: Add testcafe group for migrated tests

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/ChangePassword.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/ChangePassword.java
@@ -37,7 +37,7 @@ public class ChangePassword extends AdminCore {
 
 
 	@Test (description = "Edit password  -- manage account > Gearbox > edit account > change password",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void ChangePassword_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -78,7 +78,7 @@ public class ChangePassword extends AdminCore {
 
 
 	@Test (description = "Edit password  -- manage account > right click > change password",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void ChangePassword_02() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/EditFeatures.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/EditFeatures.java
@@ -37,7 +37,7 @@ public class EditFeatures extends AdminCore {
 
 
 	@Test (description = "Edit account - Edit features",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditFeatures_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/EditPreferences.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/EditPreferences.java
@@ -37,7 +37,7 @@ public class EditPreferences extends AdminCore {
 
 
 	@Test (description = "Edit account - Edit preferences at account level",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditPreferences_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/GetAccount.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/GetAccount.java
@@ -103,7 +103,7 @@ public class GetAccount extends AdminCore {
 
 
 	@Test (description = "Verify that system accounts such as spam/ham, wiki and galsync accounts are not displayed in the list.",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void GetAccount_03() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP
@@ -157,7 +157,7 @@ public class GetAccount extends AdminCore {
 
 
 	@Test (description = "Verify system accounts i.e. spam/ham, wiki, galsync account is displayed in Search list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void GetAccount_04() throws HarnessException {
 		// Enter the search string to find the account

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/InvalidateSession.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/InvalidateSession.java
@@ -38,7 +38,7 @@ public class InvalidateSession extends AdminCore {
 
 
 	@Test (description = " Invalidate Session  -- manage account >> Gearbox >> edit account >>  Invalidate Session",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void InvalidateSession_01() throws HarnessException {
 		// Create a new account in the admin Console using SOAP
@@ -70,7 +70,7 @@ public class InvalidateSession extends AdminCore {
 
 	@Bugs (ids = "74482")
 	@Test (description = "Invalidate Session -- manage account > right click > Invalidate Session",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void InvalidateSession_02() throws HarnessException {
 		// Create a new account in the admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/ResetPassword.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/ResetPassword.java
@@ -38,7 +38,7 @@ public class ResetPassword extends AdminCore {
 
 	@Bugs (ids = "72655")
 	@Test (description = "Edit password  -- manage account > Select account > Options > Edit > change password",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void ResetPassword_01() throws HarnessException {
 		// Create admin account

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/EditAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/aliases/EditAlias.java
@@ -37,7 +37,7 @@ public class EditAlias extends AdminCore {
 
 
 	@Test (description = "Edit a basic alias",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditAlias_01() throws HarnessException {
 		AccountItem target = new AccountItem("tc" + ConfigProperties.getUniqueString(), ConfigProperties.getStringProperty("testdomain"));
@@ -70,7 +70,7 @@ public class EditAlias extends AdminCore {
 
 	@Bugs (ids = "58191")
 	@Test (description = "Bug 58191 - JavaScript error while clicking on alias of resource",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditAlias_02() throws HarnessException {
 		// Create calendar resource

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/DuplicateCos.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/DuplicateCos.java
@@ -36,7 +36,7 @@ public class DuplicateCos extends AdminCore {
 
 
 	@Test (description = "Verify Duplicate cos operation -- Manage cos view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void DuplicateCos_01() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -74,7 +74,7 @@ public class DuplicateCos extends AdminCore {
 
 
 	@Test (description = "Verify Duplicate cos operation -- Search COS list view/Right click menu",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void DuplicateCos_02() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/EditFeatures.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/EditFeatures.java
@@ -36,7 +36,7 @@ public class EditFeatures extends AdminCore {
 
 
 	@Test (description = "Edit COS - Edit features",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditFeatures_01() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/EditPreferences.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/EditPreferences.java
@@ -37,7 +37,7 @@ public class EditPreferences extends AdminCore {
 
 
 	@Test (description = "Edit COS - Edit preferences at COS level",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditPreferences_01() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddAlias.java
@@ -37,7 +37,7 @@ public class AddAlias extends AdminCore {
 
 
 	@Test (description = "Edit DL - Add Alias",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void AddAlias_01() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddDirectMemberOfDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddDirectMemberOfDistributionList.java
@@ -40,7 +40,7 @@ public class AddDirectMemberOfDistributionList extends AdminCore {
 
 	@Bugs (ids = "99081, ZCS-1638")
 	@Test (description = "Edit DL - Add 'Direct Member of' to DL",
-		   	groups = { "bhr" })
+		   	groups = { "bhr", "testcafe" })
 
 	public void AddDirectMemberOfDistributionList_01() throws HarnessException {
 		// Create two distribution lists in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddIndirectMemberOfDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddIndirectMemberOfDistributionList.java
@@ -39,7 +39,7 @@ public class AddIndirectMemberOfDistributionList extends AdminCore {
 
 	@Bugs (ids = "99081")
 	@Test (description = "Edit DL - Add 'Indirect Member of' to DL",
-			groups = { "functional" })
+			groups = { "functional-skip" })
 
 	public void AddIndirectMemberOfDistributionList_01() throws HarnessException {
 		// Create three distribution lists in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddOwners.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/AddOwners.java
@@ -37,7 +37,7 @@ public class AddOwners extends AdminCore {
 
 
 	@Test (description = "Edit DL - Add Owner to DL",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void AddOwner_01() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/CreateDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/CreateDistributionList.java
@@ -61,7 +61,7 @@ public class CreateDistributionList extends AdminCore {
 
 
 	@Test (description = "Create a basic dynamic DL",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateDistributionList_02() throws HarnessException, ServiceException {
 		this.startingPage.zNavigateTo();
@@ -97,7 +97,7 @@ public class CreateDistributionList extends AdminCore {
 	
 	@Bugs(ids = "51011")
 	@Test (description = "Create a DL and add it as a member of another DL",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void CreateDistributionList_03() throws HarnessException {
 		this.startingPage.zNavigateTo();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/EditDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/EditDistributionList.java
@@ -38,7 +38,7 @@ public class EditDistributionList extends AdminCore {
 
 
 	@Test (description = "Edit Distribution List name - Manage Distribution List view",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditDistributionList_01() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -83,7 +83,7 @@ public class EditDistributionList extends AdminCore {
 
 
 	@Test (description = "Edit Distribution List name - Manage Distribution List view + Right Click Menu",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditDistributionList_02() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -127,7 +127,7 @@ public class EditDistributionList extends AdminCore {
 
 
 	@Test (description = "Edit Admin Distribution List name - Manage Distribution List view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditDistributionList_03() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -173,7 +173,7 @@ public class EditDistributionList extends AdminCore {
 
 
 	@Test (description = "Edit Dynamic Admin Distribution List name - Manage Distribution List view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditDistributionList_04() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -223,7 +223,7 @@ public class EditDistributionList extends AdminCore {
 
 	@Bugs (ids = "97150")
 	@Test (description = "Edit dynamic Distribution List name - Manage Distribution List view",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditDistributionList_05() throws HarnessException {
 		// Create a new dynamic dl in the Admin Console using SOAP
@@ -272,7 +272,7 @@ public class EditDistributionList extends AdminCore {
 
 	@Bugs (ids = "97150")
 	@Test (description = "Edit Dynamic Distribution List name - Manage Distribution List view + Right Click Menu",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditDistributionList_06() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/EditPreferences.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/distributionlists/EditPreferences.java
@@ -38,7 +38,7 @@ public class EditPreferences extends AdminCore {
 
 	@Bugs (ids = "104654")
 	@Test (description = "Edit DL - Edit Preferences",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditPreferences_01() throws HarnessException {
 

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/CreateDomainAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/CreateDomainAlias.java
@@ -35,7 +35,7 @@ public class CreateDomainAlias extends AdminCore {
 
 
 	@Test (description = "Create a domain alias",
-			groups = { "smoke" })
+			groups = { "smoke", "testcafe" })
 
 	public void CreateAlias_01() throws HarnessException {
 		// Create a new account in the Admin Console

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/EditDomainAlias.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/EditDomainAlias.java
@@ -40,7 +40,7 @@ public class EditDomainAlias extends AdminCore {
 
 
 	@Test (description = "Verify edit domain operation --  Manage Domain List View",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void EditDomainAlias_01() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");
@@ -92,7 +92,7 @@ public class EditDomainAlias extends AdminCore {
 
 
 	@Test (description = "Verify delete domain operation",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditDomainAlias_02() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");
@@ -144,7 +144,7 @@ public class EditDomainAlias extends AdminCore {
 
 
 	@Test (description = "Edit domain name  - Search list View",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditdomainAlias_03() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");
@@ -199,7 +199,7 @@ public class EditDomainAlias extends AdminCore {
 
 
 	@Test (description = "Edit domain name -- right click",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditdomainAlias_04() throws HarnessException {
 		String targetDomain = ConfigProperties.getStringProperty("testdomain");

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/ViewAccounts.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/ViewAccounts.java
@@ -35,7 +35,7 @@ public class ViewAccounts extends AdminCore {
 
 
 	@Test (description = "Verify edit domain operation --  View Accounts",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void ViewAccounts_01() throws HarnessException {
 		// Create a new domain in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/ZimbraHelpAdminURLModification.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/ZimbraHelpAdminURLModification.java
@@ -112,7 +112,7 @@ public class ZimbraHelpAdminURLModification extends AdminCore {
 
 	@Bugs (ids = "ZCS-3487")
 	@Test (description = "Verify that zimbra admin help page is opened as per the value set in attribute ZimbraHelpAdminURL at the global config",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void ZimbraHelpAdminURLModification_02() throws HarnessException {
 		try {

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/MTA/CheckMTASettings.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/globalsettings/MTA/CheckMTASettings.java
@@ -37,7 +37,7 @@ public class CheckMTASettings extends AdminCore {
 
 	@Bugs (ids = "104512,106769")
 	@Test (description = "Verify MTA restriction values after changing some MTA configuration through Command line and Admin console",
-			groups = { "sanity" })
+			groups = { "sanity-skip" })
 
 	public void CheckMTASettings_01() throws HarnessException {
 		// MTA restriction value to be changed though SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/CreateResource.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/CreateResource.java
@@ -61,7 +61,7 @@ public class CreateResource extends AdminCore {
 
 
 	@Test (description = "Create a basic Equipment resource",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void CreateResource_02() throws HarnessException {
 		ResourceItem resource = new ResourceItem();

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/EditResource.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/resources/EditResource.java
@@ -38,7 +38,7 @@ public class EditResource extends AdminCore {
 
 
 	@Test (description = " Edit Resource name  -- Manage resource View -- Location",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void EditResource_01() throws HarnessException {
 		// Create a new Resource in the Admin Console using SOAP
@@ -83,7 +83,7 @@ public class EditResource extends AdminCore {
 
 
 	@Test (description = " Edit Resource name  -- Manage resource View -- Location",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditResource_02() throws HarnessException {
 		// Create a new resource in the Admin Console using SOAP
@@ -137,7 +137,7 @@ public class EditResource extends AdminCore {
 
 
 	@Test (description = "Edit Resource name -- Manage resource View/Right Click Menu -- Location",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditResource_03() throws HarnessException {
 		// Create a new Resource in the Admin Console using SOAP
@@ -182,7 +182,7 @@ public class EditResource extends AdminCore {
 
 
 	@Test (description = "Edit Resource name -- Manage resource View/Right Click Menu -- Equipment",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditResource_04() throws HarnessException {
 		// Create a new Resource in the Admin Console using SOAP
@@ -227,7 +227,7 @@ public class EditResource extends AdminCore {
 
 
 	@Test (description = " Edit Resource name  -- Manage resource View -- Location",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditResource_05() throws HarnessException {
 		// Create a new Resource in the Admin Console using SOAP
@@ -276,7 +276,7 @@ public class EditResource extends AdminCore {
 
 
 	@Test (description = " Edit Resource name  -- Manage resource View -- Equipment",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditResource_06() throws HarnessException {
 		// Create a new Resource in the Admin Console using SOAP
@@ -325,7 +325,7 @@ public class EditResource extends AdminCore {
 
 
 	@Test (description = "Edit Resource name -- Manage resource View/Right Click Menu -- Location",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditResource_07() throws HarnessException {
 		// Create a new Resource in the Admin Console using SOAP
@@ -374,7 +374,7 @@ public class EditResource extends AdminCore {
 
 
 	@Test (description = "Edit Resource name -- Manage resource View/Right Click Menu -- Equipment",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditResource_08() throws HarnessException {
 		// Create a new Resource in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/distributionlists/EditDistributionList.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/search/distributionlists/EditDistributionList.java
@@ -39,7 +39,7 @@ public class EditDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify edit operation for distribution list - Search distribution list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditDistributionList_01() throws HarnessException {
 		// Create a new dl in the Admin Console using SOAP
@@ -86,7 +86,7 @@ public class EditDistributionList extends AdminCore {
 
 
 	@Test (description = "Verify edit operation for distribution list - Search distribution list view + right click",
-			groups = { "functional" })
+			groups = { "functional", "testcafe" })
 
 	public void EditDistributionList_02() throws HarnessException {
 		super.startingPage.zNavigateTo();
@@ -134,7 +134,7 @@ public class EditDistributionList extends AdminCore {
 
 	@Bugs (ids = "97150")
 	@Test (description = "Verify edit operation for dynamic distribution list - Search distribution list view",
-			groups = { "sanity" })
+			groups = { "sanity", "testcafe" })
 
 	public void EditDistributionList_03() throws HarnessException {
 		// Create a new dynamic dl in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/topmenu/LoggedInUsername.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/topmenu/LoggedInUsername.java
@@ -31,7 +31,7 @@ public class LoggedInUsername extends AdminCore {
 
 
 	@Test (description = "Verify the Top Menu displays the correct Admin username",
-			groups = { "bhr" })
+			groups = { "bhr", "testcafe" })
 
 	public void LoggedInUsername_01() throws HarnessException {
 		// Check that the displayed name is contained in the email


### PR DESCRIPTION
- Added "testcafe" test group for completed migrated tests.
- Deprecated/skip duplicate/not worth tests.

Please see zm-frontend-automation pull request:
https://github.com/ZimbraOS/zm-frontend-automation/pull/5