### PR TITLE
ZCS-11906: Add testcafe group for migrated tests

### DIFF
--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitThemes.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitThemes.java
@@ -37,7 +37,7 @@ public class LimitThemes extends AdminCore {
 
 
 	@Test (description = "Modify account to verify limited themes available",
-			groups = { "functional", "non-zimbrax" })
+			groups = { "functional", "non-zimbrax", "testcafe" })
 
 	public void LimitThemes_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitZimlets.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/accounts/LimitZimlets.java
@@ -36,7 +36,7 @@ public class LimitZimlets extends AdminCore {
 	}
 
 	@Test (description = "Modify account to verify limited Zimlets available",
-			groups = { "functional", "non-zimbrax" })
+			groups = { "functional", "non-zimbrax", "testcafe" })
 
 	public void LimitZimlets_01() throws HarnessException {
 		// Create a new account in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/DeleteCos.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/cos/DeleteCos.java
@@ -112,7 +112,7 @@ public class DeleteCos extends AdminCore {
 
 
 	@Test (description = "Verify delete cos operation -- Search list view",
-			groups = { "functional-known-failure" })
+			groups = { "functional-known-failure", "testcafe" })
 
 	public void DeleteCos_03() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP
@@ -159,7 +159,7 @@ public class DeleteCos extends AdminCore {
 
 
 	@Test (description = "Verify delete cos in -- Search list view/Right click menu",
-			groups = { "functional-known-failure" })
+			groups = { "functional-known-failure", "testcafe" })
 
 	public void DeleteCos_04() throws HarnessException {
 		// Create a new cos in the Admin Console using SOAP

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/ConfigureGAL.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/domains/ConfigureGAL.java
@@ -41,7 +41,7 @@ public class ConfigureGAL extends AdminCore {
 
 	@Bugs (ids = "96777")
 	@Test (description = "Configure internal GAL",
-			groups = { "smoke", "non-zimbrax" })
+			groups = { "smoke", "non-zimbrax", "testcafe" })
 
 	public void ConfigureGAL_01() throws HarnessException {
 		// Create a new domain using SOAP
@@ -77,7 +77,7 @@ public class ConfigureGAL extends AdminCore {
 
 	@Bugs (ids = "96777")
 	@Test (description = "Verify GAL Configuration after chnaging GAL mode of a domain from internal to both",
-			groups = { "sanity", "non-zimbrax" })
+			groups = { "sanity", "non-zimbrax", "testcafe" })
 
 	public void ConfigureGAL_02() throws HarnessException {
 		// External data source name
@@ -160,7 +160,7 @@ public class ConfigureGAL extends AdminCore {
 
 	@Bugs (ids = "96777")
 	@Test (description = "Verify GAL Configuration after chnaging GAL mode of a domain from external to both",
-			groups = { "functional", "non-zimbrax" })
+			groups = { "functional", "non-zimbrax", "testcafe" })
 
 	public void ConfigureGAL_03() throws HarnessException {
 		// Data source name

--- a/src/java/com/zimbra/qa/selenium/projects/admin/tests/zimlets/ToggleStatus.java
+++ b/src/java/com/zimbra/qa/selenium/projects/admin/tests/zimlets/ToggleStatus.java
@@ -32,7 +32,7 @@ public class ToggleStatus extends AdminCore {
 
 
 	@Test (description = "Verify administrator should be able to toggle zimlet status",
-			groups = { "functional", "non-zimbrax" })
+			groups = { "functional", "non-zimbrax", "testcafe" })
 
 	public void ToggleStatus_01() throws HarnessException {
 		String zimletList ="css=div#zl__ZIMLET_MANAGE div[id$='__rows'] div[id^='zli__']";


### PR DESCRIPTION
Please see https://github.com/ZimbraOS/zm-frontend-automation/pull/8 (ZCS-11906: Add automation tests for ACL, delegated admin, DL, global config and support for running all tests in Zimbra 8, 9, 10, multinode and X).